### PR TITLE
models --open: zero-LLM model scoreboard page in the artifact library

### DIFF
--- a/.claude/skills/ringer/SKILL.md
+++ b/.claude/skills/ringer/SKILL.md
@@ -244,6 +244,13 @@ per task via the manifest `engine` field. Defaults are deliberate:
   retry rescues. Then read `docs/MODEL-NOTES.md` (in the ringer repo) for
   the judgment the numbers can't carry. Routing is grounded in performance,
   not vibes (Jon directive 2026-07-06).
+- **"Show me the scoreboard" is one command.** When the human asks to see
+  the model scoreboard, rankings, model costs, or "which models work best,"
+  run `./ringer.py models --open` — it renders the full scoreboard (tiers,
+  first-try rates, est. $/task, usage, MODEL-NOTES excerpts, free-promo
+  watchlist) as a zero-LLM HTML page in the artifact library and opens it
+  in their browser. Costs no tokens; never hand-summarize the numbers when
+  the page can show them.
 - **Give every task a `task_type`** (canonical vocabulary in the README —
   code-feature, code-fix, code-review, research, persona-review, site-build,
   image-gen, docs, probe, bakeoff, ...). Untyped tasks bucket as (untyped)

--- a/docs/MODEL-NOTES.md
+++ b/docs/MODEL-NOTES.md
@@ -60,6 +60,12 @@ checks and raw logs support — no vibes, no worker self-reports.
   batch (task-level --since, pricing transitions, event durability + flock,
   unknown pricing, stderr notice) with test coverage: PASS attempt 1, 202s.
   Review->fix roundtrip in codex's lane works end to end.
+- 2026-07-06 — scoreboard HTML page (zero-LLM renderer, ~700-line diff,
+  design + evidence-floor ranking + cost math + notes parser): substance
+  PASS attempt 1 (the run's recorded retry was an orchestrator check bug —
+  the free-promo watchlist legitimately mentions a free model before the
+  ranked cards, and the check compared raw first-occurrence). Six review
+  findings fixed in one batch, PASS attempt 1, 141s.
 
 ## glm-5.2 via opencode (`openrouter/z-ai/glm-5.2`)
 
@@ -113,6 +119,13 @@ checks and raw logs support — no vibes, no worker self-reports.
   backfill atomicity (tmp+os.replace, pid-stamped backups) attempt 1 with
   the original behavioral grader unchanged. Structured review with an
   explicit lens is now proven glm territory, not just probation.
+- 2026-07-06 — solo adversarial review of the scoreboard renderer (~700
+  line diff, injection-focused lens): PASS attempt 1 — 1 MEDIUM (unanchored
+  MODEL-NOTES heading match cross-contaminating gpt-4/gpt-4o-style
+  families) + 5 real LOWs, plus an empirically-verified injection all-clear
+  (it actually rendered hostile model ids to prove escaping). Second
+  proven-tier structured review in one day; glm is now the default review
+  lane for mid-size diffs.
 
 ## kimi-k2.7 via opencode (`openrouter/moonshotai/kimi-k2.7-code`)
 

--- a/ringer-live-artifacts-plan.md
+++ b/ringer-live-artifacts-plan.md
@@ -1,0 +1,120 @@
+# Ringer Live Artifacts — Design Plan
+
+**Author:** aicred (Claude, MBP) — 2026-07-04, written during the aicred baseline-repair double swarm
+**For:** Jon → Ringer repo (github.com/NateBJones-Projects/ringer, Lex maintains)
+**Goal:** live, shareable visual status/review pages from Ringer runs with ZERO Anthropic tokens.
+Reserve Fable/Claude for what it's uniquely good at (triage judgment, adversarial verification,
+boss-level integration) and stop spending it on dashboard upkeep.
+
+## Why
+
+Tonight's data point: keeping a live status artifact updated through a swarm run cost a dedicated
+Claude subagent ~90k+ tokens for what is, structurally, a template render of state Ringer already
+has on disk. Meanwhile the compiled 211-recommendation review HTML from yesterday cost one Codex
+writer worker ~284k OpenAI tokens. Both jobs are automatable inside Ringer at the right tier:
+
+| Tier | Job | Engine | Marginal cost |
+|------|-----|--------|---------------|
+| 0 | Live swarm progress page | Pure Python (no LLM) | $0, forever |
+| 1 | Synthesized review/report page (judgment content) | `codex exec`, cheap model | OpenAI tokens only |
+| 2 | Hosting/sharing beyond the local machine | pluggable publish hook | whatever the hook costs |
+
+## Tier 0 — zero-LLM live status artifact (the big win)
+
+Ringer is zero-LLM orchestration; the status page should be too. Every fact a progress dashboard
+shows already lives in the run state (`~/.ringer/runs/<run>.json`): task keys, status
+(queued/running/pass/fail/retry), timings, check commands, retry counts, eval rows.
+
+**Change:** add a `render_status_html(state) -> str` function (stdlib only, one big template
+string) and call it at every point ringer.py flushes run state. Write the result next to the state
+file AND to an optional configured path.
+
+```toml
+# config.toml
+[artifact]
+enabled = true
+out = "~/.ringer/artifacts/{run_name}.html"   # {run_name}, {ts} substitutions
+open_on_start = false                          # Ringside already opens; this is for extra displays
+```
+
+Page requirements:
+- Self-contained single file (inline CSS, no CDN), dark/light aware, big status colors — built to
+  look good on a screen recording.
+- `<meta http-equiv="refresh" content="5">` — live-enough over file://, no server, no JS needed.
+- Header: run name, identity, started, elapsed, N/M pass, parallel slots.
+- One row per task: key, status chip, attempt count, duration, last check exit code; failed tasks
+  expand to show the tail of the check output (Ringer already captures it for retry injection).
+- Multi-run index: also render `~/.ringer/artifacts/index.html` listing active + recent runs, so
+  two concurrent swarms (like tonight) get one pane of glass.
+
+Acceptance: run `ringer.py demo`, open the artifact, watch it tick through pass/fail with zero
+LLM calls (verify by network/token logs). Kill -9 the orchestrator mid-run; page must show last
+known state, not corrupt.
+
+## Tier 1 — cheap-LLM report artifact (judgment content)
+
+Progress is deterministic; *synthesis* ("what did 23 scouts actually find, ranked") needs a model.
+Keep it off Anthropic by making it a first-class Ringer feature instead of a hand-rolled final
+task:
+
+```json
+"reporter": {
+  "spec": "Read every tasks/*/report.md under {workdir}. Produce ./report.html: single-file, ...",
+  "model": "gpt-5.1-codex-mini",
+  "when": "on_complete"        // or "rolling" — rerun after every task completion
+}
+```
+
+**Changes:**
+1. Optional `reporter` block in the manifest. Ringer appends it as a synthetic final task whose
+   taskdir can read all sibling taskdirs; check = `test -s report.html`.
+2. Per-task model override while you're in there: `"engine_args": ["-m", "gpt-5.1-codex-mini"]`
+   (or a `model` key mapped to codex profiles). Scouts/writers rarely need xhigh; this is the
+   other big cost lever. Default stays the config-level profile.
+3. `"when": "rolling"` mode: rerun the reporter after each task completes (cheap model, capped to
+   one in flight, debounced ~60s). Gives a *live* narrative page for long runs.
+
+Cost note: mini-tier reporter rerun 10x over a run ≈ still cheaper than one Sonnet dashboard
+session, and $0 Anthropic either way.
+
+## Tier 2 — publish hook (sharing)
+
+Local file covers Ringside + screen recording. For sharing (phone, another box, a teammate),
+don't build hosting into Ringer — add one hook:
+
+```toml
+[artifact]
+publish_cmd = "rsync -q {path} jon@fleetbox:/srv/ringer/"   # or scp, or a Convex upload script
+```
+
+Run it (best-effort, non-blocking, log-don't-fail) after each artifact write. Jon's existing
+options slot in without Ringer knowing about them: LEJ/Convex hosting, the NAS, or nothing.
+Claude-hosted Artifacts stay available for boss-narrated sessions, but are never *required*.
+
+## What stays with Claude/Fable
+
+- Triage and accept/reject judgment on findings (tonight: 211 recs → 150/20/15 with two
+  scout claims overturned by boss verification — that's the layer worth Fable tokens).
+- Adversarial review of worker diffs before commit.
+- Anything user-facing that needs Jon's voice.
+
+Boss-Claude's dashboard duty shrinks to: send milestone facts to nobody — the Tier 0 page reads
+state directly; Tier 1 reads reports. No LLM in the loop for "keeping Jon visually up to date."
+
+## Suggested build order (each independently shippable)
+
+1. Tier 0 renderer + config block (pure win, ~150 lines, no new deps).
+2. Multi-run index page.
+3. Per-task `engine_args`/model override (cost lever beyond artifacts).
+4. `reporter` block, `on_complete` mode.
+5. `rolling` mode + debounce.
+6. `publish_cmd` hook.
+
+## Gotchas for the implementer
+
+- Never render secrets: task specs can contain paths/keys; the status page should show spec
+  *previews* truncated at ~200 chars and full check output only for FAILED tasks.
+- Atomic writes (`tmp` + `os.replace`) so the meta-refresh browser never reads a half-written file.
+- Keep the renderer synchronous and cheap; it runs inside the state-flush path.
+- The reporter task must be excluded from pass/fail retry accounting for the *run verdict* of the
+  real tasks (a pretty report failing shouldn't mark a green run red — log it, don't gate on it).

--- a/ringer.py
+++ b/ringer.py
@@ -476,6 +476,8 @@ class Manifest:
         run_name = str(obj.get("run_name", "")).strip()
         if not run_name:
             raise ValueError("run_name is required")
+        if run_name == MODEL_SCOREBOARD_RUN_NAME:
+            raise ValueError("run_name model-scoreboard is reserved for the scoreboard page")
         workdir_raw = obj.get("workdir")
         if not workdir_raw:
             raise ValueError("workdir is required")
@@ -536,6 +538,8 @@ FILE_TEST_OPS = {"-e", "-f", "-s", "-d", "-r", "-w", "-x", "-L"}
 
 def lint_manifest(manifest: Manifest, *, include_model_log_nudges: bool = False) -> list[str]:
     findings: list[str] = []
+    if manifest.run_name == MODEL_SCOREBOARD_RUN_NAME:
+        findings.append("manifest: run_name model-scoreboard is reserved for the scoreboard page.")
 
     for task in manifest.tasks:
         if check_cannot_fail(task.check):
@@ -4383,7 +4387,7 @@ def parse_model_notes_sections(path: Path) -> dict[str, list[str]]:
     """Return dated bullet blocks keyed by the raw level-2 heading text."""
     try:
         lines = path.expanduser().read_text(encoding="utf-8").splitlines()
-    except FileNotFoundError:
+    except (OSError, UnicodeDecodeError):
         return {}
     sections: dict[str, list[str]] = {}
     current_heading: str | None = None
@@ -4435,10 +4439,18 @@ def model_judgment_notes(model_id: str, notes_sections: dict[str, list[str]]) ->
     needle = normalize_notes_match_text(model_id)
     if not needle:
         return []
-    for heading, bullets in notes_sections.items():
-        if needle in normalize_notes_match_text(heading):
-            return bullets
-    return []
+    id_boundary = r"A-Za-z0-9._/:-"
+    needle_re = re.compile(rf"(?<![{id_boundary}]){re.escape(needle)}(?![{id_boundary}])")
+    matches: list[tuple[int, int, int, list[str]]] = []
+    for index, (heading, bullets) in enumerate(notes_sections.items()):
+        normalized_heading = normalize_notes_match_text(heading)
+        if not needle_re.search(normalized_heading):
+            continue
+        exact_score = 1 if normalized_heading == needle else 0
+        matches.append((exact_score, len(normalized_heading), -index, bullets))
+    if not matches:
+        return []
+    return max(matches, key=lambda item: (item[0], item[1], item[2]))[3]
 
 
 def render_notes_list(items: list[str]) -> str:
@@ -4471,13 +4483,11 @@ def catalog_models_by_id(catalog_models: list[dict[str, Any]]) -> dict[str, dict
 def model_scoreboard_tier(tasks: int) -> str:
     if tasks >= 3:
         return "proven"
-    if tasks > 0:
-        return "probation"
-    return "untested-with-rows"
+    return "probation"
 
 
 def model_scoreboard_tier_rank(tier: str) -> int:
-    return {"proven": 0, "probation": 1, "untested-with-rows": 2}.get(tier, 3)
+    return {"proven": 0, "probation": 1}.get(tier, 3)
 
 
 def aggregate_model_scoreboard_rows(
@@ -4595,6 +4605,8 @@ def estimated_task_cost(row: dict[str, Any], catalog_model: dict[str, Any] | Non
     median_tokens = row.get("median_tokens")
     if median_tokens is None or catalog_model is None or catalog_model.get("variable_pricing"):
         return None
+    if catalog_model.get("free"):
+        return 0.0
     try:
         tokens = float(median_tokens)
         prompt_per_m = float(catalog_model.get("prompt_per_m") or 0)
@@ -4661,6 +4673,8 @@ def catalog_cost_html(row: dict[str, Any], catalog_model: dict[str, Any] | None)
         return '<span class="cost-line muted">catalog missing</span>'
     if median_tokens is None:
         return '<span class="cost-line">included in plan</span>'
+    if catalog_model.get("free"):
+        return '<span class="flag free">FREE</span>'
     variable = bool(catalog_model.get("variable_pricing"))
     in_price = format_catalog_price(catalog_model.get("prompt_per_m"), variable=variable)
     out_price = format_catalog_price(catalog_model.get("completion_per_m"), variable=variable)
@@ -4960,7 +4974,7 @@ def render_model_scoreboard_html(
     {cards}
   </section>
   <footer>
-    <span>Ranking sorts by evidence tier first: proven n>=3, then probation, then untested-with-rows; ties use first-try pass rate, pass rate, then lower estimated cost.</span>
+    <span>Ranking sorts by evidence tier first: proven n>=3, then probation; ties use first-try pass rate, pass rate, then lower estimated cost.</span>
     <span>Cost estimate assumes logged worker_tokens are split 50/50 between prompt and completion tokens, using the catalog $/M in/out blend.</span>
   </footer>
 </div>
@@ -5055,7 +5069,7 @@ def run_models_command(config: AppConfig, args: argparse.Namespace) -> int:
         notes_path = (getattr(args, "notes_file", None) or default_model_notes_path()).expanduser().resolve()
         scoreboard_rows = aggregate_model_scoreboard_rows(rows, task_type=args.task_type, model=args.model)
         explicit_path = None
-        if html_arg not in {None, ""} and not open_requested:
+        if html_arg not in {None, ""}:
             explicit_path = Path(str(html_arg))
         page_path = write_model_scoreboard_html(
             config,

--- a/ringer.py
+++ b/ringer.py
@@ -4206,6 +4206,28 @@ def median_int(values: list[int]) -> int | None:
     return (ordered[middle - 1] + ordered[middle]) // 2
 
 
+def model_log_task_base_key(row: dict[str, Any]) -> tuple[str, str, str, str] | None:
+    run_id = model_log_text(row.get("run_id"))
+    task_key = model_log_text(row.get("task_key"))
+    if not run_id or not task_key:
+        return None
+    return (run_id, task_key, model_log_row_model(row), model_log_row_task_type(row))
+
+
+def group_model_log_tasks(rows: list[dict[str, Any]]) -> list[list[dict[str, Any]]]:
+    grouped: list[list[dict[str, Any]]] = []
+    active_by_key: dict[tuple[str, str, str, str], int] = {}
+    for row in rows:
+        key = model_log_task_base_key(row)
+        if key is not None and model_log_row_is_retry(row) and key in active_by_key:
+            grouped[active_by_key[key]].append(row)
+            continue
+        grouped.append([row])
+        if key is not None:
+            active_by_key[key] = len(grouped) - 1
+    return grouped
+
+
 def read_model_log_rows(
     path: Path,
     *,
@@ -4232,13 +4254,8 @@ def read_model_log_rows(
                 continue
             rows.append(row)
     if since is not None:
-        task_rows_by_key: dict[tuple[str, str], list[dict[str, Any]]] = {}
-        for row in rows:
-            run_id = model_log_text(row.get("run_id"))
-            task_key = model_log_text(row.get("task_key"))
-            task_rows_by_key.setdefault((run_id, task_key), []).append(row)
-        selected_keys: set[tuple[str, str]] = set()
-        for key, task_rows in task_rows_by_key.items():
+        selected_row_ids: set[int] = set()
+        for task_rows in group_model_log_tasks(rows):
             ordered = sorted(
                 task_rows,
                 key=lambda row: (
@@ -4248,12 +4265,8 @@ def read_model_log_rows(
             )
             final_date = parse_log_date(ordered[-1].get("logged_at"))
             if final_date and final_date >= since:
-                selected_keys.add(key)
-        rows = [
-            row
-            for row in rows
-            if (model_log_text(row.get("run_id")), model_log_text(row.get("task_key"))) in selected_keys
-        ]
+                selected_row_ids.update(id(row) for row in task_rows)
+        rows = [row for row in rows if id(row) in selected_row_ids]
     return rows, skipped
 
 
@@ -4263,14 +4276,8 @@ def aggregate_model_log_rows(
     task_type: str | None = None,
     model: str | None = None,
 ) -> list[dict[str, Any]]:
-    tasks: dict[tuple[str, str], list[dict[str, Any]]] = {}
-    for row in rows:
-        run_id = model_log_text(row.get("run_id"))
-        task_key = model_log_text(row.get("task_key"))
-        tasks.setdefault((run_id, task_key), []).append(row)
-
     groups: dict[tuple[str, str], dict[str, Any]] = {}
-    for task_rows in tasks.values():
+    for task_rows in group_model_log_tasks(rows):
         ordered = sorted(
             task_rows,
             key=lambda row: (
@@ -4360,6 +4367,647 @@ def aggregate_model_log_rows(
     )
 
 
+MODEL_SCOREBOARD_RUN_NAME = "model-scoreboard"
+MODEL_SCOREBOARD_IDENTITY = "ringer-models"
+
+
+def default_model_notes_path() -> Path:
+    return Path(__file__).resolve().parent / "docs" / "MODEL-NOTES.md"
+
+
+def normalize_notes_match_text(value: str) -> str:
+    return re.sub(r"\s+", " ", value).strip().lower()
+
+
+def parse_model_notes_sections(path: Path) -> dict[str, list[str]]:
+    """Return dated bullet blocks keyed by the raw level-2 heading text."""
+    try:
+        lines = path.expanduser().read_text(encoding="utf-8").splitlines()
+    except FileNotFoundError:
+        return {}
+    sections: dict[str, list[str]] = {}
+    current_heading: str | None = None
+    current_bullets: list[str] = []
+    active_bullet: list[str] | None = None
+
+    def flush_bullet() -> None:
+        nonlocal active_bullet
+        if active_bullet is not None:
+            text = "\n".join(active_bullet).strip()
+            if re.search(r"\b\d{4}-\d{2}-\d{2}\b", text):
+                current_bullets.append(text)
+            active_bullet = None
+
+    def flush_section() -> None:
+        flush_bullet()
+        if current_heading is not None:
+            sections[current_heading] = list(current_bullets)
+
+    for line in lines:
+        heading_match = re.match(r"^##\s+(.+?)\s*$", line)
+        if heading_match:
+            flush_section()
+            current_heading = heading_match.group(1).strip()
+            current_bullets = []
+            active_bullet = None
+            continue
+        if current_heading is None:
+            continue
+        if line.startswith("## "):
+            flush_section()
+            current_heading = None
+            current_bullets = []
+            active_bullet = None
+            continue
+        if line.startswith("- "):
+            flush_bullet()
+            active_bullet = [line[2:].strip()]
+            continue
+        if active_bullet is not None and (line.startswith("  ") or not line.strip()):
+            active_bullet.append(line.strip())
+            continue
+        flush_bullet()
+    flush_section()
+    return sections
+
+
+def model_judgment_notes(model_id: str, notes_sections: dict[str, list[str]]) -> list[str]:
+    needle = normalize_notes_match_text(model_id)
+    if not needle:
+        return []
+    for heading, bullets in notes_sections.items():
+        if needle in normalize_notes_match_text(heading):
+            return bullets
+    return []
+
+
+def render_notes_list(items: list[str]) -> str:
+    if not items:
+        return '<p class="empty-note">no judgment notes yet</p>'
+    rendered = []
+    for item in items:
+        text = "<br>".join(html_escape(line) for line in item.splitlines() if line.strip())
+        rendered.append(f"<li>{text}</li>")
+    return f'<ul class="notes-list">{"".join(rendered)}</ul>'
+
+
+def normalize_catalog_for_scoreboard(model: dict[str, Any]) -> dict[str, Any]:
+    if "prompt_per_m" in model and "completion_per_m" in model:
+        return model
+    if isinstance(model.get("pricing"), dict):
+        return normalize_catalog_model(model, fetched_at=str(model.get("fetched_at") or ""))
+    return model
+
+
+def catalog_models_by_id(catalog_models: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    by_id: dict[str, dict[str, Any]] = {}
+    for model in catalog_models:
+        model_id = str(model.get("id") or "").strip()
+        if model_id:
+            by_id[model_id] = normalize_catalog_for_scoreboard(model)
+    return by_id
+
+
+def model_scoreboard_tier(tasks: int) -> str:
+    if tasks >= 3:
+        return "proven"
+    if tasks > 0:
+        return "probation"
+    return "untested-with-rows"
+
+
+def model_scoreboard_tier_rank(tier: str) -> int:
+    return {"proven": 0, "probation": 1, "untested-with-rows": 2}.get(tier, 3)
+
+
+def aggregate_model_scoreboard_rows(
+    rows: list[dict[str, Any]],
+    *,
+    task_type: str | None = None,
+    model: str | None = None,
+) -> list[dict[str, Any]]:
+    models: dict[str, dict[str, Any]] = {}
+    for task_rows in group_model_log_tasks(rows):
+        ordered = sorted(
+            task_rows,
+            key=lambda row: (
+                model_log_text(row.get("logged_at")),
+                1 if model_log_row_is_retry(row) else 0,
+            ),
+        )
+        first = ordered[0]
+        final = ordered[-1]
+        group_model = model_log_row_model(final)
+        group_task_type = model_log_row_task_type(final)
+        if model is not None and group_model != model:
+            continue
+        if task_type is not None and group_task_type != task_type:
+            continue
+        model_entry = models.setdefault(
+            group_model,
+            {
+                "model": group_model,
+                "tasks": 0,
+                "attempts": 0,
+                "passed": 0,
+                "failed": 0,
+                "retries": 0,
+                "first_try_passed": 0,
+                "last_seen": "",
+                "_duration_ms": [],
+                "_tokens": [],
+                "_task_types": {},
+            },
+        )
+        breakdown = model_entry["_task_types"].setdefault(
+            group_task_type,
+            {
+                "task_type": group_task_type,
+                "tasks": 0,
+                "attempts": 0,
+                "passed": 0,
+                "failed": 0,
+                "first_try_passed": 0,
+                "last_seen": "",
+            },
+        )
+        passed = model_log_text(final.get("verdict")).upper() == "PASS"
+        first_passed = model_log_text(first.get("verdict")).upper() == "PASS"
+        for target in (model_entry, breakdown):
+            target["tasks"] += 1
+            target["attempts"] += len(ordered)
+            target["passed"] += 1 if passed else 0
+            target["failed"] += 0 if passed else 1
+            target["first_try_passed"] += 1 if first_passed else 0
+            logged_at = model_log_text(final.get("logged_at"))
+            if logged_at > target["last_seen"]:
+                target["last_seen"] = logged_at
+        model_entry["retries"] += max(0, len(ordered) - 1)
+        duration_ms = model_log_int(final.get("duration_ms"))
+        if duration_ms is not None:
+            model_entry["_duration_ms"].append(duration_ms)
+        for row in ordered:
+            tokens = model_log_int(row.get("worker_tokens"))
+            if tokens is not None:
+                model_entry["_tokens"].append(tokens)
+
+    finalized: list[dict[str, Any]] = []
+    for entry in models.values():
+        tasks_count = int(entry["tasks"])
+        breakdown_rows = []
+        for breakdown in entry["_task_types"].values():
+            b_tasks = int(breakdown["tasks"])
+            breakdown_rows.append(
+                {
+                    "task_type": breakdown["task_type"],
+                    "tasks": b_tasks,
+                    "attempts": breakdown["attempts"],
+                    "passed": breakdown["passed"],
+                    "failed": breakdown["failed"],
+                    "first_try_pass_rate": breakdown["first_try_passed"] / b_tasks if b_tasks else 0.0,
+                    "pass_rate": breakdown["passed"] / b_tasks if b_tasks else 0.0,
+                    "last_seen": breakdown["last_seen"],
+                }
+            )
+        breakdown_rows.sort(key=lambda item: (-item["tasks"], item["task_type"]))
+        tier = model_scoreboard_tier(tasks_count)
+        finalized.append(
+            {
+                "model": entry["model"],
+                "tier": tier,
+                "tasks": tasks_count,
+                "attempts": entry["attempts"],
+                "retries": entry["retries"],
+                "passed": entry["passed"],
+                "failed": entry["failed"],
+                "first_try_pass_rate": entry["first_try_passed"] / tasks_count if tasks_count else 0.0,
+                "pass_rate": entry["passed"] / tasks_count if tasks_count else 0.0,
+                "median_duration_ms": median_int(entry["_duration_ms"]),
+                "median_tokens": median_int(entry["_tokens"]),
+                "last_seen": entry["last_seen"],
+                "task_types": breakdown_rows,
+            }
+        )
+    return finalized
+
+
+def estimated_task_cost(row: dict[str, Any], catalog_model: dict[str, Any] | None) -> float | None:
+    median_tokens = row.get("median_tokens")
+    if median_tokens is None or catalog_model is None or catalog_model.get("variable_pricing"):
+        return None
+    try:
+        tokens = float(median_tokens)
+        prompt_per_m = float(catalog_model.get("prompt_per_m") or 0)
+        completion_per_m = float(catalog_model.get("completion_per_m") or 0)
+    except (TypeError, ValueError):
+        return None
+    return tokens * ((prompt_per_m + completion_per_m) / 2.0) / 1_000_000
+
+
+def model_sort_cost(row: dict[str, Any], catalog_model: dict[str, Any] | None) -> float:
+    cost = estimated_task_cost(row, catalog_model)
+    if cost is not None:
+        return cost
+    if row.get("median_tokens") is None:
+        return 0.0
+    return float("inf")
+
+
+def order_model_scoreboard_rows(
+    rows: list[dict[str, Any]],
+    catalog_by_id: dict[str, dict[str, Any]],
+) -> list[dict[str, Any]]:
+    return sorted(
+        rows,
+        key=lambda row: (
+            model_scoreboard_tier_rank(str(row.get("tier") or "")),
+            -float(row.get("first_try_pass_rate") or 0),
+            -float(row.get("pass_rate") or 0),
+            model_sort_cost(row, catalog_by_id.get(str(row.get("model") or ""))),
+            str(row.get("model") or ""),
+        ),
+    )
+
+
+def fmt_percent(value: Any) -> str:
+    try:
+        return f"{float(value) * 100:.0f}%"
+    except (TypeError, ValueError):
+        return "0%"
+
+
+def fmt_int(value: Any) -> str:
+    try:
+        return f"{int(value):,}"
+    except (TypeError, ValueError):
+        return "0"
+
+
+def fmt_task_cost(value: float | None) -> str:
+    if value is None:
+        return ""
+    if value == 0:
+        return "$0/task"
+    if value < 0.01:
+        return f"${value:.4f}/task"
+    return f"${value:.2f}/task"
+
+
+def catalog_cost_html(row: dict[str, Any], catalog_model: dict[str, Any] | None) -> str:
+    median_tokens = row.get("median_tokens")
+    if catalog_model is None:
+        if median_tokens is None:
+            return '<span class="cost-line">included in plan</span>'
+        return '<span class="cost-line muted">catalog missing</span>'
+    if median_tokens is None:
+        return '<span class="cost-line">included in plan</span>'
+    variable = bool(catalog_model.get("variable_pricing"))
+    in_price = format_catalog_price(catalog_model.get("prompt_per_m"), variable=variable)
+    out_price = format_catalog_price(catalog_model.get("completion_per_m"), variable=variable)
+    if variable:
+        pieces = [f'<span class="cost-line">{html_escape(in_price)} $/M in · {html_escape(out_price)} $/M out</span>']
+    else:
+        pieces = [f'<span class="cost-line">${html_escape(in_price)}/M in · ${html_escape(out_price)}/M out</span>']
+    if catalog_model.get("free"):
+        pieces.append('<span class="flag free">FREE</span>')
+    if variable:
+        pieces.append('<span class="flag">var</span>')
+    est = estimated_task_cost(row, catalog_model)
+    est_text = fmt_task_cost(est)
+    if est_text:
+        pieces.append(f'<span class="cost-line">{html_escape(est_text)}</span>')
+    return " ".join(pieces)
+
+
+def derived_quality_text(row: dict[str, Any], *, best: bool) -> str:
+    candidates = [item for item in row.get("task_types", []) if int(item.get("tasks") or 0) >= 2]
+    if not candidates:
+        return "not enough per-task evidence yet"
+    if best:
+        chosen = max(candidates, key=lambda item: (float(item.get("first_try_pass_rate") or 0), int(item.get("tasks") or 0), str(item.get("task_type") or "")))
+        prefix = "best derived"
+    else:
+        chosen = min(candidates, key=lambda item: (float(item.get("first_try_pass_rate") or 0), -int(item.get("tasks") or 0), str(item.get("task_type") or "")))
+        prefix = "worst derived"
+    return (
+        f"{prefix}: {chosen['task_type']} "
+        f"({fmt_percent(chosen.get('first_try_pass_rate'))} first-try, "
+        f"{fmt_percent(chosen.get('pass_rate'))} pass, n={fmt_int(chosen.get('tasks'))})"
+    )
+
+
+def render_task_breakdown_table(task_rows: list[dict[str, Any]]) -> str:
+    if not task_rows:
+        return '<p class="empty-note">no task-type breakdown</p>'
+    rows = []
+    for item in task_rows:
+        rows.append(
+            f"""<tr>
+      <td>{html_escape(str(item.get("task_type") or ""))}</td>
+      <td class="mono">{fmt_int(item.get("tasks"))}</td>
+      <td class="mono">{fmt_percent(item.get("first_try_pass_rate"))}</td>
+      <td class="mono">{fmt_percent(item.get("pass_rate"))}</td>
+    </tr>"""
+        )
+    return f"""<table class="breakdown">
+    <thead><tr><th>task_type</th><th>n</th><th>first-try</th><th>pass</th></tr></thead>
+    <tbody>{"".join(rows)}</tbody>
+  </table>"""
+
+
+MODEL_SCOREBOARD_CSS = """
+  .scoreboard-page { max-width: 1180px; }
+  .scoreboard-briefing { max-width: 44ch; }
+  .source-grid {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 10px;
+    margin: 0 0 clamp(18px, 3vw, 28px);
+  }
+  .source-box {
+    border: 1px solid var(--hairline);
+    background: color-mix(in srgb, var(--surface) 76%, transparent);
+    padding: 12px;
+    min-width: 0;
+  }
+  .source-box b { display: block; font-size: 12px; color: var(--muted); }
+  .source-box span { display: block; overflow-wrap: anywhere; }
+  .watchlist {
+    border-top: 1px solid var(--hairline);
+    border-bottom: 1px solid var(--hairline);
+    padding: 14px 0;
+    margin: 0 0 18px;
+  }
+  .watchlist h2, .models h2 {
+    margin: 0 0 10px;
+    font-size: 16px;
+  }
+  .watch-grid {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+    gap: 16px;
+  }
+  .tag-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+  .tag-list li, .flag {
+    border: 1px solid var(--hairline);
+    padding: 3px 7px;
+    font-size: 12px;
+    color: var(--ink);
+    background: rgba(255, 255, 255, .03);
+  }
+  .flag.free { color: var(--pass); border-color: color-mix(in srgb, var(--pass) 55%, var(--hairline)); }
+  .event-list { margin: 0; padding-left: 18px; color: var(--muted); }
+  .model-card {
+    border: 1px solid var(--hairline);
+    background: var(--surface);
+    margin: 12px 0;
+  }
+  .model-summary {
+    display: grid;
+    grid-template-columns: minmax(70px, .45fr) minmax(240px, 1.6fr) minmax(180px, .9fr) minmax(170px, .9fr);
+    gap: 12px;
+    padding: 14px;
+    align-items: start;
+  }
+  .rank { font-size: 24px; font-weight: 800; line-height: 1; }
+  .tier { color: var(--muted); font-size: 13px; margin-top: 4px; }
+  .model-name { font-size: 19px; font-weight: 800; overflow-wrap: anywhere; }
+  .metric-row {
+    display: flex;
+    gap: 10px;
+    flex-wrap: wrap;
+    margin-top: 8px;
+    color: var(--muted);
+    font-size: 13px;
+  }
+  .metric-row b { color: var(--ink); }
+  .cost-line { display: inline-block; margin: 0 8px 6px 0; }
+  .quality {
+    color: var(--muted);
+    font-size: 13px;
+  }
+  .quality b { color: var(--ink); }
+  .model-detail {
+    border-top: 1px solid var(--hairline);
+    padding: 0 14px 14px;
+  }
+  .model-detail summary {
+    cursor: pointer;
+    color: var(--accent);
+    padding: 10px 0;
+    font-size: 13px;
+  }
+  .detail-grid {
+    display: grid;
+    grid-template-columns: minmax(0, .95fr) minmax(0, 1.05fr);
+    gap: 16px;
+  }
+  .breakdown {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 13px;
+  }
+  .breakdown th, .breakdown td {
+    border-bottom: 1px solid var(--hairline);
+    padding: 7px 6px;
+    text-align: left;
+  }
+  .notes-list { margin: 0; padding-left: 18px; color: var(--ink); }
+  .notes-list li { margin: 0 0 8px; }
+  .muted { color: var(--muted); }
+  .mono { font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace; }
+  @media (max-width: 820px) {
+    .source-grid, .watch-grid, .detail-grid, .model-summary { grid-template-columns: 1fr; }
+    .rank { font-size: 20px; }
+  }
+"""
+
+
+def render_free_watchlist(catalog_models: list[dict[str, Any]], catalog_path: Path) -> str:
+    normalized = [normalize_catalog_for_scoreboard(model) for model in catalog_models]
+    free_models = sorted(
+        (model for model in normalized if model.get("free")),
+        key=lambda item: (-int(item.get("context_length") or 0), str(item.get("id") or "")),
+    )
+    if free_models:
+        free_items = "".join(
+            f"<li>{html_escape(str(model.get('id') or ''))} · {fmt_int(model.get('context_length'))} ctx</li>"
+            for model in free_models[:12]
+        )
+    else:
+        free_items = '<li class="muted">no FREE catalog models in the current snapshot</li>'
+    events = read_catalog_events(catalog_changes_path(catalog_path), limit=6)
+    event_items = "".join(f"<li>{html_escape(describe_catalog_event(event))}</li>" for event in events)
+    if not event_items:
+        event_items = '<li class="muted">no catalog change log found</li>'
+    return f"""<section class="watchlist" aria-labelledby="watchlist-heading">
+    <h2 id="watchlist-heading">Free promo watchlist</h2>
+    <div class="watch-grid">
+      <div><ul class="tag-list">{free_items}</ul></div>
+      <div><ol class="event-list">{event_items}</ol></div>
+    </div>
+  </section>"""
+
+
+def render_model_card(
+    row: dict[str, Any],
+    *,
+    rank: int,
+    catalog_model: dict[str, Any] | None,
+    notes_sections: dict[str, list[str]],
+) -> str:
+    model_id = str(row.get("model") or "")
+    notes = model_judgment_notes(model_id, notes_sections)
+    median_tokens = "none" if row.get("median_tokens") is None else fmt_int(row.get("median_tokens"))
+    return f"""<article class="model-card" id="model-{html_escape(sanitize_artifact_name(model_id))}">
+  <div class="model-summary">
+    <div>
+      <div class="rank">#{rank}</div>
+      <div class="tier">{html_escape(str(row.get("tier") or ""))}</div>
+    </div>
+    <div>
+      <div class="model-name">{html_escape(model_id)}</div>
+      <div class="metric-row">
+        <span><b>n={fmt_int(row.get("tasks"))}</b> tasks</span>
+        <span><b>{fmt_int(row.get("attempts"))}</b> attempts</span>
+        <span><b>{fmt_int(row.get("retries"))}</b> retries</span>
+        <span><b>{fmt_percent(row.get("first_try_pass_rate"))}</b> first-try</span>
+        <span><b>{fmt_percent(row.get("pass_rate"))}</b> pass</span>
+      </div>
+      <div class="metric-row">
+        <span>last_seen <b>{html_escape(str(row.get("last_seen") or "unknown"))}</b></span>
+        <span>median worker_tokens <b>{html_escape(median_tokens)}</b></span>
+      </div>
+    </div>
+    <div>{catalog_cost_html(row, catalog_model)}</div>
+    <div class="quality">
+      <div><b>Best:</b> {html_escape(derived_quality_text(row, best=True))}</div>
+      <div><b>Worst:</b> {html_escape(derived_quality_text(row, best=False))}</div>
+    </div>
+  </div>
+  <details class="model-detail" open>
+    <summary>usage and judgment notes</summary>
+    <div class="detail-grid">
+      <div>{render_task_breakdown_table(row.get("task_types", []))}</div>
+      <div>
+        <div class="tier">judgment notes from MODEL-NOTES.md</div>
+        {render_notes_list(notes)}
+      </div>
+    </div>
+  </details>
+</article>"""
+
+
+def render_model_scoreboard_html(
+    *,
+    rows: list[dict[str, Any]],
+    log_path: Path,
+    rows_read: int,
+    skipped: int,
+    catalog_path: Path,
+    catalog_models: list[dict[str, Any]],
+    notes_path: Path,
+    notes_sections: dict[str, list[str]],
+    generated_at: str | None = None,
+) -> str:
+    catalog_by_id = catalog_models_by_id(catalog_models)
+    ordered = order_model_scoreboard_rows(rows, catalog_by_id)
+    generated = generated_at or datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+    cards = "".join(
+        render_model_card(
+            row,
+            rank=index,
+            catalog_model=catalog_by_id.get(str(row.get("model") or "")),
+            notes_sections=notes_sections,
+        )
+        for index, row in enumerate(ordered, start=1)
+    )
+    if not cards:
+        cards = '<p class="empty-note">No local model evidence matched these filters.</p>'
+    return f"""<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+{CSP_META_TAG}
+<title>ringer model scoreboard</title>
+<style>{ARTIFACT_BASE_CSS}
+{MODEL_SCOREBOARD_CSS}</style>
+</head>
+<body>
+<div class="page scoreboard-page">
+  <header class="corner">
+    <span class="live-dot pass" aria-hidden="true"></span>
+    <span class="eyebrow">Ringer &nbsp;·&nbsp; <b>model-scoreboard</b></span>
+    <span class="clock mono">Generated {html_escape(generated)}</span>
+  </header>
+  <h1 class="briefing scoreboard-briefing">Model performance scoreboard</h1>
+  <section class="source-grid" aria-label="scoreboard sources">
+    <div class="source-box"><b>Log</b><span class="mono">{html_escape(str(log_path))}</span></div>
+    <div class="source-box"><b>Catalog</b><span class="mono">{html_escape(str(catalog_path))}</span></div>
+    <div class="source-box"><b>Notes</b><span class="mono">{html_escape(str(notes_path))}</span></div>
+    <div class="source-box"><b>Rows</b><span>{fmt_int(rows_read)} read · {fmt_int(skipped)} skipped · {fmt_int(len(ordered))} models</span></div>
+  </section>
+  {render_free_watchlist(catalog_models, catalog_path)}
+  <section class="models" aria-labelledby="models-heading">
+    <h2 id="models-heading">Ranked models</h2>
+    {cards}
+  </section>
+  <footer>
+    <span>Ranking sorts by evidence tier first: proven n>=3, then probation, then untested-with-rows; ties use first-try pass rate, pass rate, then lower estimated cost.</span>
+    <span>Cost estimate assumes logged worker_tokens are split 50/50 between prompt and completion tokens, using the catalog $/M in/out blend.</span>
+  </footer>
+</div>
+</body>
+</html>
+"""
+
+
+def write_model_scoreboard_html(
+    config: AppConfig,
+    *,
+    path: Path | None,
+    rows: list[dict[str, Any]],
+    log_path: Path,
+    rows_read: int,
+    skipped: int,
+    catalog_path: Path,
+    catalog_models: list[dict[str, Any]],
+    notes_path: Path,
+    notes_sections: dict[str, list[str]],
+) -> Path:
+    target = path
+    if target is None:
+        target = artifact_live_path(config.state_dir, MODEL_SCOREBOARD_RUN_NAME)
+    target = target.expanduser().resolve()
+    html = render_model_scoreboard_html(
+        rows=rows,
+        log_path=log_path,
+        rows_read=rows_read,
+        skipped=skipped,
+        catalog_path=catalog_path,
+        catalog_models=catalog_models,
+        notes_path=notes_path,
+        notes_sections=notes_sections,
+    )
+    atomic_write_text(target, html)
+    if path is None:
+        update_artifact_library_live(
+            config.state_dir,
+            run_name=MODEL_SCOREBOARD_RUN_NAME,
+            run_id=MODEL_SCOREBOARD_RUN_NAME,
+            identity=MODEL_SCOREBOARD_IDENTITY,
+            state="pass",
+        )
+    return target
+
+
 def print_model_log_table(path: Path, rows_read: int, skipped: int, groups: list[dict[str, Any]]) -> None:
     print(f"Model log: {path} ({rows_read} rows, {skipped} skipped lines)")
     header = (
@@ -4398,6 +5046,32 @@ def run_models_command(config: AppConfig, args: argparse.Namespace) -> int:
             catalog_path=catalog_path,
             catalog_models=catalog_models,
         )
+        return 0
+    html_arg = getattr(args, "html", None)
+    open_requested = bool(getattr(args, "open", False))
+    if html_arg is not None or open_requested:
+        catalog_path = (args.catalog_file or default_catalog_path()).expanduser().resolve()
+        catalog_models = load_catalog_snapshot(catalog_path)
+        notes_path = (getattr(args, "notes_file", None) or default_model_notes_path()).expanduser().resolve()
+        scoreboard_rows = aggregate_model_scoreboard_rows(rows, task_type=args.task_type, model=args.model)
+        explicit_path = None
+        if html_arg not in {None, ""} and not open_requested:
+            explicit_path = Path(str(html_arg))
+        page_path = write_model_scoreboard_html(
+            config,
+            path=explicit_path,
+            rows=scoreboard_rows,
+            log_path=log_path,
+            rows_read=len(rows),
+            skipped=skipped,
+            catalog_path=catalog_path,
+            catalog_models=catalog_models,
+            notes_path=notes_path,
+            notes_sections=parse_model_notes_sections(notes_path),
+        )
+        print(page_path)
+        if open_requested:
+            open_in_browser(file_href(page_path))
         return 0
     if args.json:
         print(json.dumps(groups))
@@ -5861,6 +6535,9 @@ def build_parser() -> argparse.ArgumentParser:
     models_parser.add_argument("--since", help="only include rows logged on or after YYYY-MM-DD")
     models_parser.add_argument("--explore", action="store_true", help="show proven/probation tiers plus cheap untested catalog candidates")
     models_parser.add_argument("--catalog-file", type=Path, help="path to local OpenRouter catalog snapshot")
+    models_parser.add_argument("--notes-file", type=Path, default=default_model_notes_path(), help="path to MODEL-NOTES.md judgment layer")
+    models_parser.add_argument("--html", nargs="?", const="", help="render a self-contained HTML scoreboard; optional output path")
+    models_parser.add_argument("--open", action="store_true", help="render the HTML scoreboard to the artifact library and open it")
     models_parser.add_argument("--json", action="store_true", help="print the scoreboard as JSON")
 
     catalog_parser = subparsers.add_parser("catalog", help="show or refresh the local OpenRouter model catalog")

--- a/ringside-upgrade-notes.md
+++ b/ringside-upgrade-notes.md
@@ -1,0 +1,224 @@
+# Ringside Upgrade Notes
+
+Working log for the four-feature Ringside/Ringer upgrade (2026-07-04). Written while two
+production swarms (`aicred-docs-repair`, `aicred-site-fixes`) were live — all edits happened in
+an isolated git worktree, never in `~/fleet/swarm` directly (its `dashboard/dashboard.html` is
+re-read from disk on every live-dashboard HTTP request by the running orchestrators, so editing
+it in place would have visibly corrupted Jon's screen recording).
+
+## Stack discovered
+
+- **Repo:** `~/fleet/swarm` (git, `main` branch, Jon works here on the Mac alongside Lex; push feature branches + PRs).
+- **Ringer** (`ringer.py`, stdlib-only Python 3.11+): orchestrator + per-run state writer
+  (`~/.ringer/runs/<run_id>.json`, flushed every 1s) + optional embedded HTTP dashboard
+  (`Dashboard` class, serves `dashboard/dashboard.html` + `/state.json`, live-read from disk
+  every request — no caching).
+- **Ringside** (`hud/`): a **Tauri v2** app (Rust backend `hud/src/main.rs` + vanilla-JS/HTML
+  frontend, NOT SwiftUI/React). `productName: Ringside`, `identifier: com.jonedwards.ringside`.
+  - Rust side polls `~/.ringer/runs/*.json` every 1s (`start_state_poller`), computes
+    live/finished/died state + sort order, emits a `ringer-runs` Tauri event with the full JSON
+    array (fields are passed through mostly verbatim — new task/run JSON fields show up in the
+    frontend for free, no Rust changes needed unless you need new file I/O or window behavior).
+  - Frontend: `hud/dist/index.html` (webview HTML+CSS+JS) is a **generated copy** of the repo's
+    canonical `dashboard/dashboard.html` — synced by `hud/scripts/sync-dist.sh` at build time.
+    **Always edit `dashboard/dashboard.html`, never `hud/dist/index.html` directly**, then run
+    the sync script (or let `tauri build`'s `beforeBuildCommand` do it).
+  - `hud/frontend/hud.js` (synced to `hud/dist/hud.js`) is the Tauri-only bridge: builds the
+    custom title bar, window drag, close button, HUD ticker text. It listens for `ringer-runs`
+    and also calls the shared `update()` function defined inline in `dashboard.html`.
+  - `dashboard.html`'s inline script also does `pollLocalState()` — a `fetch('/state.json')`
+    poll. That's for when the SAME html is served by ringer.py's own embedded HTTP dashboard
+    (browser tab, no Tauri). Under Tauri it 404s harmlessly (try/catch swallows it) since there's
+    no HTTP server backing the webview.
+  - Window: 360x420 default, transparent, decorations:false, alwaysOnTop, resizable (min
+    280x220). `toggle_collapse` Tauri command shrinks it to a 34px title-bar-only strip.
+  - Capabilities: `hud/capabilities/default.json` lists allowed commands
+    (`core:default` + window permissions). New `#[tauri::command]` fns must be added to both
+    `invoke_handler!` in `main.rs` AND (if not covered by `core:default`) get a permission there.
+
+## Branch / worktree
+
+- Canonical repo: `~/fleet/swarm` (do not edit while swarms are live).
+- Working worktree: `~/fleet/swarm-ringside-upgrades`, branch `feat/ringside-upgrades`.
+- Local only — never pushed, never touched `main`.
+
+## What changed (ringer.py — Tier 0 + Tier 4 "final report", the plan doc's build order #1)
+
+File: `~/fleet/swarm-ringside-upgrades/ringer.py`
+
+- Added `ArtifactConfig` dataclass + `load_artifact_config()`; new `[artifact]` config block
+  (`enabled`, `out` template, `report_out` template, `index_out`) documented in
+  `config.sample.toml`. Defaults write under `~/.ringer/artifacts/`.
+- `TaskRuntime` gained `last_check_output`, `last_check_returncode`, `last_check_timed_out` —
+  previously the verify/check output was logged to the eval sink and then thrown away; nothing
+  else in the process remembered it, so neither a live page nor a final report could show *why*
+  a task failed without grepping `worker.log`. Set in `RingerRunner._run_task` right after
+  `verify = await self.verifier.verify(...)`.
+- `StateWriter` now takes `max_parallel` + `artifact: ArtifactConfig`. `snapshot()` gained, per
+  task: `check` (the check command), `timeout_s`, `taskdir` (absolute path, for report links),
+  `verdict` (PASS/FAIL/TIMEOUT/ERROR — more specific than `status`), `check_returncode`,
+  `check_output_tail` (capped), `log_tail_full` (40 lines vs the existing 3-line `log_tail`) —
+  this is the data Ringside's detail view (feature 1) needed and didn't have.
+- Run-level snapshot gained `max_parallel`, `artifact_path`, `report_path`, `report_ready`.
+- `flush()` now also renders+atomically-writes the Tier 0 live status HTML
+  (`render_status_html`) to `artifact_path` on every 1s tick, best-effort (wrapped so a render
+  bug can never fail the run) — this is the "live artifact" feature 2 needs; Ringside just has
+  to display the file, not build the renderer.
+- `finish()` now also renders the final report (`render_final_report_html`) to `report_path`
+  once, after the summary is built — this is feature 4. Self-contained single HTML file: full
+  task table, per-task attempts/timings/verdict/check command/check output (fuller than the live
+  page, capped ~4000 chars with a truncation note), `file://` links to each task's `taskdir`,
+  `worker.log`, and `report.md`/`report.html` if present.
+  Reporter failures never gate run exit code (matches the plan's "pretty report failing
+  shouldn't mark a green run red" rule).
+- Multi-run index: `render_artifact_index_html()` + best-effort write of
+  `~/.ringer/artifacts/index.html` on every flush, scanning `state_dir/runs/*.json` — gives one
+  pane of glass across concurrent runs (tonight's exact scenario: 2 concurrent swarms).
+- New CLI flag `--no-artifact` (both `run` and `demo`), symmetric with `--no-dashboard`.
+
+## Scope update (mid-task, from Jon via coordinator)
+
+Added **Feature 5: settings panel with persistent customization** — accent/theme color, layout,
+density (compact/comfortable), which columns/fields show, default view mode. Must persist across
+Ringside restarts. Guidance: plain JSON file (not UserDefaults — this is Tauri, not Swift),
+ideally at `~/.ringer/ringside-settings.json` so the Tier 0 HTML artifact can read the same theme
+later. Explicitly told to design this together with Feature 3 (view modes) since "default view"
+becomes one persisted setting rather than a separate mechanism. Folded into priority after 4 and 1.
+
+Settings schema (JSON, `~/.ringer/ringside-settings.json`):
+```json
+{
+  "version": 1,
+  "theme": {"accent": "#28d7ff"},
+  "density": "comfortable",
+  "columns": {"showTokens": true, "showActivity": true, "showChildren": true},
+  "layout": {"defaultView": "grid", "hiddenRunIds": []}
+}
+```
+
+## What changed (Ringside — hud/)
+
+**`hud/src/main.rs`** — 4 new `#[tauri::command]` fns, registered in `invoke_handler!` alongside
+the existing `hide_window`/`toggle_collapse` (no `capabilities/default.json` change needed —
+custom app-binary commands aren't gated by the ACL system the way plugin commands are; verified
+empirically since `hide_window`/`toggle_collapse` already worked with only `core:default` +
+window permissions listed):
+- `resize_main_window(width, height)` — feature 3 window-size presets (Medium/Large), separate
+  from `toggle_collapse`'s mini-strip bookkeeping so the two don't fight.
+- `read_artifact_html(path)` — feature 2; reads a ringer.py-rendered HTML artifact off disk,
+  canonicalized and restricted to be under the resolved ringer `state_dir` (path-traversal
+  safe). Frontend injects the result into an `<iframe srcdoc>`.
+- `load_settings()` / `save_settings(settings)` — feature 5; plain JSON file at
+  `<state_dir>/ringside-settings.json` (atomic tmp+rename write), not UserDefaults, so a future
+  Tier 0 HTML artifact could read the same theme.
+
+**`dashboard/dashboard.html`** (canonical source — `hud/dist/index.html` and `hud/build.rs` both
+regenerate from this file; never edit `dist/index.html` directly):
+- Feature 1: click a task card to expand a detail panel (engine, attempts+verdict, check
+  command, taskdir, full spec, check output, 40-line live worker.log tail) built from the new
+  ringer.py state fields. Per-task progress bar (`elapsed_s / timeout_s`), hidden when no
+  timeout is known.
+- Feature 2: new "Artifact" view mode embeds the run's live Tier 0 status page via
+  `read_artifact_html` + `iframe.srcdoc`; degrades to a friendly empty-state message outside
+  Tauri.
+- Feature 3: toolbar with Grid/Artifact toggle, Collapse-all (per-run), a substring filter over
+  run+task names ("show only some agents"), and Mini/Medium/Large window-size buttons.
+- Feature 5: gear icon opens a settings panel — accent color (drives a new `--accent` CSS
+  variable; only the neutral "live" highlight is themeable, pass/fail keep fixed semantic
+  colors), density (comfortable/compact), default view mode (feeds directly into feature 3's
+  view-mode switch, not a separate mechanism), and per-column show/hide (activity line, child
+  count, run token totals). Persisted via the new Tauri commands, debounced ~350ms; gracefully
+  in-memory-only outside Tauri.
+
+## Build / run
+
+```bash
+cd ~/fleet/swarm-ringside-upgrades
+/opt/homebrew/bin/python3.11 ringer.py demo --no-dashboard --no-artifact   # sanity: unchanged behavior
+/opt/homebrew/bin/python3.11 ringer.py demo --no-dashboard                # exercise new artifact code path
+# artifacts land in ~/.ringer/artifacts/ (shared dir, but distinctly named per run_id — does not
+# collide with or touch the two production runs' state files or dashboards)
+```
+
+Rust: the Homebrew `cargo`/`rustc` on PATH (`/opt/homebrew/bin`, comes before `~/.cargo/bin`) is
+pinned to 1.87.0 and can't build current deps (darling/time/image need 1.88+). Use the
+rustup-managed toolchain explicitly:
+```bash
+cd ~/fleet/swarm-ringside-upgrades/hud
+PATH="$HOME/.cargo/bin:$PATH" cargo check   # verified clean, 1.92.0
+```
+
+Tauri build (do NOT run `tauri build` in a way that overwrites `/Applications/Ringside.app` —
+stage output only):
+```bash
+cd ~/fleet/swarm-ringside-upgrades/hud
+bash scripts/sync-dist.sh   # regenerate dist/ from dashboard.html + frontend/hud.js
+# tauri build/dev commands, if run, must not touch /Applications/Ringside.app
+```
+
+## Tested
+
+- `ringer.py` (Python 3.11, `/opt/homebrew/bin/python3.11`): syntax check, a real `demo
+  --no-dashboard` run (3 real codex tasks, all pass) producing a correct live-status HTML,
+  final-report HTML, and multi-run index (the index correctly picked up the two live production
+  runs read-only, proving the "one pane of glass across concurrent swarms" goal). Also
+  unit-tested `render_status_html`/`render_final_report_html`/`render_artifact_index_html`
+  directly with synthetic fail/retry/long-spec-truncation state to confirm the fail-block,
+  "(retried)" marker, and check-output rendering. All test artifacts cleaned up from
+  `~/.ringer/runs/` and `~/.ringer/artifacts/` afterward; the two production run state files
+  were never touched (verified: `finished:true`, correct pass counts, all after the fact — they
+  completed naturally, unrelated to this work).
+- Rust: `cargo check` clean (via rustup's 1.92.0 toolchain) after both the command additions and
+  the dashboard.html changes (which `build.rs` also re-syncs from source).
+- Frontend: JS syntax (`node --check`) and HTML parse both clean. Live smoke test via
+  chrome-devtools MCP: served `hud/dist/index.html` statically with a synthetic `state.json`
+  (three tasks: running/pass/fail) and drove it in real Chrome —
+  - task-card click expand/collapse (both a passing and the failing task, verifying check output
+    + live-tail rendering and the "2 (FAIL)" attempts/verdict line),
+  - progress bars rendered and color-matched to status,
+  - Collapse-all toggled the whole run's task grid off/on,
+  - agent filter correctly hid non-matching tasks (verified via direct DOM inspection — the MCP
+    `fill`/`click` tools don't always dispatch a real `input`/`click` event on native form
+    controls; confirmed by dispatching the event manually and reading `task.hidden` back),
+  - settings panel opened, "Activity line" checkbox correctly hid the activity row across all
+    task cards, density/accent controls present and wired,
+  - Artifact view mode correctly hid the grid and showed the designed fallback message ("could
+    not read the live artifact (Ringside desktop app only)") since no Tauri bridge exists in a
+    plain browser — proving the code path is safe outside Ringside,
+  - zero new console errors through all of the above (one pre-existing unrelated 404, likely
+    favicon).
+  - CSS bug found+fixed during this pass: `.toolbar-group[hidden]` needed an explicit rule — the
+    plain `[hidden]` UA-stylesheet rule was losing to the author `.toolbar-group{display:flex}`
+    rule at equal specificity (author origin always wins over UA origin), so the
+    non-Tauri window-size buttons weren't actually hiding. Fixed and reverified.
+- **Not tested (needs Jon or a follow-up session):** the three Tauri-specific invoke commands
+  (`resize_main_window`, `read_artifact_html`, `load_settings`/`save_settings`) were verified by
+  code review only — I did not launch a live Ringside/Tauri GUI instance during this session
+  because Jon was actively screen-recording the installed `/Applications/Ringside.app` and a
+  second always-on-top Ringside-style window appearing mid-recording would have been disruptive.
+  All three commands compile, are registered, and their JS `invoke()` argument names match the
+  Rust parameter names exactly (Tauri does no case conversion needed here since all args are
+  already single lowercase words). Recommend a quick `cargo tauri dev` (or a staged debug build,
+  never overwriting the installed app) after the recording session to confirm the real
+  window-resize/read-artifact/settings-persist round trip.
+
+## Remaining / TODO
+
+- Live Tauri runtime verification of the 3 new commands (see above) — lowest-risk next step,
+  just needs a moment when Jon isn't mid-recording.
+- Multi-run index page (`~/.ringer/artifacts/index.html`) has no UI entry point in Ringside yet
+  — it's generated and correct, but nothing in the app links to it. Small follow-up: a toolbar
+  button or menu item that opens it (e.g. via the existing `open` shell pattern Dashboard.start()
+  already uses, or another `read_artifact_html`-style embed) — worth it if Jon wants deeper
+  history across concurrent/past runs than the live/report pair gives per-run.
+- Per-run manual collapse (vs. only "collapse all") wasn't built — the agent filter already
+  covers "show only some agents" reasonably well, but a per-run collapse chevron in `run-head`
+  would be a small, cheap addition if wanted.
+- Settings currently only cover accent/density/columns/default-view, per Jon's explicit list;
+  no window position/size persistence was added beyond the existing `tauri-plugin-window-state`
+  (already handles that generically).
+- Not done: hooking the final-report/live-artifact paths into a "Reveal in Finder" / "Open"
+  action from Ringside chrome (e.g. right-click a run) — currently the only access path is the
+  new Artifact view mode (iframe) for the live page; the final report has no Ringside UI at all
+  yet (by design the safest/lowest-risk piece was ringer.py-side rendering; a Ringside "open
+  final report" button is a small, obvious follow-up once the 3 new commands are live-verified).

--- a/tests/test_scoreboard_page.py
+++ b/tests/test_scoreboard_page.py
@@ -9,17 +9,22 @@ import os
 import sys
 import tempfile
 import unittest
+from unittest import mock
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
+import ringer  # noqa: E402
 from ringer import (  # noqa: E402
     AppConfig,
     ArtifactConfig,
     EvalConfig,
+    Manifest,
+    TaskSpec,
     artifact_library_path,
     artifact_live_path,
+    lint_manifest,
     model_judgment_notes,
     parse_model_notes_sections,
     run_models_command,
@@ -211,7 +216,7 @@ class ScoreboardPageTests(unittest.TestCase):
             encoding="utf-8",
         )
 
-    def args(self, *, html: str | None = None) -> argparse.Namespace:
+    def args(self, *, html: str | None = None, open: bool = False) -> argparse.Namespace:
         return argparse.Namespace(
             log=self.log_path,
             task_type=None,
@@ -222,7 +227,7 @@ class ScoreboardPageTests(unittest.TestCase):
             catalog_file=self.catalog_path,
             notes_file=self.notes_path,
             html=html,
-            open=False,
+            open=open,
             json=False,
         )
 
@@ -244,6 +249,7 @@ class ScoreboardPageTests(unittest.TestCase):
         self.assertIn("probation", html)
         self.assertIn("n=20", html)
         self.assertIn("FREE", html)
+        self.assertNotIn("$0/task", html)
         self.assertIn("steady code-feature performance across a larger sample", html)
         self.assertIn("Continuation line kept with the dated bullet.", html)
         self.assertIn("no judgment notes yet", html)
@@ -297,6 +303,18 @@ class ScoreboardPageTests(unittest.TestCase):
         self.assertTrue(html_path.exists())
         self.assertFalse(artifact_library_path(self.config.state_dir).exists())
 
+    def test_html_path_with_open_writes_and_opens_explicit_path_without_library(self) -> None:
+        html_path = self.root / "custom-open.html"
+        out = io.StringIO()
+        with mock.patch.object(ringer, "open_in_browser") as open_in_browser:
+            with contextlib.redirect_stdout(out):
+                self.assertEqual(0, run_models_command(self.config, self.args(html=str(html_path), open=True)))
+
+        self.assertEqual(str(html_path.resolve()) + "\n", out.getvalue())
+        self.assertTrue(html_path.exists())
+        self.assertFalse(artifact_library_path(self.config.state_dir).exists())
+        open_in_browser.assert_called_once_with(ringer.file_href(html_path.resolve()))
+
     def test_html_without_path_writes_live_artifact_library_entry(self) -> None:
         out = io.StringIO()
         args = self.args(html="")
@@ -324,6 +342,71 @@ class ScoreboardPageTests(unittest.TestCase):
         self.assertIn("steady code-feature performance", proven[0])
         self.assertIn("Continuation line kept", proven[0])
         self.assertEqual([], model_judgment_notes("openrouter/missing", sections))
+
+    def test_notes_matching_uses_id_boundaries_and_best_heading(self) -> None:
+        notes_path = self.root / "MODEL-NOTES-boundaries.md"
+        notes_path.write_text(
+            """# Notes
+
+## gpt-4o
+
+- 2026-07-06 - four-o note.
+
+## runner lane (`gpt-4`)
+
+- 2026-07-06 - generic four note.
+
+## gpt-4
+
+- 2026-07-06 - exact four note.
+""",
+            encoding="utf-8",
+        )
+        sections = parse_model_notes_sections(notes_path)
+
+        gpt4_notes = model_judgment_notes("gpt-4", sections)
+        gpt4o_notes = model_judgment_notes("gpt-4o", sections)
+
+        self.assertEqual(1, len(gpt4_notes))
+        self.assertIn("exact four note", gpt4_notes[0])
+        self.assertNotIn("four-o note", gpt4_notes[0])
+        self.assertEqual(1, len(gpt4o_notes))
+        self.assertIn("four-o note", gpt4o_notes[0])
+        self.assertNotIn("exact four note", gpt4o_notes[0])
+
+    def test_notes_parser_returns_empty_for_directory_path(self) -> None:
+        self.assertEqual({}, parse_model_notes_sections(self.root))
+
+    def test_manifest_rejects_reserved_scoreboard_run_name_and_lints_it(self) -> None:
+        task_obj = {
+            "key": "one",
+            "spec": "Create the requested artifact, keep the work scoped, and write a clear verification output.",
+            "check": "test -s output.txt",
+            "expect_files": ["output.txt"],
+            "verified": "output.txt exists",
+        }
+        with self.assertRaisesRegex(ValueError, "run_name model-scoreboard is reserved for the scoreboard page"):
+            Manifest.from_obj(
+                {
+                    "run_name": "model-scoreboard",
+                    "workdir": str(self.root / "work"),
+                    "max_parallel": 1,
+                    "tasks": [task_obj],
+                }
+            )
+
+        manifest = Manifest(
+            run_name="model-scoreboard",
+            workdir=self.root / "work",
+            max_parallel=1,
+            worktrees=False,
+            repo=None,
+            tasks=(TaskSpec.from_obj(task_obj),),
+        )
+        self.assertIn(
+            "manifest: run_name model-scoreboard is reserved for the scoreboard page.",
+            lint_manifest(manifest),
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_scoreboard_page.py
+++ b/tests/test_scoreboard_page.py
@@ -1,0 +1,330 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import contextlib
+import io
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from ringer import (  # noqa: E402
+    AppConfig,
+    ArtifactConfig,
+    EvalConfig,
+    artifact_library_path,
+    artifact_live_path,
+    model_judgment_notes,
+    parse_model_notes_sections,
+    run_models_command,
+)
+
+
+def catalog_model(model_id: str, *, prompt: str, completion: str, ctx: int = 64000) -> dict[str, object]:
+    return {
+        "id": model_id,
+        "name": model_id,
+        "context_length": ctx,
+        "architecture": {"modality": "text->text"},
+        "pricing": {"prompt": prompt, "completion": completion},
+    }
+
+
+def attempt(
+    *,
+    run_id: str,
+    task_key: str,
+    model: str,
+    task_type: str,
+    verdict: str,
+    retry: bool,
+    logged_at: str,
+    tokens: int | None = 1000,
+    engine: str = "opencode",
+) -> dict[str, object]:
+    return {
+        "run_id": run_id,
+        "task_key": task_key,
+        "worker_engine": engine,
+        "model": model,
+        "task_type": task_type,
+        "verdict": verdict,
+        "retry": retry,
+        "worker_tokens": tokens,
+        "duration_ms": 100,
+        "logged_at": logged_at,
+    }
+
+
+class ScoreboardPageTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name)
+        self.old_env = os.environ.copy()
+        self.addCleanup(self.restore_env)
+        os.environ["HOME"] = str(self.root / "home")
+        os.environ["RINGER_HOME"] = str(self.root / "ringer-home")
+        self.log_path = self.root / "eval.jsonl"
+        self.catalog_path = self.root / "catalog.json"
+        self.notes_path = self.root / "MODEL-NOTES.md"
+        self.config = AppConfig(
+            path=None,
+            identity_default=None,
+            state_dir=self.root / "state",
+            dashboard_port_base=8787,
+            hud_port=8700,
+            hud_app_path=None,
+            allow_full_access=False,
+            eval=EvalConfig(backend="jsonl", jsonl_path=self.log_path),
+            engines={},
+            artifact=ArtifactConfig(
+                enabled=True,
+                out_template=str(self.root / "live.html"),
+                report_template=str(self.root / "report.html"),
+                index_out=self.root / "index.html",
+            ),
+        )
+        self.write_fixtures()
+
+    def restore_env(self) -> None:
+        os.environ.clear()
+        os.environ.update(self.old_env)
+
+    def write_fixtures(self) -> None:
+        rows: list[dict[str, object]] = []
+        for index in range(20):
+            run_id = f"proven-{index:02d}"
+            task_key = "task"
+            if index < 18:
+                rows.append(
+                    attempt(
+                        run_id=run_id,
+                        task_key=task_key,
+                        model="openrouter/proven",
+                        task_type="code-feature",
+                        verdict="PASS",
+                        retry=False,
+                        logged_at=f"2026-07-06T10:{index:02d}:00+00:00",
+                        tokens=2000,
+                    )
+                )
+            else:
+                rows.append(
+                    attempt(
+                        run_id=run_id,
+                        task_key=task_key,
+                        model="openrouter/proven",
+                        task_type="code-feature",
+                        verdict="FAIL",
+                        retry=False,
+                        logged_at=f"2026-07-06T10:{index:02d}:00+00:00",
+                        tokens=2000,
+                    )
+                )
+                rows.append(
+                    attempt(
+                        run_id=run_id,
+                        task_key=task_key,
+                        model="openrouter/proven",
+                        task_type="code-feature",
+                        verdict="PASS",
+                        retry=True,
+                        logged_at=f"2026-07-06T11:{index:02d}:00+00:00",
+                        tokens=2200,
+                    )
+                )
+        rows.append(
+            attempt(
+                run_id="probation-1",
+                task_key="task",
+                model="openrouter/probation",
+                task_type="code-feature",
+                verdict="PASS",
+                retry=False,
+                logged_at="2026-07-06T12:00:00+00:00",
+                tokens=500,
+            )
+        )
+        rows.append(
+            attempt(
+                run_id="free-1",
+                task_key="task",
+                model="openrouter/free:free",
+                task_type="research",
+                verdict="PASS",
+                retry=False,
+                logged_at="2026-07-06T12:10:00+00:00",
+                tokens=700,
+            )
+        )
+        rows.append(
+            attempt(
+                run_id="codex-1",
+                task_key="task",
+                model="",
+                task_type="site-build",
+                verdict="PASS",
+                retry=False,
+                logged_at="2026-07-06T12:20:00+00:00",
+                tokens=None,
+                engine="codex",
+            )
+        )
+        self.log_path.write_text("\n".join(json.dumps(row) for row in rows) + "\nnot-json\n", encoding="utf-8")
+        self.catalog_path.write_text(
+            json.dumps(
+                {
+                    "models": [
+                        catalog_model("openrouter/proven", prompt="0.000001", completion="0.000003"),
+                        catalog_model("openrouter/probation", prompt="0.0000005", completion="0.000001"),
+                        catalog_model("openrouter/free:free", prompt="0.000002", completion="0.000004", ctx=128000),
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+        self.catalog_path.with_name("catalog.changes.jsonl").write_text(
+            json.dumps({"ts": "2026-07-06T12:00:00+00:00", "kind": "went_free", "id": "openrouter/free:free"})
+            + "\n",
+            encoding="utf-8",
+        )
+        self.notes_path.write_text(
+            """# Notes
+
+## Proven lane (`openrouter/proven`)
+
+- Non-dated setup line ignored by the parser.
+- 2026-07-06 - steady code-feature performance across a larger sample.
+  Continuation line kept with the dated bullet.
+
+## codex
+
+- 2026-07-06 - flat-plan site work; no token billing in the log.
+""",
+            encoding="utf-8",
+        )
+
+    def args(self, *, html: str | None = None) -> argparse.Namespace:
+        return argparse.Namespace(
+            log=self.log_path,
+            task_type=None,
+            model=None,
+            engine=None,
+            since=None,
+            explore=False,
+            catalog_file=self.catalog_path,
+            notes_file=self.notes_path,
+            html=html,
+            open=False,
+            json=False,
+        )
+
+    def render_to(self, path: Path) -> str:
+        out = io.StringIO()
+        with contextlib.redirect_stdout(out):
+            self.assertEqual(0, run_models_command(self.config, self.args(html=str(path))))
+        self.assertEqual(str(path.resolve()) + "\n", out.getvalue())
+        return path.read_text(encoding="utf-8")
+
+    def test_html_render_contains_models_tiers_counts_free_badge_and_notes(self) -> None:
+        html = self.render_to(self.root / "scoreboard.html")
+
+        self.assertIn("openrouter/proven", html)
+        self.assertIn("openrouter/probation", html)
+        self.assertIn("openrouter/free:free", html)
+        self.assertIn("codex", html)
+        self.assertIn("proven", html)
+        self.assertIn("probation", html)
+        self.assertIn("n=20", html)
+        self.assertIn("FREE", html)
+        self.assertIn("steady code-feature performance across a larger sample", html)
+        self.assertIn("Continuation line kept with the dated bullet.", html)
+        self.assertIn("no judgment notes yet", html)
+        self.assertIn("included in plan", html)
+
+    def test_evidence_floor_orders_probation_after_proven_model(self) -> None:
+        html = self.render_to(self.root / "scoreboard.html")
+
+        self.assertLess(html.index("openrouter/proven"), html.index("openrouter/probation"))
+        self.assertIn("#1", html[: html.index("openrouter/proven")])
+
+    def test_reused_task_identity_does_not_collapse_proven_evidence(self) -> None:
+        rows: list[dict[str, object]] = []
+        for index in range(20):
+            rows.append(
+                attempt(
+                    run_id="shared-run",
+                    task_key="shared-task",
+                    model="openrouter/proven",
+                    task_type="code-feature",
+                    verdict="PASS" if index < 18 else "FAIL",
+                    retry=False,
+                    logged_at=f"2026-07-06T13:{index:02d}:00+00:00",
+                    tokens=2000,
+                )
+            )
+        rows.append(
+            attempt(
+                run_id="shared-run",
+                task_key="shared-task",
+                model="openrouter/probation",
+                task_type="code-feature",
+                verdict="PASS",
+                retry=False,
+                logged_at="2026-07-06T14:00:00+00:00",
+                tokens=500,
+            )
+        )
+        self.log_path.write_text("\n".join(json.dumps(row) for row in rows) + "\n", encoding="utf-8")
+
+        html = self.render_to(self.root / "scoreboard.html")
+
+        self.assertLess(html.index("openrouter/proven"), html.index("openrouter/probation"))
+        self.assertIn("n=20", html)
+        self.assertIn("proven", html[: html.index("openrouter/proven")])
+
+    def test_html_path_does_not_write_artifact_library(self) -> None:
+        html_path = self.root / "custom.html"
+        self.render_to(html_path)
+
+        self.assertTrue(html_path.exists())
+        self.assertFalse(artifact_library_path(self.config.state_dir).exists())
+
+    def test_html_without_path_writes_live_artifact_library_entry(self) -> None:
+        out = io.StringIO()
+        args = self.args(html="")
+        with contextlib.redirect_stdout(out):
+            self.assertEqual(0, run_models_command(self.config, args))
+
+        live_path = artifact_live_path(self.config.state_dir, "model-scoreboard")
+        self.assertEqual(str(live_path.resolve()) + "\n", out.getvalue())
+        self.assertTrue(live_path.exists())
+        library = json.loads(artifact_library_path(self.config.state_dir).read_text(encoding="utf-8"))
+        self.assertIn("model-scoreboard", library["artifacts"])
+
+    def test_html_is_self_contained_with_no_external_resource_loads(self) -> None:
+        html = self.render_to(self.root / "scoreboard.html")
+
+        self.assertNotRegex(html, r"""(?:src|href)=["']https?://""")
+        self.assertNotRegex(html, r"""@import\s+["']https?://""")
+        self.assertNotIn("<script", html.lower())
+
+    def test_notes_section_parser_matches_heading_and_missing_section_falls_back(self) -> None:
+        sections = parse_model_notes_sections(self.notes_path)
+
+        proven = model_judgment_notes("openrouter/proven", sections)
+        self.assertEqual(1, len(proven))
+        self.assertIn("steady code-feature performance", proven[0])
+        self.assertIn("Continuation line kept", proven[0])
+        self.assertEqual([], model_judgment_notes("openrouter/missing", sections))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Jon's ask: 'show me the model scoreboard' → one command → a good-looking page in the browser. Model name, tier-ordered ranking with an evidence floor (a 1-for-1 model can never outrank an 18-for-20 one; n always shown), est. $/task from catalog pricing × median tokens, FREE/var/included-in-plan badges, usage counts + per-task_type breakdowns, best/worst derived qualities plus MODEL-NOTES judgment excerpts embedded verbatim, and a free-promo watchlist. Zero model calls in the render path — any Ringer instance produces it for free.

Adversarially reviewed (glm-5.2, injection-focused lens; report in ~/.ringer/work/scoreboard-review/): 6 findings all fixed with tests, injection handling verified empirically clean. 19 suites green. Live-rendered against real data (6 model cards).

🤖 Generated with [Claude Code](https://claude.com/claude-code)