### PR TITLE
Evidence-based per-user model routing: OpenRouter catalog, free-promo tracking, exploration suggester (+ review-swarm fixes)

### DIFF
--- a/.claude/skills/ringer/SKILL.md
+++ b/.claude/skills/ringer/SKILL.md
@@ -180,15 +180,36 @@ Pattern-selection judgment:
 
 ## Engine selection
 
-**The engine choice belongs to the human.** Before the FIRST run of a job,
-read what's actually wired up (`[engines.<name>]` blocks in
-`~/.config/ringer/config.toml`) and ask the user which model should do the
-typing — present the top 2–3 configured options with a one-line tradeoff
-each and a recommendation, e.g.: *"Codex (strongest all-rounder, runs on
-your existing plan — recommended for this job), GLM-5.2 via OpenCode
-(20–30x cheaper, great for volume work), or a mix — heavy tasks on Codex,
-mechanical ones on GLM?"* Honor their pick via the per-task `engine` field;
-don't re-ask every round of the same job unless the mix isn't working.
+**The engine choice belongs to the human — but the recommendation comes
+from THEIR evidence.** Before the FIRST run of a job: read what's wired up
+(`[engines.<name>]` blocks in `~/.config/ringer/config.toml`), run
+`./ringer.py models --task-type <this job's type>` for the local scoreboard,
+and glance at `./ringer.py catalog --changes` for anything newly free or
+newly cheap. Then ask the user which model should do the typing — top 2–3
+options with the NUMBERS in the pitch and a recommendation, e.g.: *"GLM is
+6/6 first-try on persona work here at ~2¢/task — recommended. Codex is also
+100% but ~8x the tokens. And kimi went free on OpenRouter yesterday — want
+it auditioning one of the small tasks?"* Honor their pick via the per-task
+`engine`/`model` fields; don't re-ask every round of the same job unless
+the mix isn't working. This is per-user by design: the scoreboard learns
+THIS user's workload — never import another machine's conclusions or
+recommend from a different user's numbers.
+
+**Explore or the scoreboard fossilizes.** Always recommending the proven
+pick means never learning a new one. In any run of 3+ tasks that has a
+low-stakes lane (docs sweeps, mechanical edits, persona reviews — strong
+executed check, retry to absorb failure), assign roughly ONE task to an
+exploration candidate from `./ringer.py models --explore --task-type <type>`
+(untested + cheap or free, text-capable, decent context). Free promos from
+`catalog --changes` jump the queue — a temporarily-free model is a zero-cost
+experiment. Never explore on time-critical work, never with more than a
+small slice of a batch, and name the experiment when presenting the engine
+ask so the human can veto it. Promotion ladder (computed by --explore):
+untested → probation (some evidence) → proven for a task_type (3+ tasks,
+first-try ≥ 0.67). Proven models earn bigger lanes in that type and an
+audition one rung up in adjacent types; repeated first-attempt failures end
+the audition — record the demotion in MODEL-NOTES so the next orchestrator
+doesn't re-run the experiment.
 
 **OpenCode is the harness; the model is a manifest field.** Unless a model
 ships its own first-class harness (Codex does), it runs through the

--- a/README.md
+++ b/README.md
@@ -231,6 +231,44 @@ Rows that match nothing keep their old `task_type` (empty); rows whose run-state
 
 `docs/MODEL-NOTES.md` is where the human-readable judgment lives on top of these numbers — the scoreboard tells you the pass rates; the notes tell you why a model shines or chokes on a given task shape.
 
+### Evidence-based routing
+
+The scoreboard only knows models you've already run. To reason about models you *haven't* tried yet, Ringer keeps a local snapshot of the OpenRouter catalog and a change log alongside the runs log:
+
+```bash
+./ringer.py catalog                  # fetch/refresh ~/.ringer/openrouter-catalog.json
+```
+
+| Flag | What it does |
+|---|---|
+| `--refresh` | Force a re-fetch even if the snapshot is fresh |
+| `--source URL_OR_PATH` | Pull from a non-default URL or local file instead of the live OpenRouter API |
+| `--file PATH` | Read a catalog document you already have on disk, no network |
+| `--free` | Filter to models with a $0 price — promo models included |
+| `--changes` | Print the recorded add/remove/price_change/went_free/went_paid events from `.changes.jsonl` |
+| `--json` | Emit the snapshot (or, with `--changes`, the event log) as JSON for piping |
+
+The snapshot lives at `~/.ringer/openrouter-catalog.json`; the change log sits beside it as `~/.ringer/openrouter-catalog.changes.jsonl`, appending one row per added, removed, price-changed, went-free, or went-paid event between snapshots. Free promos get their own call-out (`went_free`) because a temporarily-free model is a zero-cost experiment — the cheapest way to audition a new model is to catch it while someone else is paying for it.
+
+Catalog fetches are throttled to once per 24 hours. A `run` triggers that refresh in the background on its way up; it never blocks or fails a run — if the fetch is slow or the network is down, Ringer carries on with the snapshot it has. The throttle and the auto-refresh-on-run are both documented in `./ringer.py run --help` and can be turned off there.
+
+Once you have a catalog and a log, `models --explore` joins them into a routing recommendation:
+
+```bash
+./ringer.py models --explore                 # tiers across all task types
+./ringer.py models --explore --task-type docs # tiers for one task shape
+```
+
+Models with local evidence are sorted into tiers:
+
+- **proven** — 3+ tasks of this `task_type` logged, with `first_try_pass_rate >= 0.67`. The lane you trust with heavy work.
+- **probation** — some attempts logged but not enough volume or not enough first-try passes. Use it; don't lean on it.
+- **untested** — nothing in the log yet. Pulled from the catalog: text→text, 32k+ context window, up to 10 candidates, FREE models first then cheapest. These are your audition queue.
+
+The promotion ladder is the point. A model enters as **untested**. You spend a small slice of suitable runs — about one task per run — auditioning cheap or free candidates on small, low-stakes work where the executed check is strong and the single retry absorbs the failure: docs sweeps, mechanical edits, persona reviews. While evidence accumulates the model sits on **probation**. At 3+ tasks with `first_try_pass_rate >= 0.67` it's **proven** for that task type and earns a lane on the heavy work. The recommendation flow is the same one this ladder implies: exploit proven models for the load-bearing tasks, and keep spending that small slice auditioning untested candidates so the bench refills itself.
+
+The per-user philosophy, stated plainly: every user's workload is different, so the scoreboard learns what works for *your* tasks on *your* machine. A model that's proven in someone else's log is untested in yours until you've run it. The numbers are not portable between users, and the routing recommendations get personal as the log grows — which is exactly why the catalog and the change log stay local and the explore tiers are computed from your own `runs.jsonl`, not from anyone's aggregate.
+
 ## Hard-won invariants
 
 Four rules are baked into every worker invocation. They all cost us real debugging hours; you get them for free:

--- a/docs/MODEL-NOTES.md
+++ b/docs/MODEL-NOTES.md
@@ -53,6 +53,13 @@ checks and raw logs support — no vibes, no worker self-reports.
   Follow-up sentinel-pricing fix (variable-pricing models): PASS attempt 1,
   114s. With the verify-order fix landed, zero phantom retries across the
   whole batch.
+- 2026-07-06 — adversarial review of the model-router stack (2,650-line
+  diff, structured report contract): PASS attempt 1, 176s — found a real
+  HIGH (--since window inflating first-try rates) plus 3 MEDIUMs, all
+  confirmed against the code. Then fixed all five review findings in one
+  batch (task-level --since, pricing transitions, event durability + flock,
+  unknown pricing, stderr notice) with test coverage: PASS attempt 1, 202s.
+  Review->fix roundtrip in codex's lane works end to end.
 
 ## glm-5.2 via opencode (`openrouter/z-ai/glm-5.2`)
 
@@ -100,6 +107,12 @@ checks and raw logs support — no vibes, no worker self-reports.
   failures fixed all 13 (~148k tok total, ~3¢). Page builds (about+faq;
   news index + 19 generated post routes via its own extraction script) and
   2 focus-group personas: all attempt 1. Fix batch attempt 1.
+- 2026-07-06 — invariants/file-I/O review lens on the same stack: PASS
+  attempt 1, 68k tokens — caught the non-atomic backfill rewrite (real data
+  loss risk) and the daemon stdout race; both confirmed. Then fixed the
+  backfill atomicity (tmp+os.replace, pid-stamped backups) attempt 1 with
+  the original behavioral grader unchanged. Structured review with an
+  explicit lens is now proven glm territory, not just probation.
 
 ## kimi-k2.7 via opencode (`openrouter/moonshotai/kimi-k2.7-code`)
 
@@ -130,6 +143,16 @@ checks and raw logs support — no vibes, no worker self-reports.
   Events/faq/contact fix batch attempt 1, but satisfied "editorial grid" with
   an EMPTY aside landmark — axe caught it (landmark-complementary-is-top-level).
   Persona work: good. Watch for letter-of-the-spec shortcuts on layout asks.
+
+## nemotron-3-super-120b (via opencode, `openrouter/nvidia/nemotron-3-super-120b-a12b:free`)
+
+- 2026-07-06 — AUDITION FAILED (exploration slot, $0 spent — free promo).
+  Task: fresh-eyes adversarial review of a 2,650-line diff with a structured
+  report contract. Failed both attempts on the same executed check: report
+  had the right sections and verdict but under 3 concrete code citations —
+  shallow engagement with the actual code, 212k tokens burned. Don't re-run
+  this audition on long structured code review; if it gets another slot,
+  try a shorter, more mechanical task first.
 
 ## Small / flash-class models
 
@@ -184,3 +207,7 @@ checks and raw logs support — no vibes, no worker self-reports.
   before blaming the model.
 - 2026-07-06 — opencode sqlite "database is locked" again with just 2
   simultaneous opencode spawns (page-news + page-about-faq); retry absorbed it.
+
+## codex (2026-07-06, bench-operator-proofing)
+- 8/8 code-feature tasks passed attempt 1 across 3 rounds (worktrees mode, Python harness refactor; 108k-406k tokens/task). Specs embedded the approved architecture doc + exact file ownership; checks built fresh uv venvs and ran the full pytest suite.
+- Lesson (check design, not model): all 3 post-integration bugs were invisible to the checks — a test that passed only because the worker's worktree lacked .env, a `--help`-only assertion missing a runtime importlib/sys.modules bug (py3.12 dataclasses), and bare console-script names failing outside activated venvs. Checks should exercise one real invocation from a cold shell, not just --help.

--- a/docs/MODEL-NOTES.md
+++ b/docs/MODEL-NOTES.md
@@ -47,6 +47,13 @@ checks and raw logs support — no vibes, no worker self-reports.
   orchestrator integration review. Needle checks need an anti-hidden-text
   assertion or documented exceptions.
 
+- 2026-07-06 — OpenRouter catalog + explore suggester (catalog subcommand
+  with snapshot/changelog/free-detection, daemon auto-refresh, tiered
+  --explore; offline fixture-driven contract check): PASS attempt 1, 362s.
+  Follow-up sentinel-pricing fix (variable-pricing models): PASS attempt 1,
+  114s. With the verify-order fix landed, zero phantom retries across the
+  whole batch.
+
 ## glm-5.2 via opencode (`openrouter/z-ai/glm-5.2`)
 
 - The cheap-intelligence default (~$0.74/M in, $2.33/M out, 2026-07 —
@@ -75,6 +82,9 @@ checks and raw logs support — no vibes, no worker self-reports.
   manifests: passed attempt 2; attempt 1 was lost to the harness ordering
   bug, not model quality — the retry worker's log correctly diagnosed that
   harness bug unprompted, impressive debugging from the cheap lane.
+- 2026-07-06 — catalog/explore README section (flags, promotion ladder,
+  per-user framing): PASS attempt 1, ~21.5k tokens. Doc sections against a
+  grep-able content contract remain a safe glm lane.
 - 2026-07-06 — milk-crate demo, full run: 4 independent buyer-persona
   reviews (focus group) all passed attempt 1 (~15k tokens, ~2¢ each) with an
   explicit VERDICT-block contract — persona work is squarely in glm's zone.

--- a/ringer.py
+++ b/ringer.py
@@ -30,6 +30,7 @@ import urllib.request
 import webbrowser
 from dataclasses import dataclass, field, replace as dataclass_replace
 from datetime import datetime, timezone
+from decimal import Decimal, InvalidOperation
 from html import escape as html_escape
 from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
@@ -48,6 +49,9 @@ DEFAULT_TIMEOUT_S = 900
 CHECK_TIMEOUT_S = 60
 DEFAULT_DASHBOARD_PORT_BASE = 8787
 DEFAULT_HUD_PORT = 8700
+DEFAULT_CATALOG_SOURCE = "https://openrouter.ai/api/v1/models"
+CATALOG_AUTO_REFRESH_MAX_AGE_S = 24 * 60 * 60
+CATALOG_FETCH_TIMEOUT_S = 5
 DEFAULT_TOKEN_REGEX = r"tokens\s+used\s*:?\s*([0-9][0-9,]*)"
 ACTIVITY_TAIL_BYTES = 2048
 ACTIVITY_TEXT_LIMIT = 80
@@ -1198,6 +1202,437 @@ def ringer_home() -> Path:
     if value and value.strip():
         return Path(value).expanduser().resolve()
     return (Path.home() / STATE_DIR_NAME).resolve()
+
+
+def utc_now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def default_catalog_path() -> Path:
+    return ringer_home() / "openrouter-catalog.json"
+
+
+def catalog_changes_path(snapshot_path: Path) -> Path:
+    text = str(snapshot_path)
+    if text.endswith(".json"):
+        return Path(text[:-5] + ".changes.jsonl")
+    return snapshot_path.with_name(snapshot_path.name + ".changes.jsonl")
+
+
+def catalog_decimal(value: Any) -> Decimal:
+    if value is None:
+        return Decimal("0")
+    try:
+        return Decimal(str(value).strip() or "0")
+    except (InvalidOperation, ValueError):
+        return Decimal("0")
+
+
+def catalog_per_m(value: Any) -> float:
+    return float(catalog_decimal(value) * Decimal("1000000"))
+
+
+def catalog_price_equal(left: Any, right: Any) -> bool:
+    return catalog_decimal(left) == catalog_decimal(right)
+
+
+def normalize_catalog_model(raw: dict[str, Any], *, fetched_at: str) -> dict[str, Any]:
+    pricing = raw.get("pricing")
+    pricing_obj = pricing if isinstance(pricing, dict) else {}
+    architecture = raw.get("architecture")
+    architecture_obj = architecture if isinstance(architecture, dict) else {}
+    model_id = str(raw.get("id", "")).strip()
+    prompt_per_m = catalog_per_m(pricing_obj.get("prompt"))
+    completion_per_m = catalog_per_m(pricing_obj.get("completion"))
+    is_free = (
+        model_id.endswith(":free")
+        or (
+            catalog_price_equal(pricing_obj.get("prompt"), 0)
+            and catalog_price_equal(pricing_obj.get("completion"), 0)
+        )
+    )
+    context_length_raw = raw.get("context_length")
+    try:
+        context_length = int(context_length_raw)
+    except (TypeError, ValueError):
+        context_length = 0
+    return {
+        "id": model_id,
+        "name": str(raw.get("name", "")).strip() or model_id,
+        "context_length": context_length,
+        "modality": str(architecture_obj.get("modality", "")).strip(),
+        "pricing": dict(pricing_obj),
+        "prompt_per_m": prompt_per_m,
+        "completion_per_m": completion_per_m,
+        "free": is_free,
+        "fetched_at": fetched_at,
+    }
+
+
+def normalize_catalog_payload(payload: dict[str, Any], *, fetched_at: str) -> list[dict[str, Any]]:
+    data = payload.get("data")
+    if not isinstance(data, list):
+        raise ValueError("catalog source must have a JSON object with a data array")
+    models: list[dict[str, Any]] = []
+    for item in data:
+        if not isinstance(item, dict):
+            continue
+        model = normalize_catalog_model(item, fetched_at=fetched_at)
+        if model["id"]:
+            models.append(model)
+    return sorted(models, key=catalog_sort_key)
+
+
+def catalog_sort_key(model: dict[str, Any]) -> tuple[float, str]:
+    return (
+        float(model.get("prompt_per_m") or 0) + float(model.get("completion_per_m") or 0),
+        str(model.get("id") or ""),
+    )
+
+
+def fetch_catalog_payload(source: str, *, timeout: float = CATALOG_FETCH_TIMEOUT_S) -> dict[str, Any]:
+    parsed = urllib.parse.urlparse(source)
+    if parsed.scheme in {"http", "https"}:
+        request = urllib.request.Request(source, headers={"User-Agent": "ringer.py"})
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+    else:
+        payload = json.loads(Path(source).expanduser().read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("catalog source must be a JSON object")
+    return payload
+
+
+def load_catalog_snapshot(path: Path) -> list[dict[str, Any]]:
+    try:
+        data = json.loads(path.expanduser().read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return []
+    if isinstance(data, dict):
+        models = data.get("models")
+    else:
+        models = data
+    if not isinstance(models, list):
+        return []
+    return [item for item in models if isinstance(item, dict)]
+
+
+def catalog_event_model_details(model: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "name": model.get("name", ""),
+        "prompt_per_m": model.get("prompt_per_m", 0),
+        "completion_per_m": model.get("completion_per_m", 0),
+        "free": bool(model.get("free")),
+        "context_length": model.get("context_length", 0),
+        "modality": model.get("modality", ""),
+    }
+
+
+def diff_catalog_snapshots(
+    old_models: list[dict[str, Any]],
+    new_models: list[dict[str, Any]],
+    *,
+    ts: str,
+) -> list[dict[str, Any]]:
+    old_by_id = {str(model.get("id")): model for model in old_models if model.get("id")}
+    new_by_id = {str(model.get("id")): model for model in new_models if model.get("id")}
+    events: list[dict[str, Any]] = []
+
+    for model_id in sorted(new_by_id.keys() - old_by_id.keys()):
+        model = new_by_id[model_id]
+        events.append({"ts": ts, "kind": "added", "id": model_id, **catalog_event_model_details(model)})
+
+    for model_id in sorted(old_by_id.keys() - new_by_id.keys()):
+        model = old_by_id[model_id]
+        events.append({"ts": ts, "kind": "removed", "id": model_id, **catalog_event_model_details(model)})
+
+    for model_id in sorted(old_by_id.keys() & new_by_id.keys()):
+        old = old_by_id[model_id]
+        new = new_by_id[model_id]
+        old_prompt = old.get("prompt_per_m", 0)
+        new_prompt = new.get("prompt_per_m", 0)
+        old_completion = old.get("completion_per_m", 0)
+        new_completion = new.get("completion_per_m", 0)
+        old_free = bool(old.get("free"))
+        new_free = bool(new.get("free"))
+        price_changed = old_prompt != new_prompt or old_completion != new_completion
+        if price_changed:
+            events.append(
+                {
+                    "ts": ts,
+                    "kind": "price_change",
+                    "id": model_id,
+                    "name": new.get("name", old.get("name", "")),
+                    "old_prompt_per_m": old_prompt,
+                    "new_prompt_per_m": new_prompt,
+                    "old_completion_per_m": old_completion,
+                    "new_completion_per_m": new_completion,
+                    "old_free": old_free,
+                    "new_free": new_free,
+                }
+            )
+        if old_free != new_free:
+            events.append(
+                {
+                    "ts": ts,
+                    "kind": "went_free" if new_free else "went_paid",
+                    "id": model_id,
+                    "name": new.get("name", old.get("name", "")),
+                    "old_prompt_per_m": old_prompt,
+                    "new_prompt_per_m": new_prompt,
+                    "old_completion_per_m": old_completion,
+                    "new_completion_per_m": new_completion,
+                }
+            )
+    return events
+
+
+@dataclass(frozen=True)
+class CatalogRefreshResult:
+    path: Path
+    changes_path: Path
+    models: list[dict[str, Any]]
+    events: list[dict[str, Any]]
+
+
+def append_catalog_events(path: Path, events: list[dict[str, Any]]) -> None:
+    if not events:
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as fh:
+        for event in events:
+            fh.write(json.dumps(event, sort_keys=True) + "\n")
+
+
+def refresh_openrouter_catalog(
+    snapshot_path: Path,
+    *,
+    source: str = DEFAULT_CATALOG_SOURCE,
+    timeout: float = CATALOG_FETCH_TIMEOUT_S,
+) -> CatalogRefreshResult:
+    snapshot_path = snapshot_path.expanduser().resolve()
+    ts = utc_now_iso()
+    old_models = load_catalog_snapshot(snapshot_path)
+    payload = fetch_catalog_payload(source, timeout=timeout)
+    new_models = normalize_catalog_payload(payload, fetched_at=ts)
+    events = diff_catalog_snapshots(old_models, new_models, ts=ts)
+    snapshot = {"fetched_at": ts, "models": new_models}
+    atomic_write_json(snapshot_path, snapshot)
+    changes_path = catalog_changes_path(snapshot_path)
+    append_catalog_events(changes_path, events)
+    return CatalogRefreshResult(
+        path=snapshot_path,
+        changes_path=changes_path,
+        models=new_models,
+        events=events,
+    )
+
+
+def format_catalog_price(value: Any) -> str:
+    amount = float(value or 0)
+    if amount == 0:
+        return "0"
+    if amount < 0.01:
+        return f"{amount:.4f}".rstrip("0").rstrip(".")
+    return f"{amount:.2f}".rstrip("0").rstrip(".")
+
+
+def print_catalog_table(models: list[dict[str, Any]]) -> None:
+    header = f"{'id':<48} {'$/M in':>9} {'$/M out':>9} {'ctx':>8} {'FREE':<4}"
+    print(header)
+    print("-" * len(header))
+    for model in sorted(models, key=catalog_sort_key):
+        marker = "FREE" if model.get("free") else ""
+        print(
+            f"{shorten(str(model.get('id', '')), 48):<48} "
+            f"{format_catalog_price(model.get('prompt_per_m')):>9} "
+            f"{format_catalog_price(model.get('completion_per_m')):>9} "
+            f"{int(model.get('context_length') or 0):>8} {marker:<4}"
+        )
+
+
+def read_catalog_events(path: Path, *, limit: int = 20) -> list[dict[str, Any]]:
+    try:
+        lines = path.expanduser().read_text(encoding="utf-8").splitlines()
+    except FileNotFoundError:
+        return []
+    events: list[dict[str, Any]] = []
+    for line in reversed(lines):
+        if len(events) >= limit:
+            break
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(event, dict):
+            events.append(event)
+    return events
+
+
+def describe_catalog_event(event: dict[str, Any]) -> str:
+    kind = str(event.get("kind", "event"))
+    model_id = str(event.get("id", ""))
+    ts = str(event.get("ts", ""))
+    if kind == "price_change":
+        return (
+            f"{ts} {model_id} price_change: "
+            f"in {format_catalog_price(event.get('old_prompt_per_m'))}"
+            f" -> {format_catalog_price(event.get('new_prompt_per_m'))}, "
+            f"out {format_catalog_price(event.get('old_completion_per_m'))}"
+            f" -> {format_catalog_price(event.get('new_completion_per_m'))}"
+        )
+    if kind in {"went_free", "went_paid"}:
+        return f"{ts} {model_id} {kind}"
+    if kind == "added":
+        marker = " FREE" if event.get("free") else ""
+        return f"{ts} {model_id} added{marker}"
+    if kind == "removed":
+        return f"{ts} {model_id} removed"
+    return f"{ts} {model_id} {kind}"
+
+
+def run_catalog_command(args: argparse.Namespace) -> int:
+    snapshot_path = (args.file or default_catalog_path()).expanduser().resolve()
+    if args.refresh:
+        models = refresh_openrouter_catalog(
+            snapshot_path,
+            source=args.source or DEFAULT_CATALOG_SOURCE,
+        ).models
+    else:
+        models = load_catalog_snapshot(snapshot_path)
+
+    if args.changes:
+        for event in read_catalog_events(catalog_changes_path(snapshot_path)):
+            print(describe_catalog_event(event))
+        return 0
+
+    if args.free:
+        models = [model for model in models if model.get("free")]
+
+    if args.json:
+        print(json.dumps(sorted(models, key=catalog_sort_key)))
+        return 0
+
+    if not models:
+        print(f"No catalog snapshot at {snapshot_path}. Run './ringer.py catalog --refresh'.", file=sys.stderr)
+        return 1
+    print_catalog_table(models)
+    return 0
+
+
+def catalog_snapshot_is_fresh(
+    snapshot_path: Path,
+    *,
+    max_age_s: int = CATALOG_AUTO_REFRESH_MAX_AGE_S,
+    now: float | None = None,
+) -> bool:
+    try:
+        mtime = snapshot_path.expanduser().stat().st_mtime
+    except OSError:
+        return False
+    return ((time.time() if now is None else now) - mtime) < max_age_s
+
+
+def start_catalog_auto_refresh(
+    *,
+    snapshot_path: Path | None = None,
+    source: str = DEFAULT_CATALOG_SOURCE,
+    print_notice: bool = True,
+) -> threading.Thread | None:
+    try:
+        if os.environ.get("RINGER_NO_CATALOG_REFRESH") == "1":
+            return None
+        path = (snapshot_path or default_catalog_path()).expanduser().resolve()
+        if catalog_snapshot_is_fresh(path):
+            return None
+    except Exception:
+        return None
+
+    def worker() -> None:
+        try:
+            result = refresh_openrouter_catalog(path, source=source, timeout=CATALOG_FETCH_TIMEOUT_S)
+            went_free = [event for event in result.events if event.get("kind") == "went_free"]
+            if print_notice and went_free:
+                sample = ", ".join(str(event.get("id")) for event in went_free[:3])
+                extra = "" if len(went_free) <= 3 else f" and {len(went_free) - 3} more"
+                print(f"Catalog refresh: model went FREE: {sample}{extra}", flush=True)
+        except Exception:
+            pass
+
+    try:
+        thread = threading.Thread(target=worker, name="ringer-catalog-refresh", daemon=True)
+        thread.start()
+        return thread
+    except Exception:
+        return None
+
+
+def proven_model_group(group: dict[str, Any]) -> bool:
+    return int(group.get("tasks") or 0) >= 3 and float(group.get("first_try_pass_rate") or 0) >= 0.67
+
+
+def catalog_model_is_text_candidate(model: dict[str, Any]) -> bool:
+    try:
+        context_length = int(model.get("context_length") or 0)
+    except (TypeError, ValueError):
+        context_length = 0
+    return str(model.get("modality", "")).strip().lower() == "text->text" and context_length >= 32000
+
+
+def catalog_explore_candidates(
+    catalog_models: list[dict[str, Any]],
+    *,
+    tested_models: set[str],
+    limit: int = 10,
+) -> list[dict[str, Any]]:
+    candidates = [
+        model
+        for model in catalog_models
+        if str(model.get("id", "")) not in tested_models and catalog_model_is_text_candidate(model)
+    ]
+    return sorted(
+        candidates,
+        key=lambda model: (
+            not bool(model.get("free")),
+            float(model.get("prompt_per_m") or 0) + float(model.get("completion_per_m") or 0),
+            str(model.get("id") or ""),
+        ),
+    )[:limit]
+
+
+def print_model_explore(
+    *,
+    log_path: Path,
+    rows_read: int,
+    skipped: int,
+    groups: list[dict[str, Any]],
+    catalog_path: Path,
+    catalog_models: list[dict[str, Any]],
+) -> None:
+    print(f"TIERS from {log_path} ({rows_read} rows, {skipped} skipped lines)")
+    if not groups:
+        print("  no local evidence")
+    for group in groups:
+        label = "proven" if proven_model_group(group) else "probation"
+        print(
+            f"  {label:<9} {group['model']} "
+            f"task_type={group['task_type']} tasks={group['tasks']} "
+            f"first={group['first_try_pass_rate']:.2f} pass={group['pass_rate']:.2f}"
+        )
+
+    tested_models = {str(group.get("model")) for group in groups if group.get("model")}
+    candidates = catalog_explore_candidates(catalog_models, tested_models=tested_models)
+    print(f"CANDIDATES from {catalog_path}")
+    if not candidates:
+        print("  no untested text->text candidates with context >= 32000")
+    for model in candidates:
+        marker = " FREE" if model.get("free") else ""
+        print(
+            f"  untested  {model['id']} "
+            f"in={format_catalog_price(model.get('prompt_per_m'))}/M "
+            f"out={format_catalog_price(model.get('completion_per_m'))}/M "
+            f"ctx={int(model.get('context_length') or 0)}{marker}"
+        )
 
 
 def active_runs_path() -> Path:
@@ -3805,6 +4240,18 @@ def run_models_command(config: AppConfig, args: argparse.Namespace) -> int:
     since = validate_since_date(args.since)
     rows, skipped = read_model_log_rows(log_path, since=since, engine=args.engine)
     groups = aggregate_model_log_rows(rows, task_type=args.task_type, model=args.model)
+    if args.explore:
+        catalog_path = (args.catalog_file or default_catalog_path()).expanduser().resolve()
+        catalog_models = load_catalog_snapshot(catalog_path)
+        print_model_explore(
+            log_path=log_path,
+            rows_read=len(rows),
+            skipped=skipped,
+            groups=groups,
+            catalog_path=catalog_path,
+            catalog_models=catalog_models,
+        )
+        return 0
     if args.json:
         print(json.dumps(groups))
     else:
@@ -5242,6 +5689,7 @@ def build_parser() -> argparse.ArgumentParser:
     run_parser.add_argument("--identity", help="orchestrator identity for HUD state and eval rows")
     run_parser.add_argument("--no-dashboard", action="store_true", help="disable live dashboard")
     run_parser.add_argument("--browser", action="store_true", help="open the dashboard in the browser instead of Ringside")
+    run_parser.epilog = "Set RINGER_NO_CATALOG_REFRESH=1 to skip the non-blocking OpenRouter catalog auto-refresh."
     run_parser.add_argument(
         "--no-artifact",
         action="store_true",
@@ -5264,7 +5712,17 @@ def build_parser() -> argparse.ArgumentParser:
     models_parser.add_argument("--model", help="only include one resolved model bucket")
     models_parser.add_argument("--engine", help="only include rows from one worker engine")
     models_parser.add_argument("--since", help="only include rows logged on or after YYYY-MM-DD")
+    models_parser.add_argument("--explore", action="store_true", help="show proven/probation tiers plus cheap untested catalog candidates")
+    models_parser.add_argument("--catalog-file", type=Path, help="path to local OpenRouter catalog snapshot")
     models_parser.add_argument("--json", action="store_true", help="print the scoreboard as JSON")
+
+    catalog_parser = subparsers.add_parser("catalog", help="show or refresh the local OpenRouter model catalog")
+    catalog_parser.add_argument("--refresh", action="store_true", help="fetch source and rewrite the local snapshot")
+    catalog_parser.add_argument("--source", help=f"OpenRouter models URL or fixture file (default: {DEFAULT_CATALOG_SOURCE})")
+    catalog_parser.add_argument("--file", type=Path, help="catalog snapshot path (default: ~/.ringer/openrouter-catalog.json)")
+    catalog_parser.add_argument("--free", action="store_true", help="show free models only")
+    catalog_parser.add_argument("--changes", action="store_true", help="show recent catalog changes newest first")
+    catalog_parser.add_argument("--json", action="store_true", help="print the model list as JSON and nothing else")
 
     demo_parser = subparsers.add_parser("demo", help="generate and run a 3-task toy manifest in /tmp")
     demo_parser.add_argument("--config", type=Path, default=argparse.SUPPRESS, help=argparse.SUPPRESS)
@@ -5308,6 +5766,9 @@ def main(argv: list[str] | None = None) -> int:
             print(f"lint: clean ({len(manifest.tasks)} tasks)")
             return 0
 
+        if args.command == "catalog":
+            return run_catalog_command(args)
+
         config = AppConfig.load(args.config)
         if args.command == "models":
             return run_models_command(config, args)
@@ -5343,6 +5804,8 @@ def main(argv: list[str] | None = None) -> int:
             )
             return 0
         preflight_engine_bins(manifest, config)
+        if args.command == "run":
+            start_catalog_auto_refresh()
         if dashboard_enabled and not args.browser:
             ensure_hud_running(config, open_browser=True)
         return asyncio.run(

--- a/ringer.py
+++ b/ringer.py
@@ -1236,15 +1236,22 @@ def catalog_price_equal(left: Any, right: Any) -> bool:
     return catalog_decimal(left) == catalog_decimal(right)
 
 
+def catalog_price_is_negative(value: Any) -> bool:
+    return catalog_decimal(value) < 0
+
+
 def normalize_catalog_model(raw: dict[str, Any], *, fetched_at: str) -> dict[str, Any]:
     pricing = raw.get("pricing")
     pricing_obj = pricing if isinstance(pricing, dict) else {}
     architecture = raw.get("architecture")
     architecture_obj = architecture if isinstance(architecture, dict) else {}
     model_id = str(raw.get("id", "")).strip()
-    prompt_per_m = catalog_per_m(pricing_obj.get("prompt"))
-    completion_per_m = catalog_per_m(pricing_obj.get("completion"))
-    is_free = (
+    variable_pricing = catalog_price_is_negative(pricing_obj.get("prompt")) or catalog_price_is_negative(
+        pricing_obj.get("completion")
+    )
+    prompt_per_m = None if variable_pricing else catalog_per_m(pricing_obj.get("prompt"))
+    completion_per_m = None if variable_pricing else catalog_per_m(pricing_obj.get("completion"))
+    is_free = not variable_pricing and (
         model_id.endswith(":free")
         or (
             catalog_price_equal(pricing_obj.get("prompt"), 0)
@@ -1264,6 +1271,7 @@ def normalize_catalog_model(raw: dict[str, Any], *, fetched_at: str) -> dict[str
         "pricing": dict(pricing_obj),
         "prompt_per_m": prompt_per_m,
         "completion_per_m": completion_per_m,
+        "variable_pricing": variable_pricing,
         "free": is_free,
         "fetched_at": fetched_at,
     }
@@ -1283,9 +1291,13 @@ def normalize_catalog_payload(payload: dict[str, Any], *, fetched_at: str) -> li
     return sorted(models, key=catalog_sort_key)
 
 
-def catalog_sort_key(model: dict[str, Any]) -> tuple[float, str]:
+def catalog_sort_key(model: dict[str, Any]) -> tuple[bool, float, str]:
+    variable_pricing = bool(model.get("variable_pricing"))
     return (
-        float(model.get("prompt_per_m") or 0) + float(model.get("completion_per_m") or 0),
+        variable_pricing,
+        float("inf")
+        if variable_pricing
+        else float(model.get("prompt_per_m") or 0) + float(model.get("completion_per_m") or 0),
         str(model.get("id") or ""),
     )
 
@@ -1322,6 +1334,7 @@ def catalog_event_model_details(model: dict[str, Any]) -> dict[str, Any]:
         "name": model.get("name", ""),
         "prompt_per_m": model.get("prompt_per_m", 0),
         "completion_per_m": model.get("completion_per_m", 0),
+        "variable_pricing": bool(model.get("variable_pricing")),
         "free": bool(model.get("free")),
         "context_length": model.get("context_length", 0),
         "modality": model.get("modality", ""),
@@ -1355,6 +1368,27 @@ def diff_catalog_snapshots(
         new_completion = new.get("completion_per_m", 0)
         old_free = bool(old.get("free"))
         new_free = bool(new.get("free"))
+        old_variable = bool(old.get("variable_pricing"))
+        new_variable = bool(new.get("variable_pricing"))
+        if new_variable:
+            if not old_variable:
+                events.append(
+                    {
+                        "ts": ts,
+                        "kind": "pricing_variable",
+                        "id": model_id,
+                        "name": new.get("name", old.get("name", "")),
+                        "old_prompt_per_m": old_prompt,
+                        "new_prompt_per_m": new_prompt,
+                        "old_completion_per_m": old_completion,
+                        "new_completion_per_m": new_completion,
+                        "old_free": old_free,
+                        "new_free": new_free,
+                    }
+                )
+            continue
+        if old_variable:
+            continue
         price_changed = old_prompt != new_prompt or old_completion != new_completion
         if price_changed:
             events.append(
@@ -1428,7 +1462,9 @@ def refresh_openrouter_catalog(
     )
 
 
-def format_catalog_price(value: Any) -> str:
+def format_catalog_price(value: Any, *, variable: bool = False) -> str:
+    if variable or value is None:
+        return "var"
     amount = float(value or 0)
     if amount == 0:
         return "0"
@@ -1442,11 +1478,12 @@ def print_catalog_table(models: list[dict[str, Any]]) -> None:
     print(header)
     print("-" * len(header))
     for model in sorted(models, key=catalog_sort_key):
+        variable_pricing = bool(model.get("variable_pricing"))
         marker = "FREE" if model.get("free") else ""
         print(
             f"{shorten(str(model.get('id', '')), 48):<48} "
-            f"{format_catalog_price(model.get('prompt_per_m')):>9} "
-            f"{format_catalog_price(model.get('completion_per_m')):>9} "
+            f"{format_catalog_price(model.get('prompt_per_m'), variable=variable_pricing):>9} "
+            f"{format_catalog_price(model.get('completion_per_m'), variable=variable_pricing):>9} "
             f"{int(model.get('context_length') or 0):>8} {marker:<4}"
         )
 
@@ -1483,6 +1520,8 @@ def describe_catalog_event(event: dict[str, Any]) -> str:
         )
     if kind in {"went_free", "went_paid"}:
         return f"{ts} {model_id} {kind}"
+    if kind == "pricing_variable":
+        return f"{ts} {model_id} pricing_variable"
     if kind == "added":
         marker = " FREE" if event.get("free") else ""
         return f"{ts} {model_id} added{marker}"
@@ -1576,7 +1615,11 @@ def catalog_model_is_text_candidate(model: dict[str, Any]) -> bool:
         context_length = int(model.get("context_length") or 0)
     except (TypeError, ValueError):
         context_length = 0
-    return str(model.get("modality", "")).strip().lower() == "text->text" and context_length >= 32000
+    return (
+        not bool(model.get("variable_pricing"))
+        and str(model.get("modality", "")).strip().lower() == "text->text"
+        and context_length >= 32000
+    )
 
 
 def catalog_explore_candidates(

--- a/ringer.py
+++ b/ringer.py
@@ -1228,8 +1228,24 @@ def catalog_decimal(value: Any) -> Decimal:
         return Decimal("0")
 
 
+def catalog_decimal_or_none(value: Any) -> Decimal | None:
+    if value is None:
+        return None
+    try:
+        text = str(value).strip()
+        if not text:
+            return None
+        return Decimal(text)
+    except (InvalidOperation, ValueError):
+        return None
+
+
 def catalog_per_m(value: Any) -> float:
     return float(catalog_decimal(value) * Decimal("1000000"))
+
+
+def catalog_per_m_decimal(value: Decimal) -> float:
+    return float(value * Decimal("1000000"))
 
 
 def catalog_price_equal(left: Any, right: Any) -> bool:
@@ -1246,18 +1262,21 @@ def normalize_catalog_model(raw: dict[str, Any], *, fetched_at: str) -> dict[str
     architecture = raw.get("architecture")
     architecture_obj = architecture if isinstance(architecture, dict) else {}
     model_id = str(raw.get("id", "")).strip()
-    variable_pricing = catalog_price_is_negative(pricing_obj.get("prompt")) or catalog_price_is_negative(
-        pricing_obj.get("completion")
-    )
-    prompt_per_m = None if variable_pricing else catalog_per_m(pricing_obj.get("prompt"))
-    completion_per_m = None if variable_pricing else catalog_per_m(pricing_obj.get("completion"))
+    prompt_price = catalog_decimal_or_none(pricing_obj.get("prompt"))
+    completion_price = catalog_decimal_or_none(pricing_obj.get("completion"))
+    pricing_unknown = prompt_price is None or completion_price is None
+    variable_pricing = pricing_unknown or prompt_price < 0 or completion_price < 0
+    prompt_per_m = None if variable_pricing else catalog_per_m_decimal(prompt_price)
+    completion_per_m = None if variable_pricing else catalog_per_m_decimal(completion_price)
     is_free = not variable_pricing and (
         model_id.endswith(":free")
         or (
-            catalog_price_equal(pricing_obj.get("prompt"), 0)
-            and catalog_price_equal(pricing_obj.get("completion"), 0)
+            prompt_price == 0
+            and completion_price == 0
         )
     )
+    if model_id.endswith(":free"):
+        is_free = True
     context_length_raw = raw.get("context_length")
     try:
         context_length = int(context_length_raw)
@@ -1272,6 +1291,7 @@ def normalize_catalog_model(raw: dict[str, Any], *, fetched_at: str) -> dict[str
         "prompt_per_m": prompt_per_m,
         "completion_per_m": completion_per_m,
         "variable_pricing": variable_pricing,
+        "pricing_unknown": pricing_unknown,
         "free": is_free,
         "fetched_at": fetched_at,
     }
@@ -1335,6 +1355,7 @@ def catalog_event_model_details(model: dict[str, Any]) -> dict[str, Any]:
         "prompt_per_m": model.get("prompt_per_m", 0),
         "completion_per_m": model.get("completion_per_m", 0),
         "variable_pricing": bool(model.get("variable_pricing")),
+        "pricing_unknown": bool(model.get("pricing_unknown")),
         "free": bool(model.get("free")),
         "context_length": model.get("context_length", 0),
         "modality": model.get("modality", ""),
@@ -1388,6 +1409,33 @@ def diff_catalog_snapshots(
                 )
             continue
         if old_variable:
+            events.append(
+                {
+                    "ts": ts,
+                    "kind": "pricing_fixed",
+                    "id": model_id,
+                    "name": new.get("name", old.get("name", "")),
+                    "old_prompt_per_m": old_prompt,
+                    "new_prompt_per_m": new_prompt,
+                    "old_completion_per_m": old_completion,
+                    "new_completion_per_m": new_completion,
+                    "old_free": old_free,
+                    "new_free": new_free,
+                }
+            )
+            if new_free:
+                events.append(
+                    {
+                        "ts": ts,
+                        "kind": "went_free",
+                        "id": model_id,
+                        "name": new.get("name", old.get("name", "")),
+                        "old_prompt_per_m": old_prompt,
+                        "new_prompt_per_m": new_prompt,
+                        "old_completion_per_m": old_completion,
+                        "new_completion_per_m": new_completion,
+                    }
+                )
             continue
         price_changed = old_prompt != new_prompt or old_completion != new_completion
         if price_changed:
@@ -1438,6 +1486,33 @@ def append_catalog_events(path: Path, events: list[dict[str, Any]]) -> None:
             fh.write(json.dumps(event, sort_keys=True) + "\n")
 
 
+@contextlib.contextmanager
+def catalog_refresh_lock(snapshot_path: Path) -> Iterable[None]:
+    lock_path = snapshot_path.with_name(snapshot_path.name + ".lock")
+    try:
+        import fcntl
+    except Exception:
+        yield
+        return
+    fh = None
+    try:
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        fh = lock_path.open("a", encoding="utf-8")
+        fcntl.flock(fh.fileno(), fcntl.LOCK_EX)
+    except Exception:
+        if fh is not None:
+            with contextlib.suppress(Exception):
+                fh.close()
+        yield
+        return
+    try:
+        yield
+    finally:
+        with contextlib.suppress(Exception):
+            fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
+        fh.close()
+
+
 def refresh_openrouter_catalog(
     snapshot_path: Path,
     *,
@@ -1445,15 +1520,19 @@ def refresh_openrouter_catalog(
     timeout: float = CATALOG_FETCH_TIMEOUT_S,
 ) -> CatalogRefreshResult:
     snapshot_path = snapshot_path.expanduser().resolve()
-    ts = utc_now_iso()
-    old_models = load_catalog_snapshot(snapshot_path)
-    payload = fetch_catalog_payload(source, timeout=timeout)
-    new_models = normalize_catalog_payload(payload, fetched_at=ts)
-    events = diff_catalog_snapshots(old_models, new_models, ts=ts)
-    snapshot = {"fetched_at": ts, "models": new_models}
-    atomic_write_json(snapshot_path, snapshot)
     changes_path = catalog_changes_path(snapshot_path)
-    append_catalog_events(changes_path, events)
+    with catalog_refresh_lock(snapshot_path):
+        ts = utc_now_iso()
+        old_models = load_catalog_snapshot(snapshot_path)
+        payload = fetch_catalog_payload(source, timeout=timeout)
+        new_models = normalize_catalog_payload(payload, fetched_at=ts)
+        events = diff_catalog_snapshots(old_models, new_models, ts=ts)
+        snapshot = {"fetched_at": ts, "models": new_models}
+        append_catalog_events(changes_path, events)
+        # Append events before replacing the snapshot: a crash here can duplicate
+        # events on the next refresh, but duplicated events are recoverable and
+        # silently lost catalog changes are not.
+        atomic_write_json(snapshot_path, snapshot)
     return CatalogRefreshResult(
         path=snapshot_path,
         changes_path=changes_path,
@@ -1522,6 +1601,12 @@ def describe_catalog_event(event: dict[str, Any]) -> str:
         return f"{ts} {model_id} {kind}"
     if kind == "pricing_variable":
         return f"{ts} {model_id} pricing_variable"
+    if kind == "pricing_fixed":
+        return (
+            f"{ts} {model_id} pricing_fixed: "
+            f"in {format_catalog_price(event.get('new_prompt_per_m'))}, "
+            f"out {format_catalog_price(event.get('new_completion_per_m'))}"
+        )
     if kind == "added":
         marker = " FREE" if event.get("free") else ""
         return f"{ts} {model_id} added{marker}"
@@ -1594,7 +1679,7 @@ def start_catalog_auto_refresh(
             if print_notice and went_free:
                 sample = ", ".join(str(event.get("id")) for event in went_free[:3])
                 extra = "" if len(went_free) <= 3 else f" and {len(went_free) - 3} more"
-                print(f"Catalog refresh: model went FREE: {sample}{extra}", flush=True)
+                print(f"Catalog refresh: model went FREE: {sample}{extra}", file=sys.stderr, flush=True)
         except Exception:
             pass
 
@@ -4143,13 +4228,32 @@ def read_model_log_rows(
             if not isinstance(row, dict):
                 skipped += 1
                 continue
-            if since is not None:
-                logged_date = parse_log_date(row.get("logged_at"))
-                if not logged_date or logged_date < since:
-                    continue
             if engine is not None and model_log_text(row.get("worker_engine")) != engine:
                 continue
             rows.append(row)
+    if since is not None:
+        task_rows_by_key: dict[tuple[str, str], list[dict[str, Any]]] = {}
+        for row in rows:
+            run_id = model_log_text(row.get("run_id"))
+            task_key = model_log_text(row.get("task_key"))
+            task_rows_by_key.setdefault((run_id, task_key), []).append(row)
+        selected_keys: set[tuple[str, str]] = set()
+        for key, task_rows in task_rows_by_key.items():
+            ordered = sorted(
+                task_rows,
+                key=lambda row: (
+                    model_log_text(row.get("logged_at")),
+                    1 if model_log_row_is_retry(row) else 0,
+                ),
+            )
+            final_date = parse_log_date(ordered[-1].get("logged_at"))
+            if final_date and final_date >= since:
+                selected_keys.add(key)
+        rows = [
+            row
+            for row in rows
+            if (model_log_text(row.get("run_id")), model_log_text(row.get("task_key"))) in selected_keys
+        ]
     return rows, skipped
 
 

--- a/scripts/backfill_model_log.py
+++ b/scripts/backfill_model_log.py
@@ -27,6 +27,7 @@ import json
 import os
 import shutil
 import sys
+import tempfile
 from datetime import datetime, timezone
 
 
@@ -239,10 +240,26 @@ def main(argv: list[str] | None = None) -> int:
 
     if not dry_run:
         stamp = datetime.now(timezone.utc).strftime("%Y%m%d%H%M%S")
-        backup_path = f"{log_path}.bak-{stamp}"
+        backup_path = f"{log_path}.bak-{stamp}-{os.getpid()}"
+        suffix = 1
+        candidate = backup_path
+        while os.path.exists(candidate):
+            candidate = f"{backup_path}-{suffix}"
+            suffix += 1
+        backup_path = candidate
         shutil.copy2(log_path, backup_path)
-        with open(log_path, "w", encoding="utf-8") as fh:
-            fh.writelines(out_lines)
+        log_dir = os.path.dirname(os.path.abspath(log_path))
+        tmp_fd, tmp_path = tempfile.mkstemp(prefix=".backfill_", dir=log_dir)
+        try:
+            with os.fdopen(tmp_fd, "w", encoding="utf-8") as fh:
+                fh.writelines(out_lines)
+            os.replace(tmp_path, log_path)
+        except BaseException:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+            raise
 
     print_summary(summary)
     return 0

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import contextlib
+import io
+import json
+import os
+import tempfile
+import time
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from ringer import (  # noqa: E402
+    AppConfig,
+    ArtifactConfig,
+    CatalogRefreshResult,
+    EvalConfig,
+    catalog_changes_path,
+    normalize_catalog_payload,
+    refresh_openrouter_catalog,
+    run_catalog_command,
+    run_models_command,
+    start_catalog_auto_refresh,
+)
+
+
+def source_file(root: Path, name: str, models: list[dict[str, object]]) -> Path:
+    path = root / name
+    path.write_text(json.dumps({"data": models}), encoding="utf-8")
+    return path
+
+
+def model(
+    model_id: str,
+    *,
+    prompt: str,
+    completion: str,
+    context_length: int = 64000,
+    modality: str = "text->text",
+) -> dict[str, object]:
+    return {
+        "id": model_id,
+        "name": model_id,
+        "context_length": context_length,
+        "architecture": {"modality": modality},
+        "pricing": {"prompt": prompt, "completion": completion},
+    }
+
+
+class CatalogTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name)
+        self.old_env = os.environ.copy()
+        self.addCleanup(self.restore_env)
+
+    def restore_env(self) -> None:
+        os.environ.clear()
+        os.environ.update(self.old_env)
+
+    def test_pricing_per_m_and_free_detection(self) -> None:
+        models = normalize_catalog_payload(
+            {
+                "data": [
+                    model("paid", prompt="0.0000005", completion="0.0000015"),
+                    model("zero", prompt="0", completion="0"),
+                    model("promo:free", prompt="0.000002", completion="0.000003"),
+                ]
+            },
+            fetched_at="2026-07-06T00:00:00+00:00",
+        )
+        by_id = {item["id"]: item for item in models}
+        self.assertEqual(0.5, by_id["paid"]["prompt_per_m"])
+        self.assertEqual(1.5, by_id["paid"]["completion_per_m"])
+        self.assertFalse(by_id["paid"]["free"])
+        self.assertTrue(by_id["zero"]["free"])
+        self.assertTrue(by_id["promo:free"]["free"])
+
+    def test_refresh_appends_diff_events(self) -> None:
+        snapshot = self.root / "catalog.json"
+        old_source = source_file(
+            self.root,
+            "old.json",
+            [
+                model("changed", prompt="0.000001", completion="0.000002"),
+                model("removed", prompt="0.000003", completion="0.000004"),
+            ],
+        )
+        new_source = source_file(
+            self.root,
+            "new.json",
+            [
+                model("changed", prompt="0", completion="0"),
+                model("added", prompt="0.000005", completion="0.000006"),
+            ],
+        )
+
+        refresh_openrouter_catalog(snapshot, source=str(old_source))
+        refresh_openrouter_catalog(snapshot, source=str(new_source))
+
+        rows = [
+            json.loads(line)
+            for line in catalog_changes_path(snapshot).read_text(encoding="utf-8").splitlines()
+        ]
+        kinds_by_id = {(row["kind"], row["id"]) for row in rows}
+        self.assertIn(("added", "added"), kinds_by_id)
+        self.assertIn(("removed", "removed"), kinds_by_id)
+        self.assertIn(("price_change", "changed"), kinds_by_id)
+        self.assertIn(("went_free", "changed"), kinds_by_id)
+
+    def test_catalog_free_filter_json_output(self) -> None:
+        snapshot = self.root / "catalog.json"
+        source = source_file(
+            self.root,
+            "source.json",
+            [
+                model("paid", prompt="0.000001", completion="0.000001"),
+                model("free", prompt="0", completion="0"),
+            ],
+        )
+        refresh_openrouter_catalog(snapshot, source=str(source))
+        args = argparse.Namespace(
+            refresh=False,
+            source=None,
+            file=snapshot,
+            free=True,
+            changes=False,
+            json=True,
+        )
+
+        out = io.StringIO()
+        with contextlib.redirect_stdout(out):
+            rc = run_catalog_command(args)
+
+        self.assertEqual(0, rc)
+        payload = json.loads(out.getvalue())
+        self.assertEqual(["free"], [item["id"] for item in payload])
+
+    def test_models_explore_tiers_and_candidates(self) -> None:
+        log_path = self.root / "eval.jsonl"
+        rows = [
+            {
+                "run_id": f"run{i}",
+                "task_key": "task",
+                "worker_engine": "opencode",
+                "model": "proven-model",
+                "task_type": "code-feature",
+                "verdict": "PASS",
+                "logged_at": f"2026-07-0{i}T10:00:00+00:00",
+            }
+            for i in range(1, 4)
+        ]
+        rows.append(
+            {
+                "run_id": "probation-run",
+                "task_key": "task",
+                "worker_engine": "opencode",
+                "model": "probation-model",
+                "task_type": "code-feature",
+                "verdict": "FAIL",
+                "logged_at": "2026-07-04T10:00:00+00:00",
+            }
+        )
+        log_path.write_text("\n".join(json.dumps(row) for row in rows) + "\n", encoding="utf-8")
+        catalog_path = self.root / "catalog.json"
+        source = source_file(
+            self.root,
+            "catalog-source.json",
+            [
+                model("proven-model", prompt="0", completion="0"),
+                model("probation-model", prompt="0.000001", completion="0.000001"),
+                model("free-candidate:free", prompt="0.000002", completion="0.000002"),
+                model("cheap-candidate", prompt="0.0000005", completion="0.0000005"),
+                model("image-model", prompt="0", completion="0", modality="text+image->text"),
+                model("small-context", prompt="0", completion="0", context_length=16000),
+                model("embedder", prompt="0", completion="0", modality="text->embedding"),
+            ],
+        )
+        refresh_openrouter_catalog(catalog_path, source=str(source))
+        config = AppConfig(
+            path=None,
+            identity_default=None,
+            state_dir=self.root / "state",
+            dashboard_port_base=8787,
+            hud_port=8700,
+            hud_app_path=None,
+            allow_full_access=False,
+            eval=EvalConfig(backend="jsonl", jsonl_path=log_path),
+            engines={},
+            artifact=ArtifactConfig(
+                enabled=False,
+                out_template=str(self.root / "live.html"),
+                report_template=str(self.root / "report.html"),
+                index_out=self.root / "index.html",
+            ),
+        )
+        args = argparse.Namespace(
+            log=log_path,
+            task_type="code-feature",
+            model=None,
+            engine=None,
+            since=None,
+            explore=True,
+            catalog_file=catalog_path,
+            json=False,
+        )
+
+        out = io.StringIO()
+        with contextlib.redirect_stdout(out):
+            rc = run_models_command(config, args)
+
+        output = out.getvalue()
+        self.assertEqual(0, rc)
+        self.assertIn("proven    ", output)
+        self.assertIn("probation ", output)
+        self.assertIn("untested  free-candidate:free", output)
+        self.assertIn("untested  cheap-candidate", output)
+        self.assertNotIn("image-model", output)
+        self.assertNotIn("small-context", output)
+        self.assertNotIn("embedder", output)
+
+    def test_auto_refresh_throttling_env_and_exception_swallowing(self) -> None:
+        snapshot = self.root / "catalog.json"
+        snapshot.write_text('{"models":[]}', encoding="utf-8")
+        with mock.patch("ringer.refresh_openrouter_catalog") as refresh:
+            self.assertIsNone(start_catalog_auto_refresh(snapshot_path=snapshot, print_notice=False))
+            refresh.assert_not_called()
+
+        stale = time.time() - (25 * 60 * 60)
+        os.utime(snapshot, (stale, stale))
+        with mock.patch("ringer.refresh_openrouter_catalog") as refresh:
+            refresh.return_value = CatalogRefreshResult(
+                path=snapshot,
+                changes_path=catalog_changes_path(snapshot),
+                models=[],
+                events=[],
+            )
+            thread = start_catalog_auto_refresh(snapshot_path=snapshot, print_notice=False)
+            self.assertIsNotNone(thread)
+            assert thread is not None
+            thread.join(timeout=2)
+            refresh.assert_called_once()
+
+        os.environ["RINGER_NO_CATALOG_REFRESH"] = "1"
+        with mock.patch("ringer.refresh_openrouter_catalog") as refresh:
+            self.assertIsNone(start_catalog_auto_refresh(snapshot_path=snapshot, print_notice=False))
+            refresh.assert_not_called()
+        os.environ.pop("RINGER_NO_CATALOG_REFRESH")
+
+        with mock.patch("ringer.refresh_openrouter_catalog", side_effect=RuntimeError("boom")):
+            thread = start_catalog_auto_refresh(snapshot_path=snapshot, print_notice=False)
+            self.assertIsNotNone(thread)
+            assert thread is not None
+            thread.join(timeout=2)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -73,6 +73,7 @@ class CatalogTests(unittest.TestCase):
                     model("paid", prompt="0.0000005", completion="0.0000015"),
                     model("zero", prompt="0", completion="0"),
                     model("promo:free", prompt="0.000002", completion="0.000003"),
+                    model("openrouter/auto", prompt="-1", completion="-1"),
                 ]
             },
             fetched_at="2026-07-06T00:00:00+00:00",
@@ -83,6 +84,10 @@ class CatalogTests(unittest.TestCase):
         self.assertFalse(by_id["paid"]["free"])
         self.assertTrue(by_id["zero"]["free"])
         self.assertTrue(by_id["promo:free"]["free"])
+        self.assertIsNone(by_id["openrouter/auto"]["prompt_per_m"])
+        self.assertIsNone(by_id["openrouter/auto"]["completion_per_m"])
+        self.assertTrue(by_id["openrouter/auto"]["variable_pricing"])
+        self.assertFalse(by_id["openrouter/auto"]["free"])
 
     def test_refresh_appends_diff_events(self) -> None:
         snapshot = self.root / "catalog.json"
@@ -124,6 +129,7 @@ class CatalogTests(unittest.TestCase):
             [
                 model("paid", prompt="0.000001", completion="0.000001"),
                 model("free", prompt="0", completion="0"),
+                model("openrouter/auto", prompt="-1", completion="-1"),
             ],
         )
         refresh_openrouter_catalog(snapshot, source=str(source))
@@ -143,6 +149,39 @@ class CatalogTests(unittest.TestCase):
         self.assertEqual(0, rc)
         payload = json.loads(out.getvalue())
         self.assertEqual(["free"], [item["id"] for item in payload])
+
+    def test_catalog_table_shows_variable_pricing_after_priced_models(self) -> None:
+        snapshot = self.root / "catalog.json"
+        source = source_file(
+            self.root,
+            "source.json",
+            [
+                model("openrouter/auto", prompt="-1", completion="-1"),
+                model("cheap", prompt="0.0000001", completion="0.0000001"),
+                model("free", prompt="0", completion="0"),
+            ],
+        )
+        refresh_openrouter_catalog(snapshot, source=str(source))
+        args = argparse.Namespace(
+            refresh=False,
+            source=None,
+            file=snapshot,
+            free=False,
+            changes=False,
+            json=False,
+        )
+
+        out = io.StringIO()
+        with contextlib.redirect_stdout(out):
+            rc = run_catalog_command(args)
+
+        self.assertEqual(0, rc)
+        rows = [line for line in out.getvalue().splitlines() if line and not line.startswith(("id", "-"))]
+        self.assertEqual("free", rows[0].split()[0])
+        self.assertEqual("cheap", rows[1].split()[0])
+        self.assertEqual("openrouter/auto", rows[2].split()[0])
+        self.assertIn("      var       var ", rows[2])
+        self.assertNotIn("FREE", rows[2])
 
     def test_models_explore_tiers_and_candidates(self) -> None:
         log_path = self.root / "eval.jsonl"
@@ -179,6 +218,7 @@ class CatalogTests(unittest.TestCase):
                 model("probation-model", prompt="0.000001", completion="0.000001"),
                 model("free-candidate:free", prompt="0.000002", completion="0.000002"),
                 model("cheap-candidate", prompt="0.0000005", completion="0.0000005"),
+                model("openrouter/auto", prompt="-1", completion="-1"),
                 model("image-model", prompt="0", completion="0", modality="text+image->text"),
                 model("small-context", prompt="0", completion="0", context_length=16000),
                 model("embedder", prompt="0", completion="0", modality="text->embedding"),
@@ -223,9 +263,37 @@ class CatalogTests(unittest.TestCase):
         self.assertIn("probation ", output)
         self.assertIn("untested  free-candidate:free", output)
         self.assertIn("untested  cheap-candidate", output)
+        self.assertNotIn("openrouter/auto", output)
         self.assertNotIn("image-model", output)
         self.assertNotIn("small-context", output)
         self.assertNotIn("embedder", output)
+
+    def test_persistent_variable_pricing_logs_once_without_price_or_free_events(self) -> None:
+        snapshot = self.root / "catalog.json"
+        old_source = source_file(
+            self.root,
+            "old.json",
+            [model("openrouter/auto", prompt="0", completion="0")],
+        )
+        sentinel_source = source_file(
+            self.root,
+            "sentinel.json",
+            [model("openrouter/auto", prompt="-1", completion="-1")],
+        )
+
+        refresh_openrouter_catalog(snapshot, source=str(old_source))
+        refresh_openrouter_catalog(snapshot, source=str(sentinel_source))
+        refresh_openrouter_catalog(snapshot, source=str(sentinel_source))
+
+        rows = [
+            json.loads(line)
+            for line in catalog_changes_path(snapshot).read_text(encoding="utf-8").splitlines()
+        ]
+        persisted_rows = [row for row in rows if row["id"] == "openrouter/auto"]
+        self.assertEqual(
+            ["added", "pricing_variable"],
+            [row["kind"] for row in persisted_rows],
+        )
 
     def test_auto_refresh_throttling_env_and_exception_swallowing(self) -> None:
         snapshot = self.root / "catalog.json"

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -87,6 +87,7 @@ class CatalogTests(unittest.TestCase):
         self.assertIsNone(by_id["openrouter/auto"]["prompt_per_m"])
         self.assertIsNone(by_id["openrouter/auto"]["completion_per_m"])
         self.assertTrue(by_id["openrouter/auto"]["variable_pricing"])
+        self.assertFalse(by_id["openrouter/auto"]["pricing_unknown"])
         self.assertFalse(by_id["openrouter/auto"]["free"])
 
     def test_refresh_appends_diff_events(self) -> None:
@@ -268,17 +269,110 @@ class CatalogTests(unittest.TestCase):
         self.assertNotIn("small-context", output)
         self.assertNotIn("embedder", output)
 
-    def test_persistent_variable_pricing_logs_once_without_price_or_free_events(self) -> None:
+    def test_missing_or_malformed_pricing_is_unknown_variable_not_free(self) -> None:
+        snapshot = self.root / "catalog.json"
+        source = source_file(
+            self.root,
+            "unknown-pricing.json",
+            [
+                {
+                    "id": "missing-pricing",
+                    "name": "missing-pricing",
+                    "context_length": 64000,
+                    "architecture": {"modality": "text->text"},
+                    "pricing": None,
+                },
+                {
+                    "id": "malformed-pricing",
+                    "name": "malformed-pricing",
+                    "context_length": 64000,
+                    "architecture": {"modality": "text->text"},
+                    "pricing": {"prompt": "abc", "completion": "0"},
+                },
+                model("free", prompt="0", completion="0"),
+                model("cheap-candidate", prompt="0.0000005", completion="0.0000005"),
+            ],
+        )
+        refresh_openrouter_catalog(snapshot, source=str(source))
+
+        models = json.loads(snapshot.read_text(encoding="utf-8"))["models"]
+        by_id = {item["id"]: item for item in models}
+        for model_id in ("missing-pricing", "malformed-pricing"):
+            self.assertTrue(by_id[model_id]["pricing_unknown"])
+            self.assertTrue(by_id[model_id]["variable_pricing"])
+            self.assertIsNone(by_id[model_id]["prompt_per_m"])
+            self.assertIsNone(by_id[model_id]["completion_per_m"])
+            self.assertFalse(by_id[model_id]["free"])
+
+        free_args = argparse.Namespace(
+            refresh=False,
+            source=None,
+            file=snapshot,
+            free=True,
+            changes=False,
+            json=True,
+        )
+        free_out = io.StringIO()
+        with contextlib.redirect_stdout(free_out):
+            self.assertEqual(0, run_catalog_command(free_args))
+        self.assertEqual(["free"], [item["id"] for item in json.loads(free_out.getvalue())])
+
+        log_path = self.root / "eval.jsonl"
+        log_path.write_text("", encoding="utf-8")
+        config = AppConfig(
+            path=None,
+            identity_default=None,
+            state_dir=self.root / "state",
+            dashboard_port_base=8787,
+            hud_port=8700,
+            hud_app_path=None,
+            allow_full_access=False,
+            eval=EvalConfig(backend="jsonl", jsonl_path=log_path),
+            engines={},
+            artifact=ArtifactConfig(
+                enabled=False,
+                out_template=str(self.root / "live.html"),
+                report_template=str(self.root / "report.html"),
+                index_out=self.root / "index.html",
+            ),
+        )
+        explore_args = argparse.Namespace(
+            log=log_path,
+            task_type=None,
+            model=None,
+            engine=None,
+            since=None,
+            explore=True,
+            catalog_file=snapshot,
+            json=False,
+        )
+        explore_out = io.StringIO()
+        with contextlib.redirect_stdout(explore_out):
+            self.assertEqual(0, run_models_command(config, explore_args))
+        output = explore_out.getvalue()
+        self.assertIn("cheap-candidate", output)
+        self.assertNotIn("missing-pricing", output)
+        self.assertNotIn("malformed-pricing", output)
+
+    def test_variable_pricing_transitions_log_once_and_fixed_prices(self) -> None:
         snapshot = self.root / "catalog.json"
         old_source = source_file(
             self.root,
             "old.json",
-            [model("openrouter/auto", prompt="0", completion="0")],
+            [
+                model("to-variable", prompt="0", completion="0"),
+                model("to-fixed", prompt="-1", completion="-1"),
+                model("to-free", prompt="-1", completion="-1"),
+            ],
         )
         sentinel_source = source_file(
             self.root,
             "sentinel.json",
-            [model("openrouter/auto", prompt="-1", completion="-1")],
+            [
+                model("to-variable", prompt="-1", completion="-1"),
+                model("to-fixed", prompt="0.000001", completion="0.000002"),
+                model("to-free", prompt="0", completion="0"),
+            ],
         )
 
         refresh_openrouter_catalog(snapshot, source=str(old_source))
@@ -289,11 +383,52 @@ class CatalogTests(unittest.TestCase):
             json.loads(line)
             for line in catalog_changes_path(snapshot).read_text(encoding="utf-8").splitlines()
         ]
-        persisted_rows = [row for row in rows if row["id"] == "openrouter/auto"]
+        rows_by_id: dict[str, list[dict[str, object]]] = {}
+        for row in rows:
+            rows_by_id.setdefault(str(row["id"]), []).append(row)
         self.assertEqual(
             ["added", "pricing_variable"],
-            [row["kind"] for row in persisted_rows],
+            [row["kind"] for row in rows_by_id["to-variable"]],
         )
+        self.assertEqual(
+            ["added", "pricing_fixed"],
+            [row["kind"] for row in rows_by_id["to-fixed"]],
+        )
+        fixed = rows_by_id["to-fixed"][1]
+        self.assertEqual(1.0, fixed["new_prompt_per_m"])
+        self.assertEqual(2.0, fixed["new_completion_per_m"])
+        self.assertEqual(
+            ["added", "pricing_fixed", "went_free"],
+            [row["kind"] for row in rows_by_id["to-free"]],
+        )
+
+    def test_refresh_appends_events_before_snapshot_replace(self) -> None:
+        snapshot = self.root / "catalog.json"
+        old_source = source_file(
+            self.root,
+            "old.json",
+            [model("changed", prompt="0.000001", completion="0.000002")],
+        )
+        new_source = source_file(
+            self.root,
+            "new.json",
+            [model("changed", prompt="0", completion="0")],
+        )
+
+        refresh_openrouter_catalog(snapshot, source=str(old_source))
+        before = snapshot.read_text(encoding="utf-8")
+
+        with mock.patch("ringer.atomic_write_json", side_effect=RuntimeError("write stopped")):
+            with self.assertRaisesRegex(RuntimeError, "write stopped"):
+                refresh_openrouter_catalog(snapshot, source=str(new_source))
+
+        self.assertEqual(before, snapshot.read_text(encoding="utf-8"))
+        rows = [
+            json.loads(line)
+            for line in catalog_changes_path(snapshot).read_text(encoding="utf-8").splitlines()
+        ]
+        self.assertIn(("price_change", "changed"), {(row["kind"], row["id"]) for row in rows})
+        self.assertIn(("went_free", "changed"), {(row["kind"], row["id"]) for row in rows})
 
     def test_auto_refresh_throttling_env_and_exception_swallowing(self) -> None:
         snapshot = self.root / "catalog.json"
@@ -328,6 +463,30 @@ class CatalogTests(unittest.TestCase):
             self.assertIsNotNone(thread)
             assert thread is not None
             thread.join(timeout=2)
+
+    def test_auto_refresh_free_notice_goes_to_stderr(self) -> None:
+        snapshot = self.root / "catalog.json"
+        snapshot.write_text('{"models":[]}', encoding="utf-8")
+        stale = time.time() - (25 * 60 * 60)
+        os.utime(snapshot, (stale, stale))
+
+        result = CatalogRefreshResult(
+            path=snapshot,
+            changes_path=catalog_changes_path(snapshot),
+            models=[],
+            events=[{"kind": "went_free", "id": "new-free-model"}],
+        )
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        with mock.patch("ringer.refresh_openrouter_catalog", return_value=result):
+            with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+                thread = start_catalog_auto_refresh(snapshot_path=snapshot, print_notice=True)
+                self.assertIsNotNone(thread)
+                assert thread is not None
+                thread.join(timeout=2)
+
+        self.assertEqual("", stdout.getvalue())
+        self.assertIn("Catalog refresh: model went FREE: new-free-model", stderr.getvalue())
 
 
 if __name__ == "__main__":

--- a/tests/test_model_log.py
+++ b/tests/test_model_log.py
@@ -274,6 +274,61 @@ class ModelLogTests(unittest.TestCase):
             self.assertEqual("(untyped)", untyped[0]["task_type"])
             self.assertEqual(1, untyped[0]["tasks"])
 
+    def test_since_selects_tasks_by_final_attempt_and_keeps_history(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            path = Path(temp) / "eval.jsonl"
+            rows = [
+                {
+                    "run_id": "rescue-run",
+                    "task_key": "task-a",
+                    "worker_engine": "opencode",
+                    "model": "openrouter/rescue",
+                    "task_type": "code-feature",
+                    "verdict": "FAIL",
+                    "duration_ms": 100,
+                    "worker_tokens": 10,
+                    "retry": False,
+                    "logged_at": "2026-07-01T23:59:00+00:00",
+                },
+                {
+                    "run_id": "rescue-run",
+                    "task_key": "task-a",
+                    "worker_engine": "opencode",
+                    "model": "openrouter/rescue",
+                    "task_type": "code-feature",
+                    "verdict": "PASS",
+                    "duration_ms": 200,
+                    "worker_tokens": 20,
+                    "retry": True,
+                    "logged_at": "2026-07-02T00:01:00+00:00",
+                },
+                {
+                    "run_id": "old-run",
+                    "task_key": "task-b",
+                    "worker_engine": "opencode",
+                    "model": "openrouter/rescue",
+                    "task_type": "code-feature",
+                    "verdict": "PASS",
+                    "duration_ms": 300,
+                    "worker_tokens": 30,
+                    "retry": False,
+                    "logged_at": "2026-07-01T20:00:00+00:00",
+                },
+            ]
+            path.write_text("\n".join(json.dumps(row) for row in rows) + "\n", encoding="utf-8")
+
+            read_rows, skipped = read_model_log_rows(path, since="2026-07-02")
+
+            self.assertEqual(0, skipped)
+            self.assertEqual(["rescue-run", "rescue-run"], [row["run_id"] for row in read_rows])
+            groups = aggregate_model_log_rows(read_rows)
+            self.assertEqual(1, len(groups))
+            group = groups[0]
+            self.assertEqual(1, group["tasks"])
+            self.assertEqual(2, group["attempts"])
+            self.assertEqual(0.0, group["first_try_pass_rate"])
+            self.assertEqual(1.0, group["pass_rate"])
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
Continuation of #9 (auto-closed when #8's branch was deleted — same content plus the adversarial-review fixes; see #9 and the review summary comment on #8 for full context).

Since #8 merged, this adds: the OpenRouter catalog (`./ringer.py catalog` — local snapshot, $/M pricing, FREE flags, append-only change log with added/removed/price_change/went_free/pricing_fixed events), background daemon auto-refresh on run (24h throttle, flock'd, stderr notices, never blocks), `models --explore` (untested → probation → proven tiers per task_type; free-first candidate ranking; unknown/variable pricing never advertised as free), task-level `--since` semantics so retry rescues can't inflate first-try rates, atomic backfill rewrites, skill doctrine (recommendations cite the user's own local numbers; ~1 exploration task per suitable run), and MODEL-NOTES evidence including a failed $0 audition of nemotron-3-super-120b:free — the exploration ladder working as designed.

All five review-swarm findings fixed with test coverage; 18 suites green; live-smoked against the real OpenRouter API (343 models, 28 free).

🤖 Generated with [Claude Code](https://claude.com/claude-code)