### PR TITLE
Model intelligence stack: SQLite read model, identity registry, cited capability registry, redesigned scoreboard, Ringside Models tab

### DIFF
--- a/dashboard/dashboard.html
+++ b/dashboard/dashboard.html
@@ -717,6 +717,143 @@
       font-size: 12px;
       text-align: center;
     }
+    #app.models-mode { display: none; }
+    .models-view {
+      flex: 1 1 auto;
+      min-height: 0;
+      display: none;
+      flex-direction: column;
+      overflow: auto;
+      background: var(--panel);
+    }
+    .models-view.active { display: flex; }
+    .models-state {
+      flex: 0 0 auto;
+      min-height: 28px;
+      padding: 7px 10px;
+      border-bottom: 1px solid rgba(255,255,255,.08);
+      color: var(--muted);
+      background: rgba(5,8,12,.18);
+      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      font-size: 10px;
+      line-height: 1.2;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+    .models-state.error { color: #ffb7c0; }
+    .models-table-wrap {
+      flex: 1 1 auto;
+      min-height: 0;
+      overflow: auto;
+    }
+    .models-table {
+      width: 100%;
+      min-width: 860px;
+      border-collapse: collapse;
+      font-size: 11px;
+    }
+    .models-table th,
+    .models-table td {
+      padding: 8px 10px;
+      border-bottom: 1px solid rgba(255,255,255,.07);
+      vertical-align: middle;
+      text-align: left;
+    }
+    .models-table th {
+      position: sticky;
+      top: 0;
+      z-index: 2;
+      background: #0d141f;
+      color: var(--muted);
+      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      font-size: 9.5px;
+      font-weight: 800;
+      text-transform: uppercase;
+    }
+    .models-table td.numeric,
+    .models-table th.numeric { text-align: right; }
+    .model-row {
+      cursor: pointer;
+      transition: background .18s ease;
+    }
+    .model-row:hover,
+    .model-row.expanded { background: rgba(255,255,255,.045); }
+    .model-name-cell {
+      min-width: 220px;
+      display: flex;
+      flex-direction: column;
+      gap: 2px;
+    }
+    .model-display {
+      color: var(--text);
+      font-size: 12px;
+      font-weight: 850;
+    }
+    .model-slug,
+    .models-meta {
+      color: var(--muted);
+      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      font-size: 10px;
+      line-height: 1.25;
+    }
+    .tier-badge {
+      display: inline-flex;
+      align-items: center;
+      min-height: 20px;
+      padding: 3px 6px;
+      border: 1px solid rgba(255,255,255,.13);
+      border-radius: 5px;
+      color: #d8e5f6;
+      background: rgba(255,255,255,.05);
+      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      font-size: 9.5px;
+      font-weight: 900;
+      text-transform: uppercase;
+    }
+    .tier-badge.proven {
+      border-color: rgba(73,226,125,.42);
+      color: #bff8d0;
+      background: rgba(73,226,125,.12);
+    }
+    .tier-badge.probation {
+      border-color: rgba(255,190,69,.42);
+      color: #ffe1a3;
+      background: rgba(255,190,69,.11);
+    }
+    .model-breakdown td {
+      padding: 0;
+      background: rgba(5,8,12,.30);
+    }
+    .breakdown-grid {
+      display: grid;
+      grid-template-columns: minmax(120px, 1fr) repeat(5, minmax(70px, auto));
+      gap: 0;
+      padding: 8px 10px 10px 48px;
+      color: #cbd6e8;
+      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      font-size: 10px;
+    }
+    .breakdown-grid > div {
+      padding: 5px 8px;
+      border-bottom: 1px solid rgba(255,255,255,.055);
+      min-width: 0;
+    }
+    .breakdown-head {
+      color: var(--muted);
+      font-size: 9px;
+      font-weight: 800;
+      text-transform: uppercase;
+    }
+    .models-empty {
+      min-height: 220px;
+      display: grid;
+      place-items: center;
+      padding: 26px;
+      color: rgba(230,240,255,.72);
+      font-size: 13px;
+      text-align: center;
+    }
     .run.collapsed .tasks { display: none; }
     body.density-compact .toolbar { padding-top: 6px; padding-bottom: 6px; }
     body.density-compact .tasks { gap: 6px; padding: 7px; }
@@ -772,6 +909,11 @@
         flex: 1 1 180px;
         max-width: none;
       }
+      .breakdown-grid {
+        grid-template-columns: minmax(110px, 1fr) repeat(2, minmax(64px, auto));
+        padding-left: 10px;
+      }
+      .breakdown-grid .optional { display: none; }
     }
   </style>
 </head>
@@ -791,6 +933,7 @@
       <div class="toolbar-group" id="viewButtons">
         <button type="button" data-view="grid" class="active">Grid</button>
         <button type="button" data-view="artifact">Artifact</button>
+        <button type="button" data-view="models">Models</button>
       </div>
       <div class="toolbar-group">
         <button type="button" id="collapseAllBtn">Collapse all</button>
@@ -817,6 +960,7 @@
           <select id="defaultViewSelect">
             <option value="grid">Grid</option>
             <option value="artifact">Artifact</option>
+            <option value="models">Models</option>
           </select>
         </div>
         <div class="settings-title">Show fields</div>
@@ -858,6 +1002,12 @@
         </div>
       </div>
     </div>
+    <div class="models-view" id="modelsView" data-no-drag>
+      <div class="models-state" id="modelsState">models not loaded</div>
+      <div class="models-table-wrap" id="modelsTableWrap">
+        <div class="models-empty">No model results yet. Run './ringer.py models' for the local scoreboard docs.</div>
+      </div>
+    </div>
   </div>
   <script>
     const app = document.getElementById("app");
@@ -889,9 +1039,13 @@
     const artifactVersionBar = document.getElementById("artifactVersionBar");
     const artifactFrameState = document.getElementById("artifactFrameState");
     const artifactFrameWrap = document.getElementById("artifactFrameWrap");
+    const modelsView = document.getElementById("modelsView");
+    const modelsState = document.getElementById("modelsState");
+    const modelsTableWrap = document.getElementById("modelsTableWrap");
 
     const ARTIFACT_REFRESH_MS = 2000;
     const WORKER_LOG_POLL_MS = 1000;
+    const MODELS_REFRESH_MS = 30000;
     const TAURI_INVOKE = window.__TAURI__?.core?.invoke;
     const TAURI_CONVERT_FILE_SRC = window.__TAURI__?.core?.convertFileSrc;
     const IS_TAURI = Boolean(TAURI_INVOKE);
@@ -919,6 +1073,11 @@
     let artifactRefreshTimer = null;
     let artifactRefreshInFlight = false;
     let artifactRefreshSeq = 0;
+    let modelsRefreshTimer = null;
+    let modelsRefreshInFlight = false;
+    let modelsLastFetchMs = 0;
+    let modelsPayload = null;
+    let expandedModelKey = null;
     let localStatePollFailed = false;
 
     const DEFAULT_SETTINGS = {
@@ -1653,15 +1812,176 @@
       return TAURI_INVOKE(command, args);
     }
 
+    function formatModelPercent(value) {
+      const number = Number(value);
+      if (!Number.isFinite(number)) return "0%";
+      return `${Math.round(number * 100)}%`;
+    }
+
+    function formatModelDate(value) {
+      const text = String(value || "").trim();
+      if (!text) return "unknown";
+      const match = text.match(/^(\d{4})-(\d{2})-(\d{2})/);
+      if (match) {
+        const localDate = new Date(Number(match[1]), Number(match[2]) - 1, Number(match[3]));
+        return localDate.toLocaleDateString("en-US", {month: "long", day: "numeric", year: "numeric"});
+      }
+      const date = new Date(text);
+      if (Number.isNaN(date.getTime())) return text;
+      return date.toLocaleDateString("en-US", {month: "long", day: "numeric", year: "numeric"});
+    }
+
+    function modelKey(row) {
+      return String(row?.model || "");
+    }
+
+    function modelGroupsFor(row) {
+      const key = modelKey(row);
+      const groups = Array.isArray(modelsPayload?.groups) ? modelsPayload.groups : [];
+      return groups.filter(group => String(group?.model || "") === key);
+    }
+
+    function renderModelsEmpty(message) {
+      if (!modelsTableWrap) return;
+      modelsTableWrap.innerHTML = `<div class="models-empty">${escapeHtml(message)}</div>`;
+    }
+
+    function renderModelBreakdown(row) {
+      const groups = modelGroupsFor(row);
+      if (groups.length === 0) {
+        return '<div class="models-empty">No per-task breakdown recorded for this model.</div>';
+      }
+      const cells = [
+        '<div class="breakdown-head">Task type</div>',
+        '<div class="breakdown-head">Tasks</div>',
+        '<div class="breakdown-head">First</div>',
+        '<div class="breakdown-head optional">Pass</div>',
+        '<div class="breakdown-head optional">Attempts</div>',
+        '<div class="breakdown-head optional">Last used</div>',
+      ];
+      groups.forEach(group => {
+        cells.push(
+          `<div>${escapeHtml(group.task_type || "(untyped)")}</div>`,
+          `<div>${numberOrZero(group.tasks).toLocaleString()}</div>`,
+          `<div>${escapeHtml(formatModelPercent(group.first_try_pass_rate))}</div>`,
+          `<div class="optional">${escapeHtml(formatModelPercent(group.pass_rate))}</div>`,
+          `<div class="optional">${numberOrZero(group.attempts).toLocaleString()}</div>`,
+          `<div class="optional">${escapeHtml(formatModelDate(group.last_seen))}</div>`,
+        );
+      });
+      return `<div class="breakdown-grid">${cells.join("")}</div>`;
+    }
+
+    function renderModelsTable() {
+      const rows = Array.isArray(modelsPayload?.rollup) ? modelsPayload.rollup : [];
+      const error = String(modelsPayload?.error || "").trim();
+      if (modelsState) {
+        modelsState.classList.toggle("error", Boolean(error));
+        setText(modelsState, error ? `models unavailable: ${error}` : `updated ${formatModelDate(modelsPayload?.generated_at)}`);
+      }
+      if (rows.length === 0) {
+        renderModelsEmpty("No model results yet. Run './ringer.py models' for the local scoreboard docs.");
+        return;
+      }
+      const body = [];
+      rows.forEach((row, index) => {
+        const key = modelKey(row);
+        const expanded = expandedModelKey === key;
+        const display = String(row.model_display || row.model || "unknown");
+        const slug = String(row.model || "unknown");
+        const tier = safeClass(row.tier, "unknown");
+        body.push(
+          `<tr class="model-row${expanded ? " expanded" : ""}" data-model="${escapeHtml(key)}" tabindex="0">`,
+          `<td class="numeric">${index + 1}</td>`,
+          '<td>',
+          '<div class="model-name-cell">',
+          `<span class="model-display">${escapeHtml(display)}</span>`,
+          `<span class="model-slug">${escapeHtml(slug)}</span>`,
+          '</div>',
+          '</td>',
+          `<td>${escapeHtml(row.harness || "unknown")}</td>`,
+          `<td>${escapeHtml(row.access || "unknown")}</td>`,
+          `<td><span class="tier-badge ${escapeHtml(tier)}">${escapeHtml(row.tier || "unknown")}</span></td>`,
+          `<td class="numeric">${numberOrZero(row.tasks).toLocaleString()}</td>`,
+          `<td class="numeric">${escapeHtml(formatModelPercent(row.first_try_pass_rate))}</td>`,
+          `<td class="numeric">${escapeHtml(formatModelPercent(row.pass_rate))}</td>`,
+          `<td>${escapeHtml(formatModelDate(row.last_seen))}</td>`,
+          '</tr>',
+        );
+        if (expanded) {
+          body.push(
+            '<tr class="model-breakdown">',
+            `<td colspan="9">${renderModelBreakdown(row)}</td>`,
+            '</tr>',
+          );
+        }
+      });
+      modelsTableWrap.innerHTML = [
+        '<table class="models-table">',
+        '<thead><tr>',
+        '<th class="numeric">Rank</th>',
+        '<th>Model</th>',
+        '<th>Harness</th>',
+        '<th>API/Plan</th>',
+        '<th>Tier</th>',
+        '<th class="numeric">Tasks</th>',
+        '<th class="numeric">First-try %</th>',
+        '<th class="numeric">Pass %</th>',
+        '<th>Last used</th>',
+        '</tr></thead>',
+        `<tbody>${body.join("")}</tbody>`,
+        '</table>',
+      ].join("");
+    }
+
+    async function refreshModelsView(opts = {}) {
+      if (modelsRefreshInFlight) return;
+      const now = Date.now();
+      if (!opts.force && modelsLastFetchMs && now - modelsLastFetchMs < MODELS_REFRESH_MS) return;
+      modelsRefreshInFlight = true;
+      setText(modelsState, modelsPayload ? "refreshing models..." : "loading models...");
+      try {
+        const response = await fetch(`/api/models?t=${Date.now()}`, {cache: "no-store"});
+        modelsPayload = await response.json();
+        modelsLastFetchMs = Date.now();
+      } catch (err) {
+        modelsPayload = {
+          generated_at: new Date().toISOString(),
+          groups: [],
+          rollup: [],
+          error: err?.message || "models unavailable",
+        };
+      } finally {
+        modelsRefreshInFlight = false;
+        renderModelsTable();
+      }
+    }
+
+    function startModelsRefreshTimer() {
+      stopModelsRefreshTimer();
+      modelsRefreshTimer = setInterval(() => {
+        if (viewMode === "models") refreshModelsView();
+      }, MODELS_REFRESH_MS);
+    }
+
+    function stopModelsRefreshTimer() {
+      if (modelsRefreshTimer) clearInterval(modelsRefreshTimer);
+      modelsRefreshTimer = null;
+    }
+
     function normalizeViewMode(mode) {
-      return mode === "artifact" ? "artifact" : "grid";
+      return mode === "artifact" || mode === "models" ? mode : "grid";
     }
 
     function configureArtifactModeAvailability() {
       const artifactButton = viewButtons?.querySelector('button[data-view="artifact"]');
       if (artifactButton) artifactButton.title = "Live artifacts";
+      const modelsButton = viewButtons?.querySelector('button[data-view="models"]');
+      if (modelsButton) modelsButton.title = "Model scoreboard";
       const artifactOption = defaultViewSelect?.querySelector('option[value="artifact"]');
       if (artifactOption) artifactOption.title = "Live artifacts";
+      const modelsOption = defaultViewSelect?.querySelector('option[value="models"]');
+      if (modelsOption) modelsOption.title = "Model scoreboard";
     }
 
     function mergeSettings(base, incoming) {
@@ -1717,7 +2037,9 @@
     function setViewMode(mode, opts = {}) {
       viewMode = normalizeViewMode(mode);
       app.classList.toggle("artifact-mode", viewMode === "artifact");
+      app.classList.toggle("models-mode", viewMode === "models");
       artifactView.classList.toggle("active", viewMode === "artifact");
+      modelsView.classList.toggle("active", viewMode === "models");
       for (const btn of viewButtons.querySelectorAll("button[data-view]")) {
         btn.classList.toggle("active", btn.dataset.view === viewMode);
       }
@@ -1727,6 +2049,12 @@
         startArtifactRefreshTimer();
       } else {
         stopArtifactRefreshTimer();
+      }
+      if (viewMode === "models") {
+        refreshModelsView({force: true});
+        startModelsRefreshTimer();
+      } else {
+        stopModelsRefreshTimer();
       }
       if (opts.persist !== false) {
         settings.layout.defaultView = viewMode;
@@ -1738,6 +2066,24 @@
       const btn = event.target.closest("button[data-view]");
       if (!btn) return;
       setViewMode(btn.dataset.view);
+    });
+
+    modelsTableWrap?.addEventListener("click", event => {
+      const row = event.target.closest(".model-row");
+      if (!row) return;
+      const key = row.getAttribute("data-model") || "";
+      expandedModelKey = expandedModelKey === key ? null : key;
+      renderModelsTable();
+    });
+
+    modelsTableWrap?.addEventListener("keydown", event => {
+      if (event.key !== "Enter" && event.key !== " ") return;
+      const row = event.target.closest(".model-row");
+      if (!row) return;
+      event.preventDefault();
+      const key = row.getAttribute("data-model") || "";
+      expandedModelKey = expandedModelKey === key ? null : key;
+      renderModelsTable();
     });
 
     collapseAllBtn?.addEventListener("click", () => {

--- a/docs/MODEL-NOTES.md
+++ b/docs/MODEL-NOTES.md
@@ -66,6 +66,12 @@ checks and raw logs support — no vibes, no worker self-reports.
   the free-promo watchlist legitimately mentions a free model before the
   ranked cards, and the check compared raw first-occurrence). Six review
   findings fixed in one batch, PASS attempt 1, 141s.
+- 2026-07-06 — model-db stack (SQLite read model 516s, page redesign 536s,
+  Ringside tab 527s, plus three fix batches all attempt-1): five substantial
+  ringer.py features in one day, every one against an executed contract
+  check. Review lane found the HIGH that mattered (sync cursor skipping a
+  half-written trailing line). Codex is the proven lane for both sides of
+  the review->fix loop on this codebase.
 
 ## glm-5.2 via opencode (`openrouter/z-ai/glm-5.2`)
 
@@ -126,6 +132,11 @@ checks and raw logs support — no vibes, no worker self-reports.
   (it actually rendered hostile model ids to prove escaping). Second
   proven-tier structured review in one day; glm is now the default review
   lane for mid-size diffs.
+- 2026-07-06 — invariants/injection/frontend review of the 4,061-line
+  model-db branch: PASS attempt 1, 96k tokens, 14 coverage items — two real
+  contention findings (full catalog re-ingest per sync; schema writes on
+  read paths) plus an empirical XSS all-clear on the new DOM surfaces.
+  Third proven-tier structured review today.
 
 ## kimi-k2.7 via opencode (`openrouter/moonshotai/kimi-k2.7-code`)
 
@@ -167,6 +178,15 @@ checks and raw logs support — no vibes, no worker self-reports.
   this audition on long structured code review; if it gets another slot,
   try a shorter, more mechanical task first.
 
+## llama-3.3-70b-instruct (via opencode, `openrouter/meta-llama/llama-3.3-70b-instruct:free`)
+
+- 2026-07-06 — AUDITION FAILED (exploration slot, $0). Fresh-eyes review of
+  a 4,061-line diff with a verbatim-quote citation requirement: failed the
+  structured-report check both attempts. Second free-model audition to fail
+  on long structured code review (after nemotron-3-super) — the exploration
+  ladder now says: audition free models on SHORT mechanical tasks first;
+  long-diff review is a proven-tier lane.
+
 ## Small / flash-class models
 
 - First to choke on long conversational or multi-turn harness tasks —
@@ -174,6 +194,16 @@ checks and raw logs support — no vibes, no worker self-reports.
   group lesson).
 
 ## Process lessons (cross-model)
+
+- 2026-07-06 — the orchestrator's CHECKS were the day's top failure source:
+  three check bugs (fixture newline join, first-occurrence ordering vs the
+  watchlist strip, claim-prefix split on '.' instead of ':') each produced
+  a FAIL verdict on work that was actually correct — including all four
+  capability-research packets at once. Every one was caught by reading raw
+  logs/artifacts before blaming the model. Corollary for the scoreboard:
+  recorded FAILs whose root cause was a check bug are annotated here, and
+  check fixtures deserve the same review care as production code.
+
 
 - 2026-07-06 — HARNESS BUG (fix in flight on feat/model-perf-log):
   Verifier.verify evaluated expect_files BEFORE running the check, so any

--- a/registry/model-capabilities/glm-5.2.toml
+++ b/registry/model-capabilities/glm-5.2.toml
@@ -1,0 +1,194 @@
+[model]
+key = "openrouter/z-ai/glm-5.2"
+display = "GLM 5.2"
+vendor = "Z.ai"
+release_date = "2026-06-16"
+
+[api]
+endpoint_families = ["chat-completions", "native-vendor"]
+auth = "OpenCode uses OpenRouter API-key auth with model slug z-ai/glm-5.2. Native Z.ai access uses bearer-token auth against the OpenAI-compatible Z.ai Chat Completions API."
+streaming = "OpenRouter Chat Completions supports stream=true. Native Z.ai Chat Completions supports stream=true over standard Event Stream and terminates with data: [DONE]; native function-call streaming is controlled separately by tool_stream, which defaults to false."
+
+[caching]
+supported = true
+mode = "implicit"
+how_enabled = "Native Z.ai context caching is automatic and requires no request-side cache_control. Through OpenRouter/OpenCode, do not rely on prompt caching for GLM-5.2 today: OpenRouter documents provider-specific caching and current GLM-5.2 endpoint metadata reports supports_implicit_caching=false for every upstream endpoint, even though many endpoints expose input_cache_read pricing."
+ttl = "unknown"
+read_pricing_per_m = 0.16874
+write_pricing_per_m = "unknown"
+min_cacheable_prefix_tokens = "unknown"
+
+[tool_calling]
+format = "OpenAI-compatible Chat Completions tools array with function definitions and tool_choice; tool calls return assistant tool_calls with function.arguments as a JSON string. Native Z.ai documents tool_choice auto only. OpenRouter exposes tools, tool_choice, response_format, structured_outputs, and parallel_tool_calls at the model level, but support varies by upstream provider."
+parallel = true
+strict_json_schema = "unknown"
+quirks = [
+  "Use provider.require_parameters=true when a harness depends on tools, tool_choice, response_format, structured_outputs, parallel_tool_calls, reasoning, or reasoning_effort; otherwise OpenRouter may route to a provider that ignores unsupported parameters.",
+  "Current OpenRouter GLM-5.2 providers do not all expose the same tool-related parameters; only some advertise structured_outputs, and only Inceptron currently advertises parallel_tool_calls in endpoint metadata.",
+  "Native Z.ai structured output documentation describes JSON mode plus client-side JSON Schema validation examples, not a confirmed strict server-side schema guarantee for tool arguments.",
+  "Local OpenCode/Ringer observation from long structured tasks: GLM-5.2 can occasionally emit malformed or retry-needed tool JSON under long context; keep parse validation and retry behavior enabled instead of treating the first malformed tool call as a model-failure verdict."
+]
+
+[reasoning]
+params = ["reasoning", "include_reasoning", "reasoning_effort", "thinking", "thinking.type", "thinking.clear_thinking"]
+defaults = "OpenRouter reports reasoning default_enabled=true, default_effort=high, and supported_efforts=[\"xhigh\", \"high\"]. Native Z.ai enables thinking by default; native reasoning_effort defaults to max, maps low/medium to high, xhigh to max, and none/minimal to skipping thinking."
+max_output_interaction = "OpenRouter reasoning tokens are returned in message.reasoning unless excluded and are charged as output tokens. Native Z.ai max_tokens has a 131072 maximum for GLM-5.2, so visible output plus returned reasoning content must fit the generation budget used by the harness."
+
+[limits]
+context_window = 1048576
+max_output_tokens = 131072
+rate_limits = "unknown"
+
+[openrouter]
+upstream_providers = [
+  "Novita (novita/fp8)",
+  "StreamLake (streamlake/fp8)",
+  "DeepInfra (deepinfra/fp4)",
+  "DekaLLM (dekallm)",
+  "GMICloud (gmicloud/fp8)",
+  "DigitalOcean (digitalocean)",
+  "Morph (morph)",
+  "Baidu (baidu/fp8)",
+  "Io Net (io-net/fp8)",
+  "Wafer (wafer/fp4)",
+  "Decart (decart/fp4)",
+  "AkashML (akashml/fp8)",
+  "SiliconFlow (siliconflow/fp8)",
+  "Alibaba (alibaba)",
+  "AtlasCloud (atlas-cloud/fp8)",
+  "Inceptron (inceptron/fp4)",
+  "WandB (wandb/fp4)",
+  "Z.AI (z-ai/fp8)",
+  "Fireworks (fireworks)",
+  "Cloudflare (cloudflare)",
+  "Friendli (friendli)",
+  "Parasail (parasail/fp4)",
+  "Venice (venice/fp8)",
+  "Together (together)",
+  "Ambient (ambient/fp8)",
+  "Phala (phala)",
+  "Fireworks (fireworks/fast)",
+  "Wafer (wafer/fast)"
+]
+require_parameters_behavior = "Set provider.require_parameters=true when a harness depends on a parameter such as tools, tool_choice, response_format, structured_outputs, parallel_tool_calls, reasoning, or reasoning_effort. With the default false setting, OpenRouter says providers that do not support all request parameters can still receive the request and ignore unknown parameters."
+
+[pricing]
+prompt_per_m = 0.9086
+completion_per_m = 2.8556
+cache_read_per_m = 0.16874
+cache_write_per_m = "unknown"
+as_of = "2026-07-06"
+
+[[sources]]
+claim = "model: OpenRouter slug and release-date basis"
+url = "https://openrouter.ai/api/v1/models"
+accessed = "2026-07-06"
+quote = "\"id\":\"z-ai/glm-5.2\",\"canonical_slug\":\"z-ai/glm-5.2-20260616\""
+
+[[sources]]
+claim = "api: native Z.ai chat completions and streaming"
+url = "https://docs.z.ai/api-reference/llm/chat-completion.md"
+accessed = "2026-07-06"
+quote = "supports both streaming and non-streaming output modes"
+
+[[sources]]
+claim = "caching: native Z.ai implicit context caching"
+url = "https://docs.z.ai/guides/capabilities/cache.md"
+accessed = "2026-07-06"
+quote = "without manual configuration"
+
+[[sources]]
+claim = "caching: OpenRouter prompt caching is provider/model specific"
+url = "https://openrouter.ai/docs/features/prompt-caching.md"
+accessed = "2026-07-06"
+quote = "enable prompt caching on supported providers and models"
+
+[[sources]]
+claim = "caching: current OpenRouter GLM-5.2 endpoint metadata"
+url = "https://openrouter.ai/api/v1/models/z-ai/glm-5.2/endpoints"
+accessed = "2026-07-06"
+quote = "\"supports_implicit_caching\":false"
+
+[[sources]]
+claim = "tool_calling: native Z.ai function calling JSON argument format"
+url = "https://docs.z.ai/guides/capabilities/function-calling.md"
+accessed = "2026-07-06"
+quote = "Function call parameters (JSON format string)"
+
+[[sources]]
+claim = "tool_calling: native Z.ai tool_choice behavior"
+url = "https://docs.z.ai/guides/capabilities/function-calling.md"
+accessed = "2026-07-06"
+quote = "default is `auto` (only supports `auto`)"
+
+[[sources]]
+claim = "tool_calling: OpenRouter require_parameters behavior"
+url = "https://openrouter.ai/docs/guides/routing/provider-selection.md"
+accessed = "2026-07-06"
+quote = "Only use providers that support all parameters in your request"
+
+[[sources]]
+claim = "tool_calling: Z.ai structured output is JSON mode"
+url = "https://docs.z.ai/guides/capabilities/struct-output.md"
+accessed = "2026-07-06"
+quote = "set to `{\"type\": \"json_object\"}` to enable JSON mode"
+
+[[sources]]
+claim = "reasoning: OpenRouter reasoning parameter and billing"
+url = "https://openrouter.ai/docs/guides/reasoning-tokens.md"
+accessed = "2026-07-06"
+quote = "Reasoning tokens are considered output tokens"
+
+[[sources]]
+claim = "reasoning: OpenRouter GLM-5.2 reasoning defaults"
+url = "https://openrouter.ai/api/v1/models"
+accessed = "2026-07-06"
+quote = "\"default_enabled\":true,\"supported_efforts\":[\"xhigh\",\"high\"],\"default_effort\":\"high\""
+
+[[sources]]
+claim = "reasoning: native Z.ai thinking controls"
+url = "https://docs.z.ai/api-reference/llm/chat-completion.md"
+accessed = "2026-07-06"
+quote = "default: enabled"
+
+[[sources]]
+claim = "reasoning: native Z.ai reasoning_effort mapping"
+url = "https://docs.z.ai/api-reference/llm/chat-completion.md"
+accessed = "2026-07-06"
+quote = "will be mapped to `high`;"
+
+[[sources]]
+claim = "limits: native Z.ai GLM-5.2 context and output limits"
+url = "https://docs.z.ai/guides/llm/glm-5.2.md"
+accessed = "2026-07-06"
+quote = "Context Length"
+
+[[sources]]
+claim = "limits: OpenRouter GLM-5.2 context and top-provider output limits"
+url = "https://openrouter.ai/api/v1/models"
+accessed = "2026-07-06"
+quote = "\"context_length\":1048576"
+
+[[sources]]
+claim = "limits: native Z.ai max_tokens maximum"
+url = "https://docs.z.ai/api-reference/llm/chat-completion.md"
+accessed = "2026-07-06"
+quote = "maximum: 131072"
+
+[[sources]]
+claim = "openrouter: current GLM-5.2 upstream endpoints"
+url = "https://openrouter.ai/api/v1/models/z-ai/glm-5.2/endpoints"
+accessed = "2026-07-06"
+quote = "\"provider_name\":\"Novita\",\"tag\":\"novita/fp8\""
+
+[[sources]]
+claim = "pricing: OpenRouter GLM-5.2 prompt, completion, and cache-read pricing"
+url = "https://openrouter.ai/api/v1/models"
+accessed = "2026-07-06"
+quote = "\"prompt\":\"0.0000009086\",\"completion\":\"0.0000028556\",\"input_cache_read\":\"0.00000016874\""
+
+[[sources]]
+claim = "pricing: native Z.ai GLM-5.2 cached input pricing"
+url = "https://docs.z.ai/guides/overview/pricing.md"
+accessed = "2026-07-06"
+quote = "| GLM-5.2             | \\$1.4  | \\$0.26"

--- a/registry/model-capabilities/gpt-5.5.toml
+++ b/registry/model-capabilities/gpt-5.5.toml
@@ -1,0 +1,147 @@
+[model]
+key = "gpt-5.5"
+display = "GPT-5.5"
+vendor = "OpenAI"
+release_date = "2026-04-23"
+identity_verification = "OpenAI's Codex model docs list gpt-5.5 as a recommended Codex CLI/SDK model, and the OpenAI model page lists GPT-5.5 as the default model with alias gpt-5.5 and snapshot gpt-5.5-2026-04-23. Jon's assumption that the current Codex CLI OAuth-plan default model key is gpt-5.5 is consistent with the fetched official docs and the local ringer identity registry."
+
+[api]
+endpoint_families = ["responses", "chat-completions", "batch"]
+auth = "In this setup, Codex CLI signs in with ChatGPT/OAuth plan credentials and uses ChatGPT workspace permissions, plan access, and ChatGPT-managed Codex entitlements. Codex CLI can also sign in with an OpenAI API key; API-key usage is billed through the OpenAI Platform account at standard API rates instead of included ChatGPT plan credits."
+streaming = "Supported. The model page lists Streaming as supported. API streaming is available with stream=true on Responses and Chat Completions; streaming responses use server-sent events. Codex provider config exposes SSE idle timeout/retry settings and a Responses WebSocket support flag for providers that support it."
+
+[caching]
+supported = true
+mode = "implicit"
+how_enabled = "Prompt caching works automatically for eligible requests with no code changes. For GPT-5.5, prompt_cache_retention only supports 24h. Caching starts at 1024 prompt tokens; repeated prompt prefixes, tools, and structured-output schemas can contribute to the cached prefix."
+ttl = "For GPT-5.5, only 24h prompt_cache_retention is supported. Extended prompt cache key/value tensors have a maximum retention period of 24 hours; ZDR extended-cache tensors are retained for 1-2 hours for most usage and at most 24 hours."
+read_pricing_per_m = 0.50
+write_pricing_per_m = 5.00
+min_cacheable_prefix_tokens = 1024
+
+[tool_calling]
+format = "OpenAI Responses API tools and function calls with JSON Schema tool parameters. Chat Completions function calling is also supported by the model. Structured Outputs are supported, including strict JSON Schema mode with strict=true."
+parallel = true
+strict_json_schema = true
+quirks = [
+  "For reasoning models using function calling through the Responses API, pass back reasoning items, function call items, and function call output items during tool loops.",
+  "Prompt-only JSON mode can still produce incomplete JSON when output is cut off by max_output_tokens or a content filter; use Structured Outputs for schema adherence.",
+  "No GPT-5.5-specific official long-context malformed-JSON failure note was found; treat long-context JSON reliability as a harness risk and prefer strict schemas.",
+]
+
+[reasoning]
+params = ["reasoning.effort", "text.verbosity", "max_output_tokens", "model_reasoning_effort", "model_reasoning_summary", "model_verbosity"]
+defaults = "GPT-5.5 reasoning.effort supports none, low, medium, high, and xhigh; medium is the default. Codex config exposes model_reasoning_effort, model_reasoning_summary, and model_verbosity; when unset, Codex/model defaults apply."
+max_output_interaction = "max_output_tokens limits total generated tokens, including reasoning tokens, visible output tokens, and non-visible formatting tokens. If the cap is exhausted during reasoning, the response can be incomplete before any visible output is produced."
+
+[limits]
+context_window = 1050000
+max_output_tokens = 128000
+rate_limits = "Model page long-context API tiers: Free not supported; Tier 1 500 RPM / 500,000 TPM / 1,500,000 batch queue; Tier 2 5,000 RPM / 1,000,000 TPM / 3,000,000 batch queue; Tier 3 5,000 RPM / 2,000,000 TPM / 100,000,000 batch queue; Tier 4 10,000 RPM / 4,000,000 TPM / 200,000,000 batch queue; Tier 5 15,000 RPM / 40,000,000 TPM / 15,000,000,000 batch queue. ChatGPT-plan Codex OAuth usage is governed by plan entitlements, not API billing tiers."
+
+[openrouter]
+upstream_providers = []
+require_parameters_behavior = "not applicable; this registry entry is for OpenAI direct/Codex OAuth access, not an OpenRouter-served model"
+
+[pricing]
+prompt_per_m = 5.00
+completion_per_m = 30.00
+cache_read_per_m = 0.50
+cache_write_per_m = 5.00
+as_of = "2026-07-06"
+
+[[sources]]
+claim = "model: Codex docs identify gpt-5.5 as the Codex CLI model"
+url = "https://developers.openai.com/codex/models"
+accessed = "2026-07-06"
+quote = "codex -m gpt-5.5"
+
+[[sources]]
+claim = "model: OpenAI model page lists GPT-5.5 default alias and snapshot date"
+url = "https://developers.openai.com/api/docs/models/gpt-5.5"
+accessed = "2026-07-06"
+quote = "gpt-5.5-2026-04-23"
+
+[[sources]]
+claim = "api: GPT-5.5 supports Responses, Chat Completions, and Batch endpoints"
+url = "https://developers.openai.com/api/docs/models/gpt-5.5"
+accessed = "2026-07-06"
+quote = "v1/chat/completions"
+
+[[sources]]
+claim = "api: Codex CLI ChatGPT OAuth and API-key auth behavior"
+url = "https://developers.openai.com/codex/auth"
+accessed = "2026-07-06"
+quote = "Sign in with ChatGPT for subscription access"
+
+[[sources]]
+claim = "api: streaming uses stream true and SSE"
+url = "https://developers.openai.com/api/docs/guides/streaming-responses"
+accessed = "2026-07-06"
+quote = "text/event-stream"
+
+[[sources]]
+claim = "caching: automatic prompt caching and 1024-token minimum"
+url = "https://developers.openai.com/api/docs/guides/prompt-caching"
+accessed = "2026-07-06"
+quote = "Caching is enabled automatically for prompts that are 1024 tokens or longer."
+
+[[sources]]
+claim = "caching: GPT-5.5 only supports 24h prompt cache retention"
+url = "https://developers.openai.com/api/docs/guides/prompt-caching"
+accessed = "2026-07-06"
+quote = "For `gpt-5.5`, `gpt-5.5-pro`, and future models, only `24h` is supported."
+
+[[sources]]
+claim = "tool_calling: GPT-5.5 supports function calling and structured outputs"
+url = "https://developers.openai.com/api/docs/models/gpt-5.5"
+accessed = "2026-07-06"
+quote = "Function calling Supported Structured outputs Supported"
+
+[[sources]]
+claim = "tool_calling: strict structured outputs use JSON Schema strict true"
+url = "https://developers.openai.com/api/docs/guides/structured-outputs"
+accessed = "2026-07-06"
+quote = "strict: true"
+
+[[sources]]
+claim = "tool_calling: Responses API includes parallel tool call behavior"
+url = "https://developers.openai.com/api/reference/resources/responses/methods/create"
+accessed = "2026-07-06"
+quote = "\"parallel_tool_calls\": true"
+
+[[sources]]
+claim = "reasoning: GPT-5.5 reasoning effort names and default"
+url = "https://developers.openai.com/api/docs/models/gpt-5.5"
+accessed = "2026-07-06"
+quote = "Reasoning.effort supports: none, low, medium (default), high and xhigh."
+
+[[sources]]
+claim = "reasoning: max_output_tokens includes reasoning and visible output"
+url = "https://developers.openai.com/api/docs/guides/reasoning"
+accessed = "2026-07-06"
+quote = "including reasoning tokens, visible output tokens, and non-visible formatting tokens"
+
+[[sources]]
+claim = "reasoning: Codex config exposes model reasoning and verbosity controls"
+url = "https://developers.openai.com/codex/config-reference"
+accessed = "2026-07-06"
+quote = "model_reasoning_effort"
+
+[[sources]]
+claim = "limits: GPT-5.5 context window and max output tokens"
+url = "https://developers.openai.com/api/docs/models/gpt-5.5"
+accessed = "2026-07-06"
+quote = "1,050,000 context window"
+
+[[sources]]
+claim = "limits: GPT-5.5 long-context rate limit tiers"
+url = "https://developers.openai.com/api/docs/models/gpt-5.5"
+accessed = "2026-07-06"
+quote = "Tier 5 15,000 40,000,000 15,000,000,000"
+
+[[sources]]
+claim = "pricing: GPT-5.5 standard token prices and cached input price"
+url = "https://developers.openai.com/api/docs/models/gpt-5.5"
+accessed = "2026-07-06"
+quote = "$5.00 Cached input $0.50 Output $30.00"

--- a/registry/model-capabilities/grok-build.toml
+++ b/registry/model-capabilities/grok-build.toml
@@ -1,0 +1,106 @@
+[model]
+key = "grok-build"
+display = "Grok Build"
+vendor = "xAI"
+release_date = "2026-05-14"
+
+[api]
+endpoint_families = ["responses", "chat-completions", "native-vendor"]
+auth = "In our setup, Grok Build CLI v0.2.x uses grok.com OAuth/session auth through the CLI chat proxy. Generally, xAI also exposes Grok Build 0.1 on the xAI API with API-key bearer auth; xAI documents the public API slug as grok-build-0.1, while the CLI catalog exposes grok-build."
+streaming = "Supported. Public xAI text streaming uses SSE with stream=true; local Grok 0.2.81 docs say most CLI proxy models are streaming-first, while grok-build supports both streaming and non-streaming."
+
+[caching]
+supported = true
+mode = "implicit"
+how_enabled = "xAI API prompt caching is automatic for matching starting messages; xAI recommends the x-grok-conv-id header to improve cache hits. No separate CLI-only cache switch is disclosed."
+ttl = "unknown"
+read_pricing_per_m = "$0.20"
+write_pricing_per_m = "$1.00 normal prompt input price; no separate cache-write price disclosed"
+min_cacheable_prefix_tokens = "unknown"
+
+[tool_calling]
+format = "Responses API tools/function calls and xAI SDK chat tools. xAI structured-output docs say tool-call arguments strictly conform to the input JSON Schema."
+parallel = "unknown"
+strict_json_schema = true
+quirks = [
+  "With streaming, xAI returns a function call whole in a single chunk rather than streaming it across chunks.",
+  "No xAI documentation found that discloses Grok Build 0.1 parallel tool-call behavior.",
+  "No official long-context malformed-JSON failure mode was found for Grok Build 0.1."
+]
+
+[reasoning]
+params = []
+defaults = "Grok Build 0.1 is documented as a reasoning-capable coding model, but xAI does not document reasoning_effort support for this model; local Grok 0.2.81 catalog reports supports_reasoning_effort=false."
+max_output_interaction = "unknown"
+
+[limits]
+context_window = 256000
+max_output_tokens = "unknown"
+rate_limits = "CLI OAuth plan limits are unknown. Public xAI API docs for grok-build-0.1 disclose 256k context. xAI public rate-limit docs list tiered caps for grok-build-0.1 from 30 to 166 RPS and 10M to 85M TPM; the model page also shows 37 RPS and 10,000,000 TPM for us-east-1."
+
+[pricing]
+prompt_per_m = "$1.00"
+completion_per_m = "$2.00"
+cache_read_per_m = "$0.20"
+cache_write_per_m = "$1.00 normal prompt input price; no separate cache-write price disclosed"
+as_of = "2026-07-06"
+
+[[sources]]
+claim = "model: Grok Build beta release and public API slug"
+url = "https://docs.x.ai/developers/release-notes"
+accessed = "2026-07-06"
+quote = "Grok Build is now available"
+
+[[sources]]
+claim = "api: CLI TUI, headless use, browser auth, and API availability"
+url = "https://docs.x.ai/build/overview"
+accessed = "2026-07-06"
+quote = "opens a browser for authentication"
+
+[[sources]]
+claim = "caching: implicit prompt caching"
+url = "https://docs.x.ai/developers/advanced-api-usage/prompt-caching"
+accessed = "2026-07-06"
+quote = "automatically caches"
+
+[[sources]]
+claim = "tool_calling: function calling and streaming behavior"
+url = "https://docs.x.ai/developers/tools/function-calling"
+accessed = "2026-07-06"
+quote = "single chunk"
+
+[[sources]]
+claim = "tool_calling: strict tool schema behavior"
+url = "https://docs.x.ai/developers/model-capabilities/text/structured-outputs"
+accessed = "2026-07-06"
+quote = "strictly conform"
+
+[[sources]]
+claim = "reasoning: reasoning capability is present but parameter support is not disclosed for Grok Build"
+url = "https://docs.x.ai/developers/models/grok-build-0.1"
+accessed = "2026-07-06"
+quote = "The model can think"
+
+[[sources]]
+claim = "reasoning: reasoning_effort is documented for grok-4.3, not Grok Build"
+url = "https://docs.x.ai/developers/model-capabilities/text/reasoning"
+accessed = "2026-07-06"
+quote = "grok-4.3 supports"
+
+[[sources]]
+claim = "limits: public API context and public model-page rate limits"
+url = "https://docs.x.ai/developers/models/grok-build-0.1"
+accessed = "2026-07-06"
+quote = "256,000"
+
+[[sources]]
+claim = "limits: tiered API rate limits"
+url = "https://docs.x.ai/developers/rate-limits"
+accessed = "2026-07-06"
+quote = "grok-build-0.1"
+
+[[sources]]
+claim = "pricing: API input, cached input, and output token prices"
+url = "https://docs.x.ai/developers/pricing"
+accessed = "2026-07-06"
+quote = "256k$1.00$0.20$2.00"

--- a/registry/model-capabilities/grok-composer-2.5-fast.toml
+++ b/registry/model-capabilities/grok-composer-2.5-fast.toml
@@ -1,0 +1,94 @@
+[model]
+key = "grok-composer-2.5-fast"
+display = "Grok Composer 2.5 Fast"
+vendor = "Cursor (Anysphere), served in our setup through xAI Grok Build CLI"
+release_date = "2026-05-18"
+
+[api]
+endpoint_families = ["native-vendor"]
+auth = "In our setup, Grok Build CLI v0.2.x exposes grok-composer-2.5-fast through the grok.com OAuth/session-authenticated CLI chat proxy. xAI does not document this slug as a public xAI API model; Cursor documents Composer 2.5 as available in Cursor."
+streaming = "CLI proxy behavior is streaming-first in local Grok 0.2.x docs, but public xAI/Cursor docs do not disclose a standalone Composer 2.5 Fast streaming API contract."
+
+[caching]
+supported = false
+mode = "unknown"
+how_enabled = "Unknown for grok-composer-2.5-fast through the Grok CLI proxy. xAI documents automatic prompt caching for the xAI API generally, but xAI does not publish this Composer slug as a public API model."
+ttl = "unknown"
+read_pricing_per_m = "unknown"
+write_pricing_per_m = "unknown"
+min_cacheable_prefix_tokens = "unknown"
+
+[tool_calling]
+format = "Cursor-style agent/harness tool use through Grok Build CLI. The public API format for grok-composer-2.5-fast is not disclosed by xAI or Cursor."
+parallel = "unknown"
+strict_json_schema = "unknown"
+quirks = [
+  "Cursor says Composer 2.5 training targeted bad tool calls, including attempts to call tools that are not available.",
+  "No public xAI or Cursor document found for Composer 2.5 Fast strict JSON schema support.",
+  "No official long-context malformed-JSON failure mode was found for Composer 2.5 Fast."
+]
+
+[reasoning]
+params = []
+defaults = "Cursor describes Composer 2.5 as improved in sustained work, instruction following, effort calibration, and long-horizon coding behavior, but no public reasoning-control parameter is disclosed for grok-composer-2.5-fast; local Grok 0.2.81 catalog reports supports_reasoning_effort=false."
+max_output_interaction = "unknown"
+
+[limits]
+context_window = "unknown"
+max_output_tokens = "unknown"
+rate_limits = "CLI OAuth plan/account limits are unknown. Public Cursor/xAI docs found in this pass do not disclose API rate limits, max output tokens, or a standalone context window for grok-composer-2.5-fast."
+
+[pricing]
+prompt_per_m = "$3.00"
+completion_per_m = "$15.00"
+cache_read_per_m = "unknown"
+cache_write_per_m = "unknown"
+as_of = "2026-07-06"
+
+[[sources]]
+claim = "model: Composer 2.5 release date, lineage, and availability"
+url = "https://cursor.com/blog/composer-2-5"
+accessed = "2026-07-06"
+quote = "Composer 2.5 is now available"
+
+[[sources]]
+claim = "model: Composer 2.5 built on Moonshot Kimi K2.5 and SpaceXAI collaboration"
+url = "https://cursor.com/blog/composer-2-5"
+accessed = "2026-07-06"
+quote = "Moonshot's Kimi K2.5"
+
+[[sources]]
+claim = "api: Grok Build CLI browser auth and API-key fallback"
+url = "https://docs.x.ai/build/overview"
+accessed = "2026-07-06"
+quote = "opens a browser for authentication"
+
+[[sources]]
+claim = "caching: xAI API caching exists generally, but Composer CLI support is undisclosed"
+url = "https://docs.x.ai/developers/advanced-api-usage/prompt-caching"
+accessed = "2026-07-06"
+quote = "automatically caches"
+
+[[sources]]
+claim = "tool_calling: Composer 2.5 training targets unavailable-tool mistakes"
+url = "https://cursor.com/blog/composer-2-5"
+accessed = "2026-07-06"
+quote = "Tool not found"
+
+[[sources]]
+claim = "reasoning: Composer 2.5 effort calibration but no public reasoning parameter"
+url = "https://cursor.com/blog/composer-2-5"
+accessed = "2026-07-06"
+quote = "effort calibration"
+
+[[sources]]
+claim = "limits: long-horizon context behavior but exact public limit undisclosed"
+url = "https://cursor.com/blog/composer-2-5"
+accessed = "2026-07-06"
+quote = "hundreds of thousands"
+
+[[sources]]
+claim = "pricing: Composer 2.5 Fast token prices"
+url = "https://cursor.com/blog/composer-2-5"
+accessed = "2026-07-06"
+quote = "$3.00/M input and $15.00/M output"

--- a/registry/model-capabilities/kimi-k2.7-code.toml
+++ b/registry/model-capabilities/kimi-k2.7-code.toml
@@ -1,0 +1,142 @@
+[model]
+key = "moonshotai/kimi-k2.7-code"
+display = "Kimi K2.7 Code"
+vendor = "Moonshot AI"
+release_date = "2026-06-12"
+
+[api]
+endpoint_families = ["chat-completions", "responses", "native-vendor"]
+auth = "In this repo, access is via OpenRouter API key through the OpenAI-compatible OpenRouter base URL. Generally, OpenRouter uses Bearer OPENROUTER_API_KEY; native Moonshot/Kimi uses Bearer MOONSHOT_API_KEY at https://api.moonshot.cn/v1."
+streaming = "OpenRouter Chat Completions supports stream=true using SSE and may include comment payloads to ignore; OpenRouter Responses API Beta also streams SSE events. Native Kimi Chat Completions supports stream=true and ends with data: [DONE]; if the stream disconnects, Kimi warns the final usage chunk may not arrive."
+
+[caching]
+supported = true
+mode = "implicit"
+how_enabled = "OpenRouter docs say Moonshot AI prompt caching is automatic with no additional configuration; native Kimi exposes prompt_cache_key to improve cache hit rate for session/task affinity, especially Coding Agent sessions. OpenRouter endpoint metadata for this model currently lists input_cache_read prices but supports_implicit_caching=false on fetched endpoints, so harnesses should inspect cached_tokens/prompt_tokens_details and avoid assuming explicit cache_control is accepted for Kimi."
+ttl = "unknown"
+read_pricing_per_m = "$0.15 per 1M input tokens on the lowest-priced OpenRouter endpoint; native Kimi list price is ¥1.30 per 1M cache-hit input tokens"
+write_pricing_per_m = "$0.74 per 1M prompt tokens on the lowest-priced OpenRouter endpoint; OpenRouter docs say Moonshot cache writes have no separate cache-write surcharge; native Kimi cache-miss input is ¥6.50 per 1M"
+min_cacheable_prefix_tokens = "unknown"
+
+[tool_calling]
+format = "OpenAI-compatible tools/tool_choice/tool_calls. OpenRouter Chat Completions accepts tools and tool_choice and normalizes tool_calls; native Kimi Chat Completions also returns tool_calls with function.name and function.arguments. OpenRouter Responses API Beta uses OpenAI Responses-style tools."
+parallel = true
+strict_json_schema = true
+quirks = [
+  "OpenRouter require_parameters=true should be used when a harness depends on tools, response_format, structured_outputs, or parallel_tool_calls; otherwise providers that do not support a parameter may receive the request and ignore it.",
+  "Only some OpenRouter upstream endpoints for this model list parallel_tool_calls; require_parameters=true is needed if parallel tool calls are required.",
+  "Native Kimi K2.7 Code only accepts tool_choice auto or none; forcing a specific tool conflicts with thinking content and errors.",
+  "Native Kimi K2.7 Code requires preserving assistant reasoning_content during multi-step tool calls; dropping it can error.",
+  "No Kimi K2.7-specific documented long-context malformed-tool-JSON failure was found in fetched official docs; OpenRouter's structured-output docs still recommend response healing to reduce invalid JSON risk when models return imperfect formatting."
+]
+
+[reasoning]
+params = ["reasoning", "include_reasoning", "reasoning_effort", "thinking.type", "thinking.keep"]
+defaults = "OpenRouter model metadata marks reasoning mandatory and default_enabled=true. Native Kimi K2.7 Code defaults to thinking={type=\"enabled\", keep=\"all\"}; type only accepts enabled and keep only accepts all/null, so thinking cannot be disabled and preserved thinking is always on."
+max_output_interaction = "Reasoning tokens are output tokens and charged accordingly on OpenRouter. Native Kimi reasoning_content must be preserved in multi-turn/tool contexts and counts toward token usage; max reasoning budget is not separately documented for Kimi K2.7 Code."
+
+[limits]
+context_window = 262144
+max_output_tokens = 16384
+rate_limits = "OpenRouter model endpoint metadata shows top_provider max_completion_tokens=16384, while upstream endpoints vary from 16384 to 262144 or null; native Kimi K2.7 Code docs list 256K context and a default max_tokens of 32768 for K2.7/K2.6/K2.5 family behavior. OpenRouter account/model rate limits apply and can be checked with GET /api/v1/key."
+
+[openrouter]
+upstream_providers = ["DeepInfra", "Inceptron", "Parasail", "Venice", "Ambient", "Novita", "SiliconFlow", "Moonshot AI", "Cloudflare", "AtlasCloud", "Together"]
+require_parameters_behavior = "provider.require_parameters=false by default, so unsupported request parameters can be ignored by the chosen provider. Set require_parameters=true to route only to providers that support all request parameters; if none qualify, the request should not be routed to an incompatible provider."
+
+[pricing]
+prompt_per_m = "$0.74"
+completion_per_m = "$3.50"
+cache_read_per_m = "$0.15"
+cache_write_per_m = "$0 extra cache-write surcharge; uncached prompt tokens billed at prompt_per_m"
+as_of = "2026-07-06"
+
+[[sources]]
+claim = "model: OpenRouter release date, context, and list price"
+url = "https://openrouter.ai/moonshotai/kimi-k2.7-code"
+accessed = "2026-07-06"
+quote = "In / Out Price $0.74 / $3.50 per 1M Context 262K Released Jun 12, 2026"
+
+[[sources]]
+claim = "api: OpenRouter OpenAI-compatible Chat Completions and streaming"
+url = "https://openrouter.ai/docs/api/reference/overview"
+accessed = "2026-07-06"
+quote = "OpenRouter's request and response schemas are very similar to the OpenAI Chat API"
+
+[[sources]]
+claim = "api: Kimi native OpenAI-compatible access and API key"
+url = "https://platform.kimi.com/docs/guide/start-using-kimi-api"
+accessed = "2026-07-06"
+quote = "Kimi API 提供了与 Kimi 大模型交互的能力，并兼容 OpenAI API 格式"
+
+[[sources]]
+claim = "caching: OpenRouter Moonshot caching is automatic"
+url = "https://openrouter.ai/docs/guides/best-practices/prompt-caching"
+accessed = "2026-07-06"
+quote = "Prompt caching with Moonshot AI is automated and does not require any additional configuration."
+
+[[sources]]
+claim = "caching: Kimi native prompt_cache_key for coding-agent sessions"
+url = "https://platform.kimi.com/docs/api/chat"
+accessed = "2026-07-06"
+quote = "用于缓存相似请求的响应以优化缓存命中率。对于 Coding Agent，通常是代表单个会话的 session id 或 task id"
+
+[[sources]]
+claim = "tool_calling: OpenRouter standardizes tool calling"
+url = "https://openrouter.ai/docs/guides/features/tool-calling"
+accessed = "2026-07-06"
+quote = "OpenRouter standardizes the tool calling interface across models and providers"
+
+[[sources]]
+claim = "tool_calling: Kimi strict tool schemas and max 128 tools"
+url = "https://platform.kimi.com/docs/api/tool-use"
+accessed = "2026-07-06"
+quote = "每个 function 支持 `strict` 参数（boolean 类型，可选）"
+
+[[sources]]
+claim = "tool_calling: Kimi K2.7 tool_choice and reasoning_content constraints"
+url = "https://platform.kimi.com/docs/guide/kimi-k2-7-code-quickstart"
+accessed = "2026-07-06"
+quote = "tool_choice 只能使用”auto”和”none”（默认值为”auto”）"
+
+[[sources]]
+claim = "reasoning: OpenRouter reasoning parameter names and defaults"
+url = "https://openrouter.ai/docs/guides/best-practices/reasoning-tokens"
+accessed = "2026-07-06"
+quote = "You can control reasoning tokens in your requests using the `reasoning` parameter"
+
+[[sources]]
+claim = "reasoning: Kimi K2.7 thinking is mandatory and preserved"
+url = "https://platform.kimi.com/docs/api/chat"
+accessed = "2026-07-06"
+quote = "该模型始终开启思考"
+
+[[sources]]
+claim = "limits: OpenRouter model endpoint context and output limit metadata"
+url = "https://openrouter.ai/api/v1/models/moonshotai/kimi-k2.7-code/endpoints"
+accessed = "2026-07-06"
+quote = "\"context_length\":262144"
+
+[[sources]]
+claim = "limits: native Kimi K2.7 256K context"
+url = "https://platform.kimi.com/docs/guide/kimi-k2-7-code-quickstart"
+accessed = "2026-07-06"
+quote = "`kimi-k2.7-code`、`kimi-k2.7-code-highspeed`、`kimi-k2.6`、`kimi-k2.5` 模型均提供 256K 上下文窗口"
+
+[[sources]]
+claim = "pricing: OpenRouter endpoint prompt, completion, and cache-read prices"
+url = "https://openrouter.ai/api/v1/models/moonshotai/kimi-k2.7-code/endpoints"
+accessed = "2026-07-06"
+quote = "\"prompt\":\"0.00000074\",\"completion\":\"0.0000035\",\"input_cache_read\":\"0.00000015\""
+
+[[sources]]
+claim = "pricing: native Kimi K2.7 cache-hit, cache-miss, output prices"
+url = "https://platform.kimi.com/docs/pricing/chat-k27-code"
+accessed = "2026-07-06"
+quote = "[\"kimi-k2.7-code\", \"1M tokens\", \"¥1.30\", \"¥6.50\", \"¥27.00\", \"262,144 tokens\"]"
+
+[[sources]]
+claim = "openrouter: endpoint provider list and parameter support metadata"
+url = "https://openrouter.ai/api/v1/models/moonshotai/kimi-k2.7-code/endpoints"
+accessed = "2026-07-06"
+quote = "\"provider_name\":\"DeepInfra\""

--- a/registry/model-capabilities/openrouter-platform.toml
+++ b/registry/model-capabilities/openrouter-platform.toml
@@ -1,0 +1,47 @@
+[openrouter_platform]
+caching_passthrough = "OpenRouter supports provider prompt caching rather than one universal cache implementation. OpenAI, Grok, Moonshot AI, Groq, DeepSeek, and Gemini are documented as automatic/implicit on supported models; Alibaba Qwen and Anthropic can require explicit cache_control breakpoints, and Anthropic also supports top-level automatic cache_control on direct Anthropic routing. OpenRouter uses sticky routing to keep cached conversations on the same provider, exposes cached_tokens/cache_write_tokens in usage, and shows effective pricing after prompt caching. Responses API does not expose explicit per-block cache_control; use Chat Completions or Anthropic Messages for fine-grained breakpoints. For harnesses, treat cache_control as provider-specific and verify support before assuming passthrough."
+require_parameters = "provider.require_parameters defaults to false. With the default routing strategy, a provider that does not support a request parameter can still receive the request and ignore the parameter. Set require_parameters=true when behavior depends on tools, response_format, structured_outputs, reasoning controls, or parallel_tool_calls; then OpenRouter restricts routing to providers that support all specified parameters."
+free_variants = "OpenRouter free model variants use IDs ending in :free and have per-minute and per-day limits. The fetched docs currently render the exact numeric RPM/RPD thresholds as template placeholders/blanks, so exact current numbers are unknown from official fetched text. Negative credit balance can still produce 402 errors for free models. Free variants do not imply a uniform data policy; use provider.data_collection='deny' or provider.zdr=true when the harness requires providers that do not retain prompts."
+provider_routing = "By default OpenRouter load-balances across top providers to maximize uptime and selects low-cost/best available serving, with fallback to other providers or GPUs on 5xx responses or rate limits. provider.order prioritizes providers, allow_fallbacks=false disables fallback beyond the chosen path, only/ignore constrain providers, sort chooses price/throughput/latency, quantizations filters serving precision, and base provider slugs match all endpoint variants. Sticky routing can pin cached sessions to a provider; manual provider.order takes priority over sticky routing."
+
+[[sources]]
+claim = "openrouter_platform: caching_passthrough provider sticky routing and supported provider cache modes"
+url = "https://openrouter.ai/docs/guides/best-practices/prompt-caching"
+accessed = "2026-07-06"
+quote = "Most providers automatically enable prompt caching"
+
+[[sources]]
+claim = "openrouter_platform: caching_passthrough usage metrics"
+url = "https://openrouter.ai/docs/guides/best-practices/prompt-caching"
+accessed = "2026-07-06"
+quote = "The usage object in API responses includes detailed cache metrics"
+
+[[sources]]
+claim = "openrouter_platform: require_parameters routing behavior"
+url = "https://openrouter.ai/docs/guides/routing/provider-selection"
+accessed = "2026-07-06"
+quote = "Only use providers that support all parameters in your request."
+
+[[sources]]
+claim = "openrouter_platform: free_variants rate limits and 402 behavior"
+url = "https://openrouter.ai/docs/api/reference/limits"
+accessed = "2026-07-06"
+quote = "free model variant (with an ID ending in"
+
+[[sources]]
+claim = "openrouter_platform: free_variants and provider data policies"
+url = "https://openrouter.ai/docs/guides/routing/provider-selection"
+accessed = "2026-07-06"
+quote = "`deny`: use only providers which do not collect user data"
+
+[[sources]]
+claim = "openrouter_platform: provider_routing default load balancing and provider object"
+url = "https://openrouter.ai/docs/guides/routing/provider-selection"
+accessed = "2026-07-06"
+quote = "By default, requests are load balanced across the top providers to maximize uptime."
+
+[[sources]]
+claim = "openrouter_platform: provider_routing fallback behavior"
+url = "https://openrouter.ai/docs/api/reference/overview"
+accessed = "2026-07-06"
+quote = "fall back to other providers or GPUs if it receives a 5xx response code or if you are rate-limited."

--- a/registry/model-identity.toml
+++ b/registry/model-identity.toml
@@ -1,0 +1,55 @@
+# Model identity registry — resolves (engine, manifest model field) into the
+# display triple: Model / Harness / Access. This is what the scoreboard and
+# Ringside show, and what keeps engine names (codex) from masquerading as
+# model names.
+#
+# confidence: "verified" requires a cited source (see source field);
+# "unverified" entries are best current knowledge awaiting the capability
+# research pass. Update via PR — this file is loaded into the local read DB.
+
+[engines.codex]
+harness = "Codex CLI"
+access = "OAuth plan"
+default_model_key = "gpt-5.5"
+
+[engines.codex.models."gpt-5.5"]
+display = "GPT-5.5"
+confidence = "unverified"   # Jon's belief 2026-07-06; capability research to confirm + cite
+source = ""
+
+[engines.grok]
+harness = "Grok Build CLI"
+access = "OAuth plan"
+default_model_key = "grok-build"
+
+[engines.grok.models."grok-build"]
+display = "Grok Build"
+confidence = "unverified"
+source = ""
+
+[engines.grok.models."grok-composer-2.5-fast"]
+display = "Grok Composer 2.5 Fast"
+confidence = "unverified"
+source = ""
+
+[engines.opencode]
+harness = "OpenCode"
+access = "OpenRouter API"
+# model key = the manifest "model" slug; entries below map slugs to display
+# names. Unlisted slugs display as the slug with the "openrouter/" prefix
+# stripped, access "OpenRouter API".
+
+[engines.opencode.models."openrouter/z-ai/glm-5.2"]
+display = "GLM 5.2"
+confidence = "verified"
+source = "manifest model field; OpenRouter slug z-ai/glm-5.2"
+
+[engines.opencode.models."openrouter/moonshotai/kimi-k2.7-code"]
+display = "Kimi K2.7 Code"
+confidence = "verified"
+source = "manifest model field; OpenRouter slug moonshotai/kimi-k2.7-code"
+
+[engines.opencode.models."openrouter/nvidia/nemotron-3-super-120b-a12b:free"]
+display = "Nemotron 3 Super 120B (free)"
+confidence = "verified"
+source = "manifest model field; OpenRouter slug nvidia/nemotron-3-super-120b-a12b:free"

--- a/registry/model-identity.toml
+++ b/registry/model-identity.toml
@@ -23,12 +23,16 @@ access = "OAuth plan"
 default_model_key = "grok-build"
 
 [engines.grok.models."grok-build"]
-display = "Grok Build"
+# "Grok Build" is the HARNESS (the CLI product); the model behind the
+# grok-build alias is unnamed by xAI in our data — capability research task
+# caps-grok is establishing the true lineage with citations. Until then the
+# display shows the alias explicitly rather than harness branding.
+display = "Grok (grok-build alias)"
 confidence = "unverified"
 source = ""
 
 [engines.grok.models."grok-composer-2.5-fast"]
-display = "Grok Composer 2.5 Fast"
+display = "Composer 2.5 Fast"
 confidence = "unverified"
 source = ""
 

--- a/registry/model-identity.toml
+++ b/registry/model-identity.toml
@@ -14,8 +14,8 @@ default_model_key = "gpt-5.5"
 
 [engines.codex.models."gpt-5.5"]
 display = "GPT-5.5"
-confidence = "unverified"   # Jon's belief 2026-07-06; capability research to confirm + cite
-source = ""
+confidence = "verified"     # snapshot gpt-5.5-2026-04-23, Codex CLI default; see capability file
+source = "https://developers.openai.com/codex/models"
 
 [engines.grok]
 harness = "Grok Build CLI"
@@ -27,14 +27,14 @@ default_model_key = "grok-build"
 # grok-build alias is unnamed by xAI in our data — capability research task
 # caps-grok is establishing the true lineage with citations. Until then the
 # display shows the alias explicitly rather than harness branding.
-display = "Grok (grok-build alias)"
-confidence = "unverified"
-source = ""
+display = "Grok Build 0.1"
+confidence = "verified"     # xAI overloads the brand: the CLI is the harness, "Grok Build 0.1" is the MODEL with its own official model page
+source = "https://docs.x.ai/developers/release-notes"
 
 [engines.grok.models."grok-composer-2.5-fast"]
 display = "Composer 2.5 Fast"
-confidence = "unverified"
-source = ""
+confidence = "verified"     # Cursor (Anysphere) model, served through xAI's Grok Build CLI in our setup
+source = "https://cursor.com/blog/composer-2-5"
 
 [engines.opencode]
 harness = "OpenCode"

--- a/ringer.py
+++ b/ringer.py
@@ -16,6 +16,11 @@ import socket
 import subprocess
 import sys
 
+try:
+    import sqlite3
+except Exception:  # pragma: no cover - exercised by monkeypatch in tests.
+    sqlite3 = None  # type: ignore[assignment]
+
 if sys.version_info < (3, 11):
     raise SystemExit(
         f"ringer requires Python 3.11+ (tomllib); found {sys.version.split()[0]} at {sys.executable}"
@@ -1617,6 +1622,14 @@ def describe_catalog_event(event: dict[str, Any]) -> str:
     if kind == "removed":
         return f"{ts} {model_id} removed"
     return f"{ts} {model_id} {kind}"
+
+
+def describe_catalog_event_humanized(event: dict[str, Any]) -> str:
+    text = describe_catalog_event(event)
+    ts = str(event.get("ts", ""))
+    if ts and text.startswith(ts):
+        return humanized_log_date(ts) + text[len(ts) :]
+    return text
 
 
 def run_catalog_command(args: argparse.Namespace) -> int:
@@ -4379,6 +4392,680 @@ def default_model_notes_path() -> Path:
     return Path(__file__).resolve().parent / "docs" / "MODEL-NOTES.md"
 
 
+def default_model_registry_path() -> Path:
+    return Path(__file__).resolve().parent / "registry" / "model-identity.toml"
+
+
+def default_read_model_db_path() -> Path:
+    return ringer_home() / "ringer.db"
+
+
+@dataclass(frozen=True)
+class ModelIdentity:
+    model_display: str
+    harness: str
+    access: str
+    confidence: str = ""
+    source: str = ""
+
+
+@dataclass(frozen=True)
+class ModelIdentityRegistry:
+    identities: dict[tuple[str, str], ModelIdentity]
+    defaults: dict[str, str]
+    engine_meta: dict[str, ModelIdentity]
+
+    def resolve(self, engine: str, model_key: str) -> ModelIdentity:
+        engine_key = model_log_text(engine)
+        raw_model_key = model_log_text(model_key)
+        lookup_key = raw_model_key or self.defaults.get(engine_key, "")
+        identity = self.identities.get((engine_key, lookup_key))
+        if identity is not None:
+            return identity
+        meta = self.engine_meta.get(engine_key)
+        if engine_key == "opencode" and raw_model_key.startswith("openrouter/"):
+            return ModelIdentity(
+                model_display=raw_model_key.removeprefix("openrouter/"),
+                harness=(meta.harness if meta else "OpenCode"),
+                access=(meta.access if meta else "OpenRouter API"),
+                confidence="fallback",
+                source="unlisted OpenRouter slug",
+            )
+        if meta is not None and lookup_key:
+            return ModelIdentity(
+                model_display=lookup_key,
+                harness=meta.harness,
+                access=meta.access,
+                confidence="fallback",
+                source="engine default model key",
+            )
+        unknown = engine_key or "unknown"
+        return ModelIdentity(
+            model_display=unknown,
+            harness=unknown,
+            access="unknown",
+            confidence="unknown",
+            source="",
+        )
+
+
+EMPTY_MODEL_IDENTITY_REGISTRY = ModelIdentityRegistry({}, {}, {})
+
+
+def load_model_identity_registry(path: Path | None = None) -> ModelIdentityRegistry:
+    registry_path = (path or default_model_registry_path()).expanduser().resolve()
+    try:
+        with registry_path.open("rb") as fh:
+            data = tomllib.load(fh)
+    except (OSError, tomllib.TOMLDecodeError):
+        return EMPTY_MODEL_IDENTITY_REGISTRY
+    engines_raw = data.get("engines", {})
+    if not isinstance(engines_raw, dict):
+        return EMPTY_MODEL_IDENTITY_REGISTRY
+    identities: dict[tuple[str, str], ModelIdentity] = {}
+    defaults: dict[str, str] = {}
+    engine_meta: dict[str, ModelIdentity] = {}
+    for engine_name, raw_engine in engines_raw.items():
+        if not isinstance(raw_engine, dict):
+            continue
+        engine = str(engine_name).strip()
+        if not engine:
+            continue
+        harness = model_log_text(raw_engine.get("harness")) or engine
+        access = model_log_text(raw_engine.get("access")) or "unknown"
+        default_key = model_log_text(raw_engine.get("default_model_key"))
+        if default_key:
+            defaults[engine] = default_key
+        engine_meta[engine] = ModelIdentity(
+            model_display=engine,
+            harness=harness,
+            access=access,
+            confidence="engine",
+            source="",
+        )
+        models_raw = raw_engine.get("models", {})
+        if not isinstance(models_raw, dict):
+            continue
+        for model_key_raw, raw_model in models_raw.items():
+            if not isinstance(raw_model, dict):
+                continue
+            model_key = str(model_key_raw).strip()
+            if not model_key:
+                continue
+            identities[(engine, model_key)] = ModelIdentity(
+                model_display=model_log_text(raw_model.get("display")) or model_key,
+                harness=harness,
+                access=access,
+                confidence=model_log_text(raw_model.get("confidence")),
+                source=model_log_text(raw_model.get("source")),
+            )
+    return ModelIdentityRegistry(identities, defaults, engine_meta)
+
+
+def model_log_row_engine(row: dict[str, Any]) -> str:
+    return model_log_text(row.get("worker_engine") if "worker_engine" in row else row.get("engine"))
+
+
+def row_identity_fields(row: dict[str, Any], registry: ModelIdentityRegistry) -> dict[str, str]:
+    identity = registry.resolve(model_log_row_engine(row), model_log_text(row.get("model")))
+    return {
+        "model_display": identity.model_display,
+        "harness": identity.harness,
+        "access": identity.access,
+    }
+
+
+def task_final_rows(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    finals: list[dict[str, Any]] = []
+    for task_rows in group_model_log_tasks(rows):
+        ordered = sorted(
+            task_rows,
+            key=lambda row: (
+                model_log_text(row.get("logged_at")),
+                1 if model_log_row_is_retry(row) else 0,
+            ),
+        )
+        if ordered:
+            finals.append(ordered[-1])
+    return finals
+
+
+def enrich_model_groups_with_identity(
+    groups: list[dict[str, Any]],
+    rows: list[dict[str, Any]],
+    registry: ModelIdentityRegistry,
+    *,
+    include_task_type: bool,
+) -> list[dict[str, Any]]:
+    identity_rows: dict[tuple[str, str] | tuple[str], dict[str, str]] = {}
+    latest: dict[tuple[str, str] | tuple[str], str] = {}
+    for row in task_final_rows(rows):
+        group_model = model_log_row_model(row)
+        group_task_type = model_log_row_task_type(row)
+        key: tuple[str, str] | tuple[str]
+        key = (group_model, group_task_type) if include_task_type else (group_model,)
+        logged_at = model_log_text(row.get("logged_at"))
+        if key not in latest or logged_at >= latest[key]:
+            latest[key] = logged_at
+            identity_rows[key] = row_identity_fields(row, registry)
+    enriched: list[dict[str, Any]] = []
+    for group in groups:
+        key = (
+            (str(group.get("model") or ""), str(group.get("task_type") or ""))
+            if include_task_type
+            else (str(group.get("model") or ""),)
+        )
+        item = dict(group)
+        item.update(
+            identity_rows.get(
+                key,
+                {
+                    "model_display": str(group.get("model") or ""),
+                    "harness": "unknown",
+                    "access": "unknown",
+                },
+            )
+        )
+        enriched.append(item)
+    return enriched
+
+
+def ensure_sqlite_available() -> Any:
+    if sqlite3 is None:
+        raise RuntimeError("sqlite3 is unavailable")
+    return sqlite3
+
+
+def connect_read_model_db(path: Path) -> Any:
+    sqlite = ensure_sqlite_available()
+    path = path.expanduser().resolve()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite.connect(str(path))
+    conn.row_factory = sqlite.Row
+    conn.execute("PRAGMA busy_timeout=5000")
+    conn.execute("PRAGMA journal_mode=WAL")
+    return conn
+
+
+def create_read_model_schema(conn: Any) -> None:
+    conn.executescript(
+        """
+        CREATE TABLE IF NOT EXISTS schema_version (
+            version INTEGER NOT NULL
+        );
+        DELETE FROM schema_version;
+        INSERT INTO schema_version(version) VALUES (1);
+        PRAGMA user_version = 1;
+
+        CREATE TABLE IF NOT EXISTS attempts (
+            id INTEGER PRIMARY KEY,
+            run_id TEXT,
+            task_key TEXT,
+            logged_at TEXT,
+            engine TEXT,
+            model TEXT,
+            task_type TEXT,
+            retry INTEGER,
+            verdict TEXT,
+            duration_ms INTEGER,
+            worker_tokens INTEGER,
+            orchestrator TEXT
+        );
+        CREATE INDEX IF NOT EXISTS idx_attempts_model_task_type
+            ON attempts(model, task_type);
+        CREATE INDEX IF NOT EXISTS idx_attempts_logged_at
+            ON attempts(logged_at);
+
+        CREATE TABLE IF NOT EXISTS catalog_models (
+            id TEXT PRIMARY KEY,
+            name TEXT,
+            context_length INTEGER,
+            prompt_per_m REAL,
+            completion_per_m REAL,
+            free INTEGER,
+            variable_pricing INTEGER,
+            pricing_unknown INTEGER,
+            fetched_at TEXT,
+            modality TEXT
+        );
+        CREATE TABLE IF NOT EXISTS catalog_events (
+            id INTEGER PRIMARY KEY,
+            ts TEXT,
+            kind TEXT,
+            model_id TEXT,
+            payload TEXT
+        );
+        CREATE TABLE IF NOT EXISTS identity (
+            engine TEXT NOT NULL,
+            model_key TEXT NOT NULL,
+            model_display TEXT,
+            harness TEXT,
+            access TEXT,
+            confidence TEXT,
+            source TEXT,
+            PRIMARY KEY (engine, model_key)
+        );
+        CREATE TABLE IF NOT EXISTS identity_defaults (
+            engine TEXT PRIMARY KEY,
+            default_model_key TEXT,
+            harness TEXT,
+            access TEXT
+        );
+        CREATE TABLE IF NOT EXISTS sync_state (
+            key TEXT PRIMARY KEY,
+            value TEXT
+        );
+        """
+    )
+
+
+def drop_read_model_tables(conn: Any) -> None:
+    conn.executescript(
+        """
+        DROP TABLE IF EXISTS attempts;
+        DROP TABLE IF EXISTS catalog_models;
+        DROP TABLE IF EXISTS catalog_events;
+        DROP TABLE IF EXISTS identity;
+        DROP TABLE IF EXISTS identity_defaults;
+        DROP TABLE IF EXISTS sync_state;
+        DROP TABLE IF EXISTS schema_version;
+        """
+    )
+
+
+def read_log_rows_from_offset(path: Path, offset: int) -> tuple[list[dict[str, Any]], int, int]:
+    rows: list[dict[str, Any]] = []
+    skipped = 0
+    final_offset = offset
+    try:
+        with path.open("rb") as fh:
+            fh.seek(offset)
+            for raw_line in fh:
+                final_offset = fh.tell()
+                try:
+                    line = raw_line.decode("utf-8")
+                    row = json.loads(line)
+                except (UnicodeDecodeError, json.JSONDecodeError):
+                    skipped += 1
+                    continue
+                if not isinstance(row, dict):
+                    skipped += 1
+                    continue
+                rows.append(row)
+    except FileNotFoundError:
+        return [], 0, 0
+    return rows, skipped, final_offset
+
+
+def insert_attempt_rows(conn: Any, rows: list[dict[str, Any]]) -> int:
+    payloads: list[tuple[Any, ...]] = []
+    for row in rows:
+        payloads.append(
+            (
+                model_log_text(row.get("run_id")),
+                model_log_text(row.get("task_key")),
+                model_log_text(row.get("logged_at")),
+                model_log_row_engine(row),
+                model_log_text(row.get("model")),
+                model_log_text(row.get("task_type")),
+                1 if model_log_row_is_retry(row) else 0,
+                model_log_text(row.get("verdict")),
+                model_log_int(row.get("duration_ms")),
+                model_log_int(row.get("worker_tokens")),
+                model_log_text(row.get("orchestrator")),
+            )
+        )
+    if payloads:
+        conn.executemany(
+            """
+            INSERT INTO attempts (
+                run_id, task_key, logged_at, engine, model, task_type, retry,
+                verdict, duration_ms, worker_tokens, orchestrator
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            payloads,
+        )
+    return len(payloads)
+
+
+def refresh_catalog_tables(conn: Any, catalog_path: Path) -> None:
+    conn.execute("DELETE FROM catalog_models")
+    try:
+        catalog_models = load_catalog_snapshot(catalog_path)
+    except (OSError, json.JSONDecodeError, ValueError):
+        catalog_models = []
+    payloads: list[tuple[Any, ...]] = []
+    for model in catalog_models:
+        normalized = normalize_catalog_for_scoreboard(model)
+        model_id = model_log_text(normalized.get("id"))
+        if not model_id:
+            continue
+        payloads.append(
+            (
+                model_id,
+                model_log_text(normalized.get("name")),
+                model_log_int(normalized.get("context_length")),
+                normalized.get("prompt_per_m"),
+                normalized.get("completion_per_m"),
+                1 if normalized.get("free") else 0,
+                1 if normalized.get("variable_pricing") else 0,
+                1 if normalized.get("pricing_unknown") else 0,
+                model_log_text(normalized.get("fetched_at")),
+                model_log_text(normalized.get("modality")),
+            )
+        )
+    if payloads:
+        conn.executemany(
+            """
+            INSERT INTO catalog_models (
+                id, name, context_length, prompt_per_m, completion_per_m, free,
+                variable_pricing, pricing_unknown, fetched_at, modality
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            payloads,
+        )
+
+    conn.execute("DELETE FROM catalog_events")
+    event_payloads: list[tuple[Any, ...]] = []
+    for event in read_catalog_events(catalog_changes_path(catalog_path), limit=10_000_000):
+        event_payloads.append(
+            (
+                model_log_text(event.get("ts")),
+                model_log_text(event.get("kind")),
+                model_log_text(event.get("id")),
+                json.dumps(event, sort_keys=True),
+            )
+        )
+    if event_payloads:
+        conn.executemany(
+            "INSERT INTO catalog_events(ts, kind, model_id, payload) VALUES (?, ?, ?, ?)",
+            event_payloads,
+        )
+
+
+def refresh_identity_tables(conn: Any, registry_path: Path) -> None:
+    registry = load_model_identity_registry(registry_path)
+    conn.execute("DELETE FROM identity")
+    conn.execute("DELETE FROM identity_defaults")
+    if registry.identities:
+        conn.executemany(
+            """
+            INSERT INTO identity (
+                engine, model_key, model_display, harness, access, confidence, source
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                (
+                    engine,
+                    model_key,
+                    identity.model_display,
+                    identity.harness,
+                    identity.access,
+                    identity.confidence,
+                    identity.source,
+                )
+                for (engine, model_key), identity in sorted(registry.identities.items())
+            ],
+        )
+    if registry.engine_meta:
+        conn.executemany(
+            """
+            INSERT INTO identity_defaults(engine, default_model_key, harness, access)
+            VALUES (?, ?, ?, ?)
+            """,
+            [
+                (
+                    engine,
+                    registry.defaults.get(engine, ""),
+                    identity.harness,
+                    identity.access,
+                )
+                for engine, identity in sorted(registry.engine_meta.items())
+            ],
+        )
+
+
+@dataclass(frozen=True)
+class ReadModelSyncResult:
+    db_path: Path
+    log_path: Path
+    attempts_inserted: int
+    skipped: int
+    offset: int
+    rebuilt: bool
+
+
+def rebuild_read_model_db(
+    db_path: Path,
+    log_path: Path,
+    *,
+    catalog_path: Path | None = None,
+    registry_path: Path | None = None,
+) -> ReadModelSyncResult:
+    db_path = db_path.expanduser().resolve()
+    log_path = log_path.expanduser().resolve()
+    catalog_path = (catalog_path or default_catalog_path()).expanduser().resolve()
+    registry_path = (registry_path or default_model_registry_path()).expanduser().resolve()
+    with contextlib.closing(connect_read_model_db(db_path)) as conn:
+        conn.execute("BEGIN IMMEDIATE")
+        try:
+            drop_read_model_tables(conn)
+            create_read_model_schema(conn)
+            rows, skipped, offset = read_log_rows_from_offset(log_path, 0)
+            inserted = insert_attempt_rows(conn, rows)
+            refresh_catalog_tables(conn, catalog_path)
+            refresh_identity_tables(conn, registry_path)
+            conn.execute(
+                "INSERT OR REPLACE INTO sync_state(key, value) VALUES ('log_offset', ?)",
+                (str(offset),),
+            )
+            conn.commit()
+        except Exception:
+            conn.rollback()
+            raise
+    return ReadModelSyncResult(db_path, log_path, inserted, skipped, offset, True)
+
+
+def sync_read_model_db(
+    db_path: Path,
+    log_path: Path,
+    *,
+    catalog_path: Path | None = None,
+    registry_path: Path | None = None,
+) -> ReadModelSyncResult:
+    db_path = db_path.expanduser().resolve()
+    log_path = log_path.expanduser().resolve()
+    catalog_path = (catalog_path or default_catalog_path()).expanduser().resolve()
+    registry_path = (registry_path or default_model_registry_path()).expanduser().resolve()
+    try:
+        log_size = log_path.stat().st_size
+    except FileNotFoundError:
+        log_size = 0
+    with contextlib.closing(connect_read_model_db(db_path)) as conn:
+        conn.execute("BEGIN IMMEDIATE")
+        try:
+            create_read_model_schema(conn)
+            row = conn.execute("SELECT value FROM sync_state WHERE key = 'log_offset'").fetchone()
+            offset = int(row["value"]) if row is not None and str(row["value"]).isdigit() else 0
+            if log_size < offset:
+                conn.rollback()
+                return rebuild_read_model_db(
+                    db_path,
+                    log_path,
+                    catalog_path=catalog_path,
+                    registry_path=registry_path,
+                )
+            rows, skipped, new_offset = read_log_rows_from_offset(log_path, offset)
+            inserted = insert_attempt_rows(conn, rows)
+            refresh_catalog_tables(conn, catalog_path)
+            refresh_identity_tables(conn, registry_path)
+            conn.execute(
+                "INSERT OR REPLACE INTO sync_state(key, value) VALUES ('log_offset', ?)",
+                (str(new_offset),),
+            )
+            conn.commit()
+        except Exception:
+            conn.rollback()
+            raise
+    return ReadModelSyncResult(db_path, log_path, inserted, skipped, new_offset, False)
+
+
+def load_identity_registry_from_db(conn: Any) -> ModelIdentityRegistry:
+    create_read_model_schema(conn)
+    identities: dict[tuple[str, str], ModelIdentity] = {}
+    defaults: dict[str, str] = {}
+    engine_meta: dict[str, ModelIdentity] = {}
+    for row in conn.execute("SELECT * FROM identity"):
+        engine = model_log_text(row["engine"])
+        model_key = model_log_text(row["model_key"])
+        if not engine or not model_key:
+            continue
+        identities[(engine, model_key)] = ModelIdentity(
+            model_display=model_log_text(row["model_display"]) or model_key,
+            harness=model_log_text(row["harness"]) or engine,
+            access=model_log_text(row["access"]) or "unknown",
+            confidence=model_log_text(row["confidence"]),
+            source=model_log_text(row["source"]),
+        )
+    for row in conn.execute("SELECT * FROM identity_defaults"):
+        engine = model_log_text(row["engine"])
+        if not engine:
+            continue
+        defaults[engine] = model_log_text(row["default_model_key"])
+        engine_meta[engine] = ModelIdentity(
+            model_display=engine,
+            harness=model_log_text(row["harness"]) or engine,
+            access=model_log_text(row["access"]) or "unknown",
+            confidence="engine",
+            source="",
+        )
+    return ModelIdentityRegistry(identities, defaults, engine_meta)
+
+
+def db_attempt_rows(
+    db_path: Path,
+    *,
+    since: str | None = None,
+    engine: str | None = None,
+) -> tuple[list[dict[str, Any]], ModelIdentityRegistry]:
+    with contextlib.closing(connect_read_model_db(db_path)) as conn:
+        create_read_model_schema(conn)
+        query = """
+            SELECT run_id, task_key, logged_at, engine, model, task_type, retry,
+                   verdict, duration_ms, worker_tokens, orchestrator
+            FROM attempts
+        """
+        params: list[Any] = []
+        if engine is not None:
+            query += " WHERE engine = ?"
+            params.append(engine)
+        query += " ORDER BY id"
+        rows = [
+            {
+                "run_id": row["run_id"],
+                "task_key": row["task_key"],
+                "logged_at": row["logged_at"],
+                "worker_engine": row["engine"],
+                "model": row["model"],
+                "task_type": row["task_type"],
+                "retry": bool(row["retry"]),
+                "verdict": row["verdict"],
+                "duration_ms": row["duration_ms"],
+                "worker_tokens": row["worker_tokens"],
+                "orchestrator": row["orchestrator"],
+            }
+            for row in conn.execute(query, params)
+        ]
+        registry = load_identity_registry_from_db(conn)
+        conn.commit()
+    if since is not None:
+        selected_row_ids: set[int] = set()
+        for task_rows in group_model_log_tasks(rows):
+            ordered = sorted(
+                task_rows,
+                key=lambda row: (
+                    model_log_text(row.get("logged_at")),
+                    1 if model_log_row_is_retry(row) else 0,
+                ),
+            )
+            final_date = parse_log_date(ordered[-1].get("logged_at"))
+            if final_date and final_date >= since:
+                selected_row_ids.update(id(row) for row in task_rows)
+        rows = [row for row in rows if id(row) in selected_row_ids]
+    return rows, registry
+
+
+def db_catalog_models(db_path: Path) -> list[dict[str, Any]]:
+    with contextlib.closing(connect_read_model_db(db_path)) as conn:
+        create_read_model_schema(conn)
+        rows = [
+            {
+                "id": row["id"],
+                "name": row["name"],
+                "context_length": row["context_length"],
+                "prompt_per_m": row["prompt_per_m"],
+                "completion_per_m": row["completion_per_m"],
+                "free": bool(row["free"]),
+                "variable_pricing": bool(row["variable_pricing"]),
+                "pricing_unknown": bool(row["pricing_unknown"]),
+                "fetched_at": row["fetched_at"],
+                "modality": row["modality"],
+            }
+            for row in conn.execute("SELECT * FROM catalog_models ORDER BY id")
+        ]
+        conn.commit()
+        return rows
+
+
+def db_catalog_events(db_path: Path, *, limit: int = 20) -> list[dict[str, Any]]:
+    with contextlib.closing(connect_read_model_db(db_path)) as conn:
+        create_read_model_schema(conn)
+        rows = conn.execute(
+            "SELECT payload FROM catalog_events ORDER BY id DESC LIMIT ?",
+            (limit,),
+        ).fetchall()
+        conn.commit()
+    events: list[dict[str, Any]] = []
+    for row in rows:
+        try:
+            event = json.loads(row["payload"])
+        except (TypeError, json.JSONDecodeError):
+            continue
+        if isinstance(event, dict):
+            events.append(event)
+    return events
+
+
+def run_db_command(config: AppConfig, args: argparse.Namespace) -> int:
+    db_path = (args.db or default_read_model_db_path()).expanduser().resolve()
+    log_path = (args.log or config.eval.jsonl_path).expanduser().resolve()
+    catalog_path = (getattr(args, "catalog_file", None) or default_catalog_path()).expanduser().resolve()
+    registry_path = (getattr(args, "registry", None) or default_model_registry_path()).expanduser().resolve()
+    if args.db_command == "rebuild":
+        result = rebuild_read_model_db(
+            db_path,
+            log_path,
+            catalog_path=catalog_path,
+            registry_path=registry_path,
+        )
+    else:
+        result = sync_read_model_db(
+            db_path,
+            log_path,
+            catalog_path=catalog_path,
+            registry_path=registry_path,
+        )
+    action = "rebuild" if result.rebuilt else "sync"
+    print(
+        f"db {action}: {result.db_path} "
+        f"attempts={result.attempts_inserted} skipped={result.skipped} offset={result.offset}"
+    )
+    return 0
+
+
 def normalize_notes_match_text(value: str) -> str:
     return re.sub(r"\s+", " ", value).strip().lower()
 
@@ -4458,7 +5145,11 @@ def render_notes_list(items: list[str]) -> str:
         return '<p class="empty-note">no judgment notes yet</p>'
     rendered = []
     for item in items:
-        text = "<br>".join(html_escape(line) for line in item.splitlines() if line.strip())
+        text = "<br>".join(
+            html_escape(humanize_dates_in_text(line))
+            for line in item.splitlines()
+            if line.strip()
+        )
         rendered.append(f"<li>{text}</li>")
     return f'<ul class="notes-list">{"".join(rendered)}</ul>'
 
@@ -4665,6 +5356,35 @@ def fmt_task_cost(value: float | None) -> str:
     return f"${value:.2f}/task"
 
 
+def humanized_log_date(value: Any, *, prefix: str = "") -> str:
+    text = model_log_text(value)
+    if not text:
+        return f"{prefix}unknown" if prefix else "unknown"
+    candidate = text[:10]
+    try:
+        dt = datetime.strptime(candidate, "%Y-%m-%d")
+    except ValueError:
+        return f"{prefix}{text}" if prefix else text
+    rendered = f"{dt.strftime('%B')} {dt.day}, {dt.year}"
+    return f"{prefix}{rendered}" if prefix else rendered
+
+
+def humanize_dates_in_text(value: str) -> str:
+    return re.sub(
+        r"\b\d{4}-\d{2}-\d{2}\b",
+        lambda match: humanized_log_date(match.group(0)),
+        value,
+    )
+
+
+def source_file_link(path: Path, label: str) -> str:
+    resolved = path.expanduser().resolve()
+    return (
+        f'<a class="source-link" href="{html_escape(file_href(resolved))}" '
+        f'title="{html_escape(str(resolved))}">{html_escape(label)}</a>'
+    )
+
+
 def catalog_cost_html(row: dict[str, Any], catalog_model: dict[str, Any] | None) -> str:
     median_tokens = row.get("median_tokens")
     if catalog_model is None:
@@ -4746,6 +5466,8 @@ MODEL_SCOREBOARD_CSS = """
   }
   .source-box b { display: block; font-size: 12px; color: var(--muted); }
   .source-box span { display: block; overflow-wrap: anywhere; }
+  .source-link { color: var(--accent); text-decoration: none; }
+  .source-link:hover { text-decoration: underline; }
   .watchlist {
     border-top: 1px solid var(--hairline);
     border-bottom: 1px solid var(--hairline);
@@ -4793,6 +5515,18 @@ MODEL_SCOREBOARD_CSS = """
   .rank { font-size: 24px; font-weight: 800; line-height: 1; }
   .tier { color: var(--muted); font-size: 13px; margin-top: 4px; }
   .model-name { font-size: 19px; font-weight: 800; overflow-wrap: anywhere; }
+  .model-id { color: var(--muted); font-size: 12px; overflow-wrap: anywhere; margin-top: 3px; }
+  .identity-grid {
+    display: grid;
+    gap: 6px;
+    font-size: 13px;
+  }
+  .identity-grid b {
+    display: block;
+    color: var(--muted);
+    font-size: 12px;
+    font-weight: 700;
+  }
   .metric-row {
     display: flex;
     gap: 10px;
@@ -4844,7 +5578,12 @@ MODEL_SCOREBOARD_CSS = """
 """
 
 
-def render_free_watchlist(catalog_models: list[dict[str, Any]], catalog_path: Path) -> str:
+def render_free_watchlist(
+    catalog_models: list[dict[str, Any]],
+    catalog_path: Path,
+    *,
+    events: list[dict[str, Any]] | None = None,
+) -> str:
     normalized = [normalize_catalog_for_scoreboard(model) for model in catalog_models]
     free_models = sorted(
         (model for model in normalized if model.get("free")),
@@ -4857,8 +5596,12 @@ def render_free_watchlist(catalog_models: list[dict[str, Any]], catalog_path: Pa
         )
     else:
         free_items = '<li class="muted">no FREE catalog models in the current snapshot</li>'
-    events = read_catalog_events(catalog_changes_path(catalog_path), limit=6)
-    event_items = "".join(f"<li>{html_escape(describe_catalog_event(event))}</li>" for event in events)
+    if events is None:
+        events = read_catalog_events(catalog_changes_path(catalog_path), limit=6)
+    event_items = "".join(
+        f"<li>{html_escape(describe_catalog_event_humanized(event))}</li>"
+        for event in events[:6]
+    )
     if not event_items:
         event_items = '<li class="muted">no catalog change log found</li>'
     return f"""<section class="watchlist" aria-labelledby="watchlist-heading">
@@ -4878,8 +5621,12 @@ def render_model_card(
     notes_sections: dict[str, list[str]],
 ) -> str:
     model_id = str(row.get("model") or "")
+    model_display = str(row.get("model_display") or model_id)
+    harness = str(row.get("harness") or "unknown")
+    access = str(row.get("access") or "unknown")
     notes = model_judgment_notes(model_id, notes_sections)
     median_tokens = "none" if row.get("median_tokens") is None else fmt_int(row.get("median_tokens"))
+    model_id_line = "" if model_id == model_display else f'<div class="model-id">{html_escape(model_id)}</div>'
     return f"""<article class="model-card" id="model-{html_escape(sanitize_artifact_name(model_id))}">
   <div class="model-summary">
     <div>
@@ -4887,7 +5634,8 @@ def render_model_card(
       <div class="tier">{html_escape(str(row.get("tier") or ""))}</div>
     </div>
     <div>
-      <div class="model-name">{html_escape(model_id)}</div>
+      <div class="model-name">{html_escape(model_display)}</div>
+      {model_id_line}
       <div class="metric-row">
         <span><b>n={fmt_int(row.get("tasks"))}</b> tasks</span>
         <span><b>{fmt_int(row.get("attempts"))}</b> attempts</span>
@@ -4896,11 +5644,15 @@ def render_model_card(
         <span><b>{fmt_percent(row.get("pass_rate"))}</b> pass</span>
       </div>
       <div class="metric-row">
-        <span>last_seen <b>{html_escape(str(row.get("last_seen") or "unknown"))}</b></span>
+        <span><b>{html_escape(humanized_log_date(row.get("last_seen"), prefix="last used: "))}</b></span>
         <span>median worker_tokens <b>{html_escape(median_tokens)}</b></span>
       </div>
     </div>
-    <div>{catalog_cost_html(row, catalog_model)}</div>
+    <div class="identity-grid">
+      <span><b>Harness</b>{html_escape(harness)}</span>
+      <span><b>API-Plan</b>{html_escape(access)}</span>
+      <span><b>Cost</b>{catalog_cost_html(row, catalog_model)}</span>
+    </div>
     <div class="quality">
       <div><b>Best:</b> {html_escape(derived_quality_text(row, best=True))}</div>
       <div><b>Worst:</b> {html_escape(derived_quality_text(row, best=False))}</div>
@@ -4929,6 +5681,7 @@ def render_model_scoreboard_html(
     catalog_models: list[dict[str, Any]],
     notes_path: Path,
     notes_sections: dict[str, list[str]],
+    catalog_events: list[dict[str, Any]] | None = None,
     generated_at: str | None = None,
 ) -> str:
     catalog_by_id = catalog_models_by_id(catalog_models)
@@ -4959,16 +5712,16 @@ def render_model_scoreboard_html(
   <header class="corner">
     <span class="live-dot pass" aria-hidden="true"></span>
     <span class="eyebrow">Ringer &nbsp;·&nbsp; <b>model-scoreboard</b></span>
-    <span class="clock mono">Generated {html_escape(generated)}</span>
+    <span class="clock">Generated {html_escape(humanized_log_date(generated))}</span>
   </header>
   <h1 class="briefing scoreboard-briefing">Model performance scoreboard</h1>
   <section class="source-grid" aria-label="scoreboard sources">
-    <div class="source-box"><b>Log</b><span class="mono">{html_escape(str(log_path))}</span></div>
-    <div class="source-box"><b>Catalog</b><span class="mono">{html_escape(str(catalog_path))}</span></div>
-    <div class="source-box"><b>Notes</b><span class="mono">{html_escape(str(notes_path))}</span></div>
-    <div class="source-box"><b>Rows</b><span>{fmt_int(rows_read)} read · {fmt_int(skipped)} skipped · {fmt_int(len(ordered))} models</span></div>
+    <div class="source-box"><b>Log</b><span>{source_file_link(log_path, "eval log")}</span></div>
+    <div class="source-box"><b>Catalog</b><span>{source_file_link(catalog_path, "catalog")}</span></div>
+    <div class="source-box"><b>Notes</b><span>{source_file_link(notes_path, "model notes")}</span></div>
+    <div class="source-box"><b>Models</b><span>{fmt_int(len(ordered))} ranked</span></div>
   </section>
-  {render_free_watchlist(catalog_models, catalog_path)}
+  {render_free_watchlist(catalog_models, catalog_path, events=catalog_events)}
   <section class="models" aria-labelledby="models-heading">
     <h2 id="models-heading">Ranked models</h2>
     {cards}
@@ -4976,6 +5729,7 @@ def render_model_scoreboard_html(
   <footer>
     <span>Ranking sorts by evidence tier first: proven n>=3, then probation; ties use first-try pass rate, pass rate, then lower estimated cost.</span>
     <span>Cost estimate assumes logged worker_tokens are split 50/50 between prompt and completion tokens, using the catalog $/M in/out blend.</span>
+    <span>{fmt_int(rows_read)} rows read, {fmt_int(skipped)} skipped lines.</span>
   </footer>
 </div>
 </body>
@@ -4995,6 +5749,7 @@ def write_model_scoreboard_html(
     catalog_models: list[dict[str, Any]],
     notes_path: Path,
     notes_sections: dict[str, list[str]],
+    catalog_events: list[dict[str, Any]] | None = None,
 ) -> Path:
     target = path
     if target is None:
@@ -5007,6 +5762,7 @@ def write_model_scoreboard_html(
         skipped=skipped,
         catalog_path=catalog_path,
         catalog_models=catalog_models,
+        catalog_events=catalog_events,
         notes_path=notes_path,
         notes_sections=notes_sections,
     )
@@ -5025,17 +5781,21 @@ def write_model_scoreboard_html(
 def print_model_log_table(path: Path, rows_read: int, skipped: int, groups: list[dict[str, Any]]) -> None:
     print(f"Model log: {path} ({rows_read} rows, {skipped} skipped lines)")
     header = (
-        f"{'task_type':<18} {'model':<32} {'tasks':>5} {'attempts':>8} "
-        f"{'passed':>6} {'failed':>6} {'pass':>6} {'first':>6} "
-        f"{'dur_ms':>8} {'tokens':>8} {'last_seen'}"
+        f"{'task_type':<18} {'model':<32} {'harness':<16} {'tasks':>5} "
+        f"{'attempts':>8} {'passed':>6} {'failed':>6} {'pass':>6} "
+        f"{'first':>6} {'dur_ms':>8} {'tokens':>8} {'last_seen'}"
     )
     print(header)
     print("-" * len(header))
     for group in groups:
         duration = "" if group["median_duration_ms"] is None else str(group["median_duration_ms"])
         tokens = "" if group["median_tokens"] is None else str(group["median_tokens"])
+        display = str(group.get("model_display") or group["model"])
+        if display != group["model"]:
+            display = f"{display} ({group['model']})"
         print(
-            f"{group['task_type']:<18} {shorten(group['model'], 32):<32} "
+            f"{group['task_type']:<18} {shorten(display, 32):<32} "
+            f"{shorten(str(group.get('harness') or 'unknown'), 16):<16} "
             f"{group['tasks']:>5} {group['attempts']:>8} {group['passed']:>6} "
             f"{group['failed']:>6} {group['pass_rate']:>6.2f} "
             f"{group['first_try_pass_rate']:>6.2f} {duration:>8} "
@@ -5047,11 +5807,36 @@ def print_model_log_table(path: Path, rows_read: int, skipped: int, groups: list
 def run_models_command(config: AppConfig, args: argparse.Namespace) -> int:
     log_path = (args.log or config.eval.jsonl_path).expanduser().resolve()
     since = validate_since_date(args.since)
-    rows, skipped = read_model_log_rows(log_path, since=since, engine=args.engine)
-    groups = aggregate_model_log_rows(rows, task_type=args.task_type, model=args.model)
+    db_path = (getattr(args, "db", None) or default_read_model_db_path()).expanduser().resolve()
+    catalog_path = (getattr(args, "catalog_file", None) or default_catalog_path()).expanduser().resolve()
+    registry_path = (getattr(args, "registry", None) or default_model_registry_path()).expanduser().resolve()
+    using_db = True
+    catalog_events: list[dict[str, Any]] | None = None
+    try:
+        sync_result = sync_read_model_db(
+            db_path,
+            log_path,
+            catalog_path=catalog_path,
+            registry_path=registry_path,
+        )
+        rows, identity_registry = db_attempt_rows(db_path, since=since, engine=args.engine)
+        skipped = sync_result.skipped
+        catalog_models_from_db = db_catalog_models(db_path)
+        catalog_events = db_catalog_events(db_path, limit=6)
+    except Exception as exc:
+        using_db = False
+        print(f"models: SQLite read model unavailable; using JSONL fallback ({exc})", file=sys.stderr)
+        rows, skipped = read_model_log_rows(log_path, since=since, engine=args.engine)
+        identity_registry = load_model_identity_registry(registry_path)
+        catalog_models_from_db = []
+    groups = enrich_model_groups_with_identity(
+        aggregate_model_log_rows(rows, task_type=args.task_type, model=args.model),
+        rows,
+        identity_registry,
+        include_task_type=True,
+    )
     if args.explore:
-        catalog_path = (args.catalog_file or default_catalog_path()).expanduser().resolve()
-        catalog_models = load_catalog_snapshot(catalog_path)
+        catalog_models = catalog_models_from_db if using_db else load_catalog_snapshot(catalog_path)
         print_model_explore(
             log_path=log_path,
             rows_read=len(rows),
@@ -5064,10 +5849,14 @@ def run_models_command(config: AppConfig, args: argparse.Namespace) -> int:
     html_arg = getattr(args, "html", None)
     open_requested = bool(getattr(args, "open", False))
     if html_arg is not None or open_requested:
-        catalog_path = (args.catalog_file or default_catalog_path()).expanduser().resolve()
-        catalog_models = load_catalog_snapshot(catalog_path)
+        catalog_models = catalog_models_from_db if using_db else load_catalog_snapshot(catalog_path)
         notes_path = (getattr(args, "notes_file", None) or default_model_notes_path()).expanduser().resolve()
-        scoreboard_rows = aggregate_model_scoreboard_rows(rows, task_type=args.task_type, model=args.model)
+        scoreboard_rows = enrich_model_groups_with_identity(
+            aggregate_model_scoreboard_rows(rows, task_type=args.task_type, model=args.model),
+            rows,
+            identity_registry,
+            include_task_type=False,
+        )
         explicit_path = None
         if html_arg not in {None, ""}:
             explicit_path = Path(str(html_arg))
@@ -5082,6 +5871,7 @@ def run_models_command(config: AppConfig, args: argparse.Namespace) -> int:
             catalog_models=catalog_models,
             notes_path=notes_path,
             notes_sections=parse_model_notes_sections(notes_path),
+            catalog_events=catalog_events,
         )
         print(page_path)
         if open_requested:
@@ -6540,9 +7330,20 @@ def build_parser() -> argparse.ArgumentParser:
     hud_parser.add_argument("--port", type=int, help=f"port to bind on 127.0.0.1 (default: {DEFAULT_HUD_PORT})")
     hud_parser.add_argument("--no-open", action="store_true", help="start the server without opening a browser")
 
+    db_parser = subparsers.add_parser("db", help="manage the derived SQLite read model")
+    db_parser.add_argument("--config", type=Path, default=argparse.SUPPRESS, help=argparse.SUPPRESS)
+    db_subparsers = db_parser.add_subparsers(dest="db_command", required=True)
+    for name in ("rebuild", "sync"):
+        sub = db_subparsers.add_parser(name, help=f"{name} the derived SQLite read model")
+        sub.add_argument("--db", type=Path, help="path to SQLite read model (default: ~/.ringer/ringer.db)")
+        sub.add_argument("--log", type=Path, help="path to local eval JSONL log")
+        sub.add_argument("--catalog-file", type=Path, help="path to local OpenRouter catalog snapshot")
+        sub.add_argument("--registry", type=Path, help="path to model identity registry")
+
     models_parser = subparsers.add_parser("models", help="show the local per-model performance scoreboard")
     models_parser.add_argument("--config", type=Path, default=argparse.SUPPRESS, help=argparse.SUPPRESS)
     models_parser.add_argument("--log", type=Path, help="path to local eval JSONL log")
+    models_parser.add_argument("--db", type=Path, help="path to SQLite read model (default: ~/.ringer/ringer.db)")
     models_parser.add_argument("--task-type", help="only include one task_type bucket")
     models_parser.add_argument("--model", help="only include one resolved model bucket")
     models_parser.add_argument("--engine", help="only include rows from one worker engine")
@@ -6550,6 +7351,7 @@ def build_parser() -> argparse.ArgumentParser:
     models_parser.add_argument("--explore", action="store_true", help="show proven/probation tiers plus cheap untested catalog candidates")
     models_parser.add_argument("--catalog-file", type=Path, help="path to local OpenRouter catalog snapshot")
     models_parser.add_argument("--notes-file", type=Path, default=default_model_notes_path(), help="path to MODEL-NOTES.md judgment layer")
+    models_parser.add_argument("--registry", type=Path, default=default_model_registry_path(), help=argparse.SUPPRESS)
     models_parser.add_argument("--html", nargs="?", const="", help="render a self-contained HTML scoreboard; optional output path")
     models_parser.add_argument("--open", action="store_true", help="render the HTML scoreboard to the artifact library and open it")
     models_parser.add_argument("--json", action="store_true", help="print the scoreboard as JSON")
@@ -6608,6 +7410,8 @@ def main(argv: list[str] | None = None) -> int:
             return run_catalog_command(args)
 
         config = AppConfig.load(args.config)
+        if args.command == "db":
+            return run_db_command(config, args)
         if args.command == "models":
             return run_models_command(config, args)
         if args.command == "hud":

--- a/ringer.py
+++ b/ringer.py
@@ -3672,9 +3672,306 @@ def artifact_content_type(path: Path) -> str:
     return "application/octet-stream"
 
 
+def inject_models_tab_into_ringside_html(html: str) -> str:
+    if 'id="models-panel"' in html or 'id="artifacts-panel"' not in html:
+        return html
+    tabs = """
+    <nav class="tabs" id="ringside-tabs" aria-label="Ringside views">
+      <button type="button" class="tab" id="runs-tab" aria-selected="true">Runs</button>
+      <button type="button" class="tab" id="models-tab" aria-selected="false">Models</button>
+    </nav>
+"""
+    panel = """
+      <section id="models-panel" class="panel models-panel" hidden>
+        <div id="models-status" class="models-status mono">models not loaded</div>
+        <div id="models-table-wrap" class="models-table-wrap">
+          <div class="empty">No model results yet. Run './ringer.py models' for the local scoreboard docs.</div>
+        </div>
+      </section>
+"""
+    style = """
+    .models-panel {
+      min-height: calc(100vh - 83px);
+      padding: 0 clamp(12px, 2vw, 22px) clamp(20px, 3vw, 30px);
+    }
+    .models-status {
+      padding: 10px 0;
+      color: var(--muted);
+      font-size: 12px;
+      border-bottom: 1px solid var(--hairline);
+    }
+    .models-status.error { color: var(--fail); }
+    .models-table-wrap { overflow: auto; }
+    .models-table {
+      width: 100%;
+      min-width: 860px;
+      border-collapse: collapse;
+      font-size: 13px;
+    }
+    .models-table th,
+    .models-table td {
+      padding: 11px 10px;
+      border-bottom: 1px solid var(--hairline);
+      vertical-align: middle;
+      text-align: left;
+    }
+    .models-table th {
+      color: var(--muted);
+      font-size: 11px;
+      font-weight: 700;
+      letter-spacing: .06em;
+      text-transform: uppercase;
+    }
+    .models-table .numeric { text-align: right; }
+    .model-row { cursor: pointer; }
+    .model-row:hover,
+    .model-row.expanded { background: var(--surface); }
+    .model-name-cell { display: grid; gap: 1px; min-width: 220px; }
+    .model-display { color: var(--ink); font-weight: 700; }
+    .model-slug,
+    .models-meta {
+      color: var(--muted);
+      font-size: 12px;
+    }
+    .tier-badge {
+      display: inline-flex;
+      align-items: center;
+      min-height: 22px;
+      padding: 2px 7px;
+      border: 1px solid var(--hairline);
+      border-radius: 5px;
+      color: var(--ink);
+      font-size: 11px;
+      font-weight: 700;
+      text-transform: uppercase;
+    }
+    .tier-badge.proven {
+      border-color: color-mix(in srgb, var(--pass) 48%, var(--hairline));
+      color: var(--pass);
+    }
+    .tier-badge.probation {
+      border-color: color-mix(in srgb, var(--accent) 48%, var(--hairline));
+      color: var(--accent);
+    }
+    .model-breakdown td {
+      padding: 0;
+      background: color-mix(in srgb, var(--surface) 72%, transparent);
+    }
+    .breakdown-grid {
+      display: grid;
+      grid-template-columns: minmax(120px, 1fr) repeat(5, minmax(70px, auto));
+      gap: 0;
+      padding: 8px 10px 10px 46px;
+      color: var(--muted);
+      font-size: 12px;
+    }
+    .breakdown-grid > div {
+      padding: 5px 8px;
+      border-bottom: 1px solid var(--hairline);
+      min-width: 0;
+    }
+    .breakdown-head {
+      font-size: 10px;
+      font-weight: 700;
+      letter-spacing: .06em;
+      text-transform: uppercase;
+    }
+    @media (max-width: 760px) {
+      .breakdown-grid {
+        grid-template-columns: minmax(110px, 1fr) repeat(2, minmax(64px, auto));
+        padding-left: 10px;
+      }
+      .breakdown-grid .optional { display: none; }
+    }
+"""
+    script = r"""
+    function installModelsView() {
+      const MODELS_REFRESH_MS = 30000;
+      const VIEW_KEY = "ringside-view";
+      const runsPanel = document.getElementById("artifacts-panel");
+      const modelsPanel = document.getElementById("models-panel");
+      const runsTab = document.getElementById("runs-tab");
+      const modelsTab = document.getElementById("models-tab");
+      const status = document.getElementById("models-status");
+      const wrap = document.getElementById("models-table-wrap");
+      if (!runsPanel || !modelsPanel || !runsTab || !modelsTab || !status || !wrap) return;
+      let payload = null;
+      let expandedModel = null;
+      let lastFetch = 0;
+      let inFlight = false;
+      let activeView = "runs";
+
+      function html(value) {
+        return String(value ?? "")
+          .replace(/&/g, "&amp;")
+          .replace(/</g, "&lt;")
+          .replace(/>/g, "&gt;")
+          .replace(/"/g, "&quot;")
+          .replace(/'/g, "&#39;");
+      }
+
+      function numberOrZeroLocal(value) {
+        const number = Number(value);
+        return Number.isFinite(number) ? number : 0;
+      }
+
+      function percent(value) {
+        const number = Number(value);
+        return Number.isFinite(number) ? `${Math.round(number * 100)}%` : "0%";
+      }
+
+      function modelDate(value) {
+        const text = String(value || "").trim();
+        if (!text) return "unknown";
+        const match = text.match(/^(\d{4})-(\d{2})-(\d{2})/);
+        if (match) {
+          const date = new Date(Number(match[1]), Number(match[2]) - 1, Number(match[3]));
+          return date.toLocaleDateString("en-US", {month: "long", day: "numeric", year: "numeric"});
+        }
+        const stamp = Date.parse(text);
+        return Number.isFinite(stamp)
+          ? new Date(stamp).toLocaleDateString("en-US", {month: "long", day: "numeric", year: "numeric"})
+          : text;
+      }
+
+      function safeClass(value) {
+        return String(value || "unknown").toLowerCase().replace(/[^a-z0-9_-]+/g, "-").replace(/^-+|-+$/g, "") || "unknown";
+      }
+
+      function groupsFor(model) {
+        const groups = Array.isArray(payload?.groups) ? payload.groups : [];
+        return groups.filter(group => String(group?.model || "") === model);
+      }
+
+      function breakdown(model) {
+        const groups = groupsFor(model);
+        if (!groups.length) return '<div class="empty">No per-task breakdown recorded for this model.</div>';
+        const cells = [
+          '<div class="breakdown-head">Task type</div>',
+          '<div class="breakdown-head">Tasks</div>',
+          '<div class="breakdown-head">First</div>',
+          '<div class="breakdown-head optional">Pass</div>',
+          '<div class="breakdown-head optional">Attempts</div>',
+          '<div class="breakdown-head optional">Last used</div>',
+        ];
+        groups.forEach(group => {
+          cells.push(
+            `<div>${html(group.task_type || "(untyped)")}</div>`,
+            `<div>${numberOrZeroLocal(group.tasks).toLocaleString()}</div>`,
+            `<div>${html(percent(group.first_try_pass_rate))}</div>`,
+            `<div class="optional">${html(percent(group.pass_rate))}</div>`,
+            `<div class="optional">${numberOrZeroLocal(group.attempts).toLocaleString()}</div>`,
+            `<div class="optional">${html(modelDate(group.last_seen))}</div>`,
+          );
+        });
+        return `<div class="breakdown-grid mono">${cells.join("")}</div>`;
+      }
+
+      function renderModels() {
+        const rows = Array.isArray(payload?.rollup) ? payload.rollup : [];
+        const error = String(payload?.error || "").trim();
+        status.classList.toggle("error", Boolean(error));
+        status.textContent = error ? `models unavailable: ${error}` : `updated ${modelDate(payload?.generated_at)}`;
+        if (!rows.length) {
+          wrap.innerHTML = '<div class="empty">No model results yet. Run \'./ringer.py models\' for the local scoreboard docs.</div>';
+          return;
+        }
+        const body = [];
+        rows.forEach((row, index) => {
+          const model = String(row.model || "");
+          const expanded = expandedModel === model;
+          const tierClass = safeClass(row.tier);
+          body.push(
+            `<tr class="model-row${expanded ? " expanded" : ""}" data-model="${html(model)}" tabindex="0">`,
+            `<td class="numeric">${index + 1}</td>`,
+            '<td><span class="model-name-cell">',
+            `<span class="model-display">${html(row.model_display || row.model || "unknown")}</span>`,
+            `<span class="model-slug mono">${html(row.model || "unknown")}</span>`,
+            '</span></td>',
+            `<td>${html(row.harness || "unknown")}</td>`,
+            `<td>${html(row.access || "unknown")}</td>`,
+            `<td><span class="tier-badge ${html(tierClass)}">${html(row.tier || "unknown")}</span></td>`,
+            `<td class="numeric">${numberOrZeroLocal(row.tasks).toLocaleString()}</td>`,
+            `<td class="numeric">${html(percent(row.first_try_pass_rate))}</td>`,
+            `<td class="numeric">${html(percent(row.pass_rate))}</td>`,
+            `<td>${html(modelDate(row.last_seen))}</td>`,
+            '</tr>',
+          );
+          if (expanded) body.push(`<tr class="model-breakdown"><td colspan="9">${breakdown(model)}</td></tr>`);
+        });
+        wrap.innerHTML = [
+          '<table class="models-table">',
+          '<thead><tr>',
+          '<th class="numeric">Rank</th><th>Model</th><th>Harness</th><th>API/Plan</th><th>Tier</th>',
+          '<th class="numeric">Tasks</th><th class="numeric">First-try %</th><th class="numeric">Pass %</th><th>Last used</th>',
+          '</tr></thead>',
+          `<tbody>${body.join("")}</tbody>`,
+          '</table>',
+        ].join("");
+      }
+
+      async function fetchModels(force) {
+        const now = Date.now();
+        if (inFlight || (!force && lastFetch && now - lastFetch < MODELS_REFRESH_MS)) return;
+        inFlight = true;
+        status.textContent = payload ? "refreshing models..." : "loading models...";
+        try {
+          const response = await fetch(`/api/models?t=${Date.now()}`, {cache: "no-store"});
+          payload = await response.json();
+          lastFetch = Date.now();
+        } catch (error) {
+          payload = {generated_at: new Date().toISOString(), groups: [], rollup: [], error: error?.message || "models unavailable"};
+        } finally {
+          inFlight = false;
+          renderModels();
+        }
+      }
+
+      function selectView(view, persist = true) {
+        activeView = view === "models" ? "models" : "runs";
+        runsPanel.hidden = activeView === "models";
+        modelsPanel.hidden = activeView !== "models";
+        runsTab.setAttribute("aria-selected", String(activeView === "runs"));
+        modelsTab.setAttribute("aria-selected", String(activeView === "models"));
+        if (persist) localStorage.setItem(VIEW_KEY, activeView);
+        if (activeView === "models") fetchModels(true);
+      }
+
+      runsTab.addEventListener("click", () => selectView("runs"));
+      modelsTab.addEventListener("click", () => selectView("models"));
+      wrap.addEventListener("click", event => {
+        const row = event.target.closest(".model-row");
+        if (!row) return;
+        const model = row.getAttribute("data-model") || "";
+        expandedModel = expandedModel === model ? null : model;
+        renderModels();
+      });
+      wrap.addEventListener("keydown", event => {
+        if (event.key !== "Enter" && event.key !== " ") return;
+        const row = event.target.closest(".model-row");
+        if (!row) return;
+        event.preventDefault();
+        const model = row.getAttribute("data-model") || "";
+        expandedModel = expandedModel === model ? null : model;
+        renderModels();
+      });
+      setInterval(() => {
+        if (activeView === "models") fetchModels(false);
+      }, MODELS_REFRESH_MS);
+      selectView(localStorage.getItem(VIEW_KEY) === "models" ? "models" : "runs", false);
+    }
+
+"""
+    html = html.replace("    main {\n", style + "    main {\n", 1)
+    html = html.replace("    <main>\n", tabs + "\n    <main>\n", 1)
+    html = html.replace("    </main>\n", panel + "    </main>\n", 1)
+    html = html.replace("    tickClock();\n", script + "    installModelsView();\n    tickClock();\n", 1)
+    return html
+
+
 def read_ringside_html() -> str:
     try:
-        return RINGSIDE_HTML_PATH.read_text(encoding="utf-8")
+        return inject_models_tab_into_ringside_html(RINGSIDE_HTML_PATH.read_text(encoding="utf-8"))
     except OSError:
         return """<!doctype html>
 <html lang="en">
@@ -3845,11 +4142,14 @@ class PersistentHudServer:
         self.httpd: ThreadingHTTPServer | None = None
         self.thread: threading.Thread | None = None
         self.port: int | None = None
+        self.model_log_path: Path | None = None
+        self.model_db_path: Path | None = None
 
     def start(self) -> int:
         state_dir = self.state_dir
         artifact_root = artifacts_dir(state_dir)
         preferred_port = self.preferred_port
+        server_ref = self
 
         class Handler(BaseHTTPRequestHandler):
             def do_GET(self) -> None:  # noqa: N802
@@ -3871,6 +4171,21 @@ class PersistentHudServer:
                             "active": read_active_runs_file(),
                         },
                     )
+                    return
+                if path == "/api/models":
+                    try:
+                        payload = build_models_api_payload(
+                            log_path=server_ref.model_log_path or (state_dir / "runs.jsonl"),
+                            db_path=server_ref.model_db_path,
+                        )
+                    except Exception as exc:
+                        payload = {
+                            "generated_at": utc_now_iso(),
+                            "groups": [],
+                            "rollup": [],
+                            "error": str(exc) or exc.__class__.__name__,
+                        }
+                    send_json_response(self, payload)
                     return
                 if path.startswith("/api/open-folder"):
                     query = urllib.parse.urlparse(path).query
@@ -3953,6 +4268,9 @@ class PersistentHudServer:
                 webbrowser.open(url)
         print(f"Ringside: {url}", flush=True)
         return self.port
+
+    def start_background(self) -> int:
+        return self.start()
 
     def stop(self) -> None:
         if self.httpd is not None:
@@ -6090,6 +6408,60 @@ def print_model_log_table(path: Path, rows_read: int, skipped: int, groups: list
     print("Judgment layer: docs/MODEL-NOTES.md")
 
 
+def build_models_api_payload(
+    *,
+    log_path: Path,
+    db_path: Path | None = None,
+    catalog_path: Path | None = None,
+    registry_path: Path | None = None,
+) -> dict[str, Any]:
+    log_path = log_path.expanduser().resolve()
+    db_path = (db_path or default_read_model_db_path()).expanduser().resolve()
+    catalog_path = (catalog_path or default_catalog_path()).expanduser().resolve()
+    registry_path = (registry_path or default_model_registry_path()).expanduser().resolve()
+    using_db = True
+    catalog_models: list[dict[str, Any]] = []
+    try:
+        sync_read_model_db(
+            db_path,
+            log_path,
+            catalog_path=catalog_path,
+            registry_path=registry_path,
+        )
+        rows, identity_registry = db_attempt_rows(db_path)
+        catalog_models = db_catalog_models(db_path)
+    except Exception:
+        using_db = False
+        rows, _skipped = read_model_log_rows(log_path)
+        identity_registry = load_model_identity_registry(registry_path)
+    if not using_db:
+        with contextlib.suppress(Exception):
+            catalog_models = load_catalog_snapshot(catalog_path)
+    groups = enrich_model_groups_with_identity(
+        aggregate_model_log_rows(rows),
+        rows,
+        identity_registry,
+        include_task_type=True,
+    )
+    rollup = enrich_model_groups_with_identity(
+        aggregate_model_scoreboard_rows(rows),
+        rows,
+        identity_registry,
+        include_task_type=False,
+    )
+    catalog_by_id = catalog_models_by_id(catalog_models)
+    ordered_rollup: list[dict[str, Any]] = []
+    for row in order_model_scoreboard_rows(rollup, catalog_by_id):
+        item = dict(row)
+        item.setdefault("task_type", "(all)")
+        ordered_rollup.append(item)
+    return {
+        "generated_at": utc_now_iso(),
+        "groups": groups,
+        "rollup": ordered_rollup,
+    }
+
+
 def run_models_command(config: AppConfig, args: argparse.Namespace) -> int:
     log_path = (args.log or config.eval.jsonl_path).expanduser().resolve()
     since = validate_since_date(args.since)
@@ -7569,6 +7941,7 @@ def run_persistent_hud(config: AppConfig, *, port: int | None, open_viewer: bool
         preferred_port=chosen_port,
         open_viewer=open_viewer,
     )
+    server.model_log_path = config.eval.jsonl_path
     server.start()
     try:
         while True:

--- a/ringer.py
+++ b/ringer.py
@@ -4143,6 +4143,7 @@ class PersistentHudServer:
         self.thread: threading.Thread | None = None
         self.port: int | None = None
         self.model_log_path: Path | None = None
+        self.default_model_log_path: Path = state_dir / "runs.jsonl"
         self.model_db_path: Path | None = None
 
     def start(self) -> int:
@@ -4176,6 +4177,7 @@ class PersistentHudServer:
                     try:
                         payload = build_models_api_payload(
                             log_path=server_ref.model_log_path or (state_dir / "runs.jsonl"),
+                            default_log_path=server_ref.default_model_log_path,
                             db_path=server_ref.model_db_path,
                         )
                     except Exception as exc:
@@ -4716,6 +4718,17 @@ def default_model_registry_path() -> Path:
 
 def default_read_model_db_path() -> Path:
     return ringer_home() / "ringer.db"
+
+
+def should_use_read_model_db(
+    *,
+    log_path: Path,
+    default_log_path: Path,
+    explicit_db: bool,
+) -> bool:
+    if explicit_db:
+        return True
+    return log_path.expanduser().resolve() == default_log_path.expanduser().resolve()
 
 
 @dataclass(frozen=True)
@@ -6411,27 +6424,38 @@ def print_model_log_table(path: Path, rows_read: int, skipped: int, groups: list
 def build_models_api_payload(
     *,
     log_path: Path,
+    default_log_path: Path | None = None,
     db_path: Path | None = None,
     catalog_path: Path | None = None,
     registry_path: Path | None = None,
 ) -> dict[str, Any]:
     log_path = log_path.expanduser().resolve()
-    db_path = (db_path or default_read_model_db_path()).expanduser().resolve()
+    default_log_path = (default_log_path or log_path).expanduser().resolve()
+    explicit_db = db_path is not None
+    resolved_db_path = (db_path or default_read_model_db_path()).expanduser().resolve()
     catalog_path = (catalog_path or default_catalog_path()).expanduser().resolve()
     registry_path = (registry_path or default_model_registry_path()).expanduser().resolve()
-    using_db = True
+    using_db = should_use_read_model_db(
+        log_path=log_path,
+        default_log_path=default_log_path,
+        explicit_db=explicit_db,
+    )
     catalog_models: list[dict[str, Any]] = []
-    try:
-        sync_read_model_db(
-            db_path,
-            log_path,
-            catalog_path=catalog_path,
-            registry_path=registry_path,
-        )
-        rows, identity_registry = db_attempt_rows(db_path)
-        catalog_models = db_catalog_models(db_path)
-    except Exception:
-        using_db = False
+    if using_db:
+        try:
+            sync_read_model_db(
+                resolved_db_path,
+                log_path,
+                catalog_path=catalog_path,
+                registry_path=registry_path,
+            )
+            rows, identity_registry = db_attempt_rows(resolved_db_path)
+            catalog_models = db_catalog_models(resolved_db_path)
+        except Exception:
+            using_db = False
+            rows, _skipped = read_model_log_rows(log_path)
+            identity_registry = load_model_identity_registry(registry_path)
+    else:
         rows, _skipped = read_model_log_rows(log_path)
         identity_registry = load_model_identity_registry(registry_path)
     if not using_db:
@@ -6463,27 +6487,38 @@ def build_models_api_payload(
 
 
 def run_models_command(config: AppConfig, args: argparse.Namespace) -> int:
-    log_path = (args.log or config.eval.jsonl_path).expanduser().resolve()
+    default_log_path = config.eval.jsonl_path.expanduser().resolve()
+    log_path = (args.log or default_log_path).expanduser().resolve()
     since = validate_since_date(args.since)
+    explicit_db = getattr(args, "db", None) is not None
     db_path = (getattr(args, "db", None) or default_read_model_db_path()).expanduser().resolve()
     catalog_path = (getattr(args, "catalog_file", None) or default_catalog_path()).expanduser().resolve()
     registry_path = (getattr(args, "registry", None) or default_model_registry_path()).expanduser().resolve()
-    using_db = True
+    using_db = should_use_read_model_db(
+        log_path=log_path,
+        default_log_path=default_log_path,
+        explicit_db=explicit_db,
+    )
     catalog_events: list[dict[str, Any]] | None = None
-    try:
-        sync_result = sync_read_model_db(
-            db_path,
-            log_path,
-            catalog_path=catalog_path,
-            registry_path=registry_path,
-        )
-        rows, identity_registry = db_attempt_rows(db_path, since=since, engine=args.engine)
-        skipped = sync_result.skipped
-        catalog_models_from_db = db_catalog_models(db_path)
-        catalog_events = db_catalog_events(db_path, limit=6)
-    except Exception as exc:
-        using_db = False
-        print(f"models: SQLite read model unavailable; using JSONL fallback ({exc})", file=sys.stderr)
+    if using_db:
+        try:
+            sync_result = sync_read_model_db(
+                db_path,
+                log_path,
+                catalog_path=catalog_path,
+                registry_path=registry_path,
+            )
+            rows, identity_registry = db_attempt_rows(db_path, since=since, engine=args.engine)
+            skipped = sync_result.skipped
+            catalog_models_from_db = db_catalog_models(db_path)
+            catalog_events = db_catalog_events(db_path, limit=6)
+        except Exception as exc:
+            using_db = False
+            print(f"models: SQLite read model unavailable; using JSONL fallback ({exc})", file=sys.stderr)
+            rows, skipped = read_model_log_rows(log_path, since=since, engine=args.engine)
+            identity_registry = load_model_identity_registry(registry_path)
+            catalog_models_from_db = []
+    else:
         rows, skipped = read_model_log_rows(log_path, since=since, engine=args.engine)
         identity_registry = load_model_identity_registry(registry_path)
         catalog_models_from_db = []
@@ -7942,6 +7977,7 @@ def run_persistent_hud(config: AppConfig, *, port: int | None, open_viewer: bool
         open_viewer=open_viewer,
     )
     server.model_log_path = config.eval.jsonl_path
+    server.default_model_log_path = config.eval.jsonl_path
     server.start()
     try:
         while True:

--- a/ringer.py
+++ b/ringer.py
@@ -5140,18 +5140,56 @@ def model_judgment_notes(model_id: str, notes_sections: dict[str, list[str]]) ->
     return max(matches, key=lambda item: (item[0], item[1], item[2]))[3]
 
 
-def render_notes_list(items: list[str]) -> str:
+def strip_inline_markdown(value: str) -> str:
+    text = re.sub(r"`([^`]*)`", r"\1", value)
+    text = re.sub(r"\[([^\]]+)\]\([^)]+\)", r"\1", text)
+    text = re.sub(r"[*_]{1,3}([^*_]+)[*_]{1,3}", r"\1", text)
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def normalized_judgment_note(item: str) -> tuple[str, str] | None:
+    text = re.sub(r"\s+", " ", item).strip()
+    match = re.match(r"^-?\s*(\d{4}-\d{2}-\d{2})\s+(?:[-\u2013\u2014]+\s*)?(.*)$", text)
+    if not match:
+        return None
+    body = strip_inline_markdown(match.group(2))
+    if not body:
+        return None
+    date = humanized_log_date(match.group(1))
+    short_date = re.sub(r",\s*\d{4}$", "", date)
+    return short_date, body
+
+
+def note_date_key(item: str) -> str:
+    match = re.search(r"\b\d{4}-\d{2}-\d{2}\b", item)
+    return match.group(0) if match else ""
+
+
+def render_notes_list(items: list[str], *, notes_path: Path | None = None, limit: int = 5) -> str:
     if not items:
         return '<p class="empty-note">no judgment notes yet</p>'
+    ordered_items = sorted(items, key=note_date_key, reverse=True)
     rendered = []
-    for item in items:
-        text = "<br>".join(
-            html_escape(humanize_dates_in_text(line))
-            for line in item.splitlines()
-            if line.strip()
+    for item in ordered_items[:limit]:
+        note = normalized_judgment_note(item)
+        if note is None:
+            body = strip_inline_markdown(item)
+            if not body:
+                continue
+            rendered.append(f"<li><span>{html_escape(body)}</span></li>")
+            continue
+        date, body = note
+        rendered.append(
+            f'<li><time>{html_escape(date)}</time><span>{html_escape(body)}</span></li>'
         )
-        rendered.append(f"<li>{text}</li>")
-    return f'<ul class="notes-list">{"".join(rendered)}</ul>'
+    if not rendered:
+        return '<p class="empty-note">no judgment notes yet</p>'
+    more = ""
+    if len(ordered_items) > limit and notes_path is not None:
+        more = (
+            f'<li class="more-notes">{source_file_link(notes_path, "more in model notes")}</li>'
+        )
+    return f'<ul class="notes-list">{"".join(rendered)}{more}</ul>'
 
 
 def normalize_catalog_for_scoreboard(model: dict[str, Any]) -> dict[str, Any]:
@@ -5356,6 +5394,20 @@ def fmt_task_cost(value: float | None) -> str:
     return f"${value:.2f}/task"
 
 
+def fmt_short_task_cost(value: float | None) -> str:
+    if value is None:
+        return "in plan"
+    if value == 0:
+        return "free"
+    if value < 0.10:
+        cents = value * 100
+        if cents < 1:
+            return "<1¢"
+        rounded = round(cents)
+        return f"~{rounded}¢"
+    return f"${value:.2f}"
+
+
 def humanized_log_date(value: Any, *, prefix: str = "") -> str:
     text = model_log_text(value)
     if not text:
@@ -5385,32 +5437,117 @@ def source_file_link(path: Path, label: str) -> str:
     )
 
 
-def catalog_cost_html(row: dict[str, Any], catalog_model: dict[str, Any] | None) -> str:
+def model_task_cost_label(row: dict[str, Any], catalog_model: dict[str, Any] | None) -> str:
     median_tokens = row.get("median_tokens")
-    if catalog_model is None:
-        if median_tokens is None:
-            return '<span class="cost-line">included in plan</span>'
-        return '<span class="cost-line muted">catalog missing</span>'
     if median_tokens is None:
-        return '<span class="cost-line">included in plan</span>'
+        return "in plan"
+    if catalog_model is None:
+        return "catalog missing"
     if catalog_model.get("free"):
-        return '<span class="flag free">FREE</span>'
-    variable = bool(catalog_model.get("variable_pricing"))
-    in_price = format_catalog_price(catalog_model.get("prompt_per_m"), variable=variable)
-    out_price = format_catalog_price(catalog_model.get("completion_per_m"), variable=variable)
-    if variable:
-        pieces = [f'<span class="cost-line">{html_escape(in_price)} $/M in · {html_escape(out_price)} $/M out</span>']
+        return "free"
+    if catalog_model.get("variable_pricing"):
+        return "var"
+    return fmt_short_task_cost(estimated_task_cost(row, catalog_model))
+
+
+def rate_bar_html(value: Any) -> str:
+    try:
+        pct = max(0.0, min(100.0, float(value) * 100))
+    except (TypeError, ValueError):
+        pct = 0.0
+    return (
+        '<span class="rate-meter" aria-hidden="true">'
+        f'<span class="rate-bar bar-fill" style="width: {pct:.0f}%"></span>'
+        "</span>"
+    )
+
+
+def rate_cell_html(value: Any) -> str:
+    return (
+        f'<span class="rate-value">{html_escape(fmt_percent(value))}</span>'
+        f"{rate_bar_html(value)}"
+    )
+
+
+def compact_context_label(value: Any) -> str:
+    try:
+        ctx = int(value)
+    except (TypeError, ValueError):
+        return "unknown ctx"
+    if ctx >= 1_000_000 and ctx % 1_000_000 == 0:
+        return f"{ctx // 1_000_000}M ctx"
+    if ctx >= 1_000:
+        if ctx % 1_000 == 0:
+            return f"{ctx // 1_000}K ctx"
+        return f"{ctx / 1000:.1f}K ctx"
+    return f"{ctx} ctx"
+
+
+def short_model_name(value: Any) -> str:
+    text = str(value or "").strip()
+    if not text:
+        return "unknown"
+    text = text.removeprefix("openrouter/")
+    text = text.removesuffix(":free")
+    if "/" in text:
+        text = text.rsplit("/", 1)[-1]
+    text = re.sub(r"[-_]+", " ", text)
+    text = re.sub(r"\s+", " ", text).strip()
+    if not text:
+        return "unknown"
+    parts = []
+    for part in text.split():
+        parts.append(part.upper() if part.lower() in {"gpt", "glm", "ai", "llm"} else part.capitalize())
+    return " ".join(parts)
+
+
+def catalog_model_display_name(model: dict[str, Any]) -> str:
+    name = str(model.get("name") or "").strip()
+    model_id = str(model.get("id") or "").strip()
+    if name and name != model_id:
+        return name.removesuffix(" (free)").strip()
+    return short_model_name(model_id)
+
+
+def humanized_short_date(value: Any) -> str:
+    return re.sub(r",\s*\d{4}$", "", humanized_log_date(value))
+
+
+def humanized_catalog_event_line(event: dict[str, Any], catalog_by_id: dict[str, dict[str, Any]]) -> str:
+    model_id = str(event.get("id") or "")
+    if model_id in catalog_by_id:
+        label = catalog_model_display_name(catalog_by_id[model_id])
     else:
-        pieces = [f'<span class="cost-line">${html_escape(in_price)}/M in · ${html_escape(out_price)}/M out</span>']
-    if catalog_model.get("free"):
-        pieces.append('<span class="flag free">FREE</span>')
-    if variable:
-        pieces.append('<span class="flag">var</span>')
-    est = estimated_task_cost(row, catalog_model)
-    est_text = fmt_task_cost(est)
-    if est_text:
-        pieces.append(f'<span class="cost-line">{html_escape(est_text)}</span>')
-    return " ".join(pieces)
+        label = short_model_name(model_id)
+    kind = str(event.get("kind") or "event")
+    date = humanized_short_date(event.get("ts"))
+    if kind == "went_free":
+        action = "went free"
+    elif kind == "went_paid":
+        action = "went paid"
+    elif kind == "pricing_variable":
+        action = "moved to variable pricing"
+    elif kind == "pricing_fixed":
+        action = "returned to fixed pricing"
+    elif kind == "added":
+        action = "was added"
+    elif kind == "removed":
+        action = "was removed"
+    else:
+        action = kind.replace("_", " ")
+    return f"{label} {action} — {date}"
+
+
+def watchlist_chip_html(model: dict[str, Any]) -> str:
+    model_id = str(model.get("id") or "").strip()
+    label = catalog_model_display_name(model)
+    context = compact_context_label(model.get("context_length"))
+    title = model_id or label
+    return (
+        '<li class="watch-chip">'
+        f'<span data-model="{html_escape(model_id)}" title="{html_escape(title)}">'
+        f"{html_escape(label)} · {html_escape(context)}</span></li>"
+    )
 
 
 def derived_quality_text(row: dict[str, Any], *, best: bool) -> str:
@@ -5438,9 +5575,9 @@ def render_task_breakdown_table(task_rows: list[dict[str, Any]]) -> str:
         rows.append(
             f"""<tr>
       <td>{html_escape(str(item.get("task_type") or ""))}</td>
-      <td class="mono">{fmt_int(item.get("tasks"))}</td>
-      <td class="mono">{fmt_percent(item.get("first_try_pass_rate"))}</td>
-      <td class="mono">{fmt_percent(item.get("pass_rate"))}</td>
+      <td class="num">{fmt_int(item.get("tasks"))}</td>
+      <td class="num rate-cell">{rate_cell_html(item.get("first_try_pass_rate"))}</td>
+      <td class="num rate-cell">{rate_cell_html(item.get("pass_rate"))}</td>
     </tr>"""
         )
     return f"""<table class="breakdown">
@@ -5450,112 +5587,214 @@ def render_task_breakdown_table(task_rows: list[dict[str, Any]]) -> str:
 
 
 MODEL_SCOREBOARD_CSS = """
-  .scoreboard-page { max-width: 1180px; }
-  .scoreboard-briefing { max-width: 44ch; }
-  .source-grid {
+  .scoreboard-page { max-width: 1240px; }
+  .scoreboard-header {
     display: grid;
-    grid-template-columns: repeat(4, minmax(0, 1fr));
-    gap: 10px;
-    margin: 0 0 clamp(18px, 3vw, 28px);
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 18px;
+    align-items: end;
+    margin-bottom: clamp(14px, 2.5vw, 22px);
   }
-  .source-box {
-    border: 1px solid var(--hairline);
-    background: color-mix(in srgb, var(--surface) 76%, transparent);
-    padding: 12px;
-    min-width: 0;
+  .scoreboard-title {
+    margin: 0;
+    font-size: clamp(28px, 5vw, 54px);
+    line-height: .98;
+    letter-spacing: 0;
+    text-wrap: balance;
   }
-  .source-box b { display: block; font-size: 12px; color: var(--muted); }
-  .source-box span { display: block; overflow-wrap: anywhere; }
-  .source-link { color: var(--accent); text-decoration: none; }
-  .source-link:hover { text-decoration: underline; }
+  .scoreboard-meta {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 12px;
+    flex-wrap: wrap;
+    color: var(--muted);
+    font-size: 12px;
+  }
+  .source-links {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    flex-wrap: wrap;
+  }
+  .source-link {
+    color: var(--ink);
+    text-decoration: none;
+    border-bottom: 1px solid var(--hairline);
+  }
+  .source-link:hover { border-bottom-color: var(--ink); }
   .watchlist {
     border-top: 1px solid var(--hairline);
     border-bottom: 1px solid var(--hairline);
-    padding: 14px 0;
-    margin: 0 0 18px;
+    padding: 12px 0;
+    margin: 0 0 clamp(18px, 3vw, 28px);
+    color: var(--muted);
+    font-size: 13px;
   }
-  .watchlist h2, .models h2 {
-    margin: 0 0 10px;
-    font-size: 16px;
-  }
-  .watch-grid {
-    display: grid;
-    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
-    gap: 16px;
-  }
-  .tag-list {
+  .watchline {
     display: flex;
+    align-items: center;
+    gap: 10px;
     flex-wrap: wrap;
-    gap: 8px;
+  }
+  .watch-title { color: var(--ink); font-weight: 650; }
+  .watch-chips, .event-list {
+    display: contents;
     margin: 0;
     padding: 0;
     list-style: none;
   }
-  .tag-list li, .flag {
+  .watch-chip {
     border: 1px solid var(--hairline);
-    padding: 3px 7px;
+    padding: 3px 7px 4px;
     font-size: 12px;
     color: var(--ink);
     background: rgba(255, 255, 255, .03);
   }
-  .flag.free { color: var(--pass); border-color: color-mix(in srgb, var(--pass) 55%, var(--hairline)); }
-  .event-list { margin: 0; padding-left: 18px; color: var(--muted); }
-  .model-card {
+  .event-list li {
+    color: var(--muted);
+  }
+  .event-list li::before {
+    content: "/";
+    color: var(--hairline);
+    margin: 0 8px 0 2px;
+  }
+  .table-scroll {
+    overflow-x: auto;
     border: 1px solid var(--hairline);
-    background: var(--surface);
-    margin: 12px 0;
+    border-left: 0;
+    border-right: 0;
   }
-  .model-summary {
-    display: grid;
-    grid-template-columns: minmax(70px, .45fr) minmax(240px, 1.6fr) minmax(180px, .9fr) minmax(170px, .9fr);
-    gap: 12px;
-    padding: 14px;
-    align-items: start;
-  }
-  .rank { font-size: 24px; font-weight: 800; line-height: 1; }
-  .tier { color: var(--muted); font-size: 13px; margin-top: 4px; }
-  .model-name { font-size: 19px; font-weight: 800; overflow-wrap: anywhere; }
-  .model-id { color: var(--muted); font-size: 12px; overflow-wrap: anywhere; margin-top: 3px; }
-  .identity-grid {
-    display: grid;
-    gap: 6px;
+  .ranked-table {
+    width: 100%;
+    min-width: 1040px;
+    border-collapse: collapse;
     font-size: 13px;
   }
-  .identity-grid b {
-    display: block;
+  .ranked-table th {
+    color: var(--muted);
+    font-size: 11px;
+    font-weight: 650;
+    letter-spacing: .08em;
+    text-transform: uppercase;
+    text-align: left;
+    padding: 10px 12px;
+    border-bottom: 1px solid var(--hairline);
+    white-space: nowrap;
+  }
+  .ranked-table td {
+    padding: 17px 12px;
+    border-bottom: 1px solid var(--hairline);
+    vertical-align: middle;
+    color: var(--ink);
+  }
+  .ranked-table tr.model-row:hover td {
+    background: color-mix(in srgb, var(--surface) 48%, transparent);
+  }
+  .rank-cell {
+    width: 58px;
+    font-size: 16px;
+    font-weight: 760;
+  }
+  .model-cell { min-width: 230px; }
+  .model-name {
+    font-size: 16px;
+    font-weight: 760;
+    line-height: 1.2;
+    overflow-wrap: anywhere;
+  }
+  .model-id {
+    margin-top: 3px;
     color: var(--muted);
     font-size: 12px;
+    overflow-wrap: anywhere;
+  }
+  .tier-badge {
+    display: inline-flex;
+    align-items: center;
+    min-width: 78px;
+    justify-content: center;
+    padding: 3px 8px 4px;
+    border-radius: 4px;
+    font-size: 12px;
     font-weight: 700;
+    color: var(--ink);
+    border: 1px solid transparent;
   }
-  .metric-row {
-    display: flex;
-    gap: 10px;
-    flex-wrap: wrap;
-    margin-top: 8px;
-    color: var(--muted);
-    font-size: 13px;
+  .tier-badge.proven {
+    background: color-mix(in srgb, var(--pass) 30%, transparent);
+    border-color: color-mix(in srgb, var(--pass) 58%, var(--hairline));
   }
-  .metric-row b { color: var(--ink); }
-  .cost-line { display: inline-block; margin: 0 8px 6px 0; }
-  .quality {
-    color: var(--muted);
-    font-size: 13px;
+  .tier-badge.probation {
+    background: color-mix(in srgb, var(--accent) 24%, transparent);
+    border-color: color-mix(in srgb, var(--accent) 48%, var(--hairline));
   }
-  .quality b { color: var(--ink); }
+  .num {
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+  }
+  .rate-cell {
+    min-width: 108px;
+  }
+  .rate-value {
+    display: inline-block;
+    min-width: 38px;
+  }
+  .rate-meter {
+    display: inline-block;
+    width: 48px;
+    height: 6px;
+    margin-left: 8px;
+    vertical-align: 1px;
+    border-radius: 4px;
+    background: color-mix(in srgb, var(--muted) 22%, transparent);
+    overflow: hidden;
+  }
+  .rate-bar {
+    display: block;
+    height: 100%;
+    border-radius: 4px;
+    background: var(--pass);
+  }
+  .detail-row td {
+    padding: 0;
+    background: color-mix(in srgb, var(--surface) 55%, transparent);
+  }
   .model-detail {
-    border-top: 1px solid var(--hairline);
-    padding: 0 14px 14px;
+    padding: 0;
   }
   .model-detail summary {
     cursor: pointer;
-    color: var(--accent);
-    padding: 10px 0;
+    color: var(--ink);
+    padding: 11px 12px;
+    font-size: 13px;
+    border-bottom: 1px solid var(--hairline);
+  }
+  .model-detail summary:hover { background: color-mix(in srgb, var(--surface) 70%, transparent); }
+  .detail-content {
+    display: grid;
+    grid-template-columns: minmax(0, .86fr) minmax(260px, 1.14fr);
+    gap: 22px;
+    padding: 16px 12px 20px;
+  }
+  .detail-heading {
+    margin: 0 0 8px;
+    color: var(--muted);
+    font-size: 11px;
+    font-weight: 650;
+    letter-spacing: .08em;
+    text-transform: uppercase;
+  }
+  .quality-lines {
+    display: grid;
+    gap: 6px;
+    margin: 12px 0 0;
+    color: var(--muted);
     font-size: 13px;
   }
-  .detail-grid {
-    display: grid;
-    grid-template-columns: minmax(0, .95fr) minmax(0, 1.05fr);
-    gap: 16px;
+  .quality-lines b { color: var(--ink); }
+  .notes-panel {
+    min-width: 0;
   }
   .breakdown {
     width: 100%;
@@ -5564,16 +5803,55 @@ MODEL_SCOREBOARD_CSS = """
   }
   .breakdown th, .breakdown td {
     border-bottom: 1px solid var(--hairline);
-    padding: 7px 6px;
+    padding: 8px 6px;
     text-align: left;
   }
-  .notes-list { margin: 0; padding-left: 18px; color: var(--ink); }
-  .notes-list li { margin: 0 0 8px; }
+  .breakdown th {
+    color: var(--muted);
+    font-weight: 650;
+  }
+  .notes-list {
+    display: grid;
+    gap: 10px;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    color: var(--ink);
+  }
+  .notes-list li {
+    display: grid;
+    grid-template-columns: 72px minmax(0, 1fr);
+    gap: 12px;
+    align-items: baseline;
+  }
+  .notes-list time {
+    color: var(--muted);
+    font-size: 11px;
+    font-variant-caps: all-small-caps;
+    letter-spacing: .08em;
+    white-space: nowrap;
+  }
+  .more-notes {
+    color: var(--muted);
+    font-size: 12px;
+  }
+  .empty-note { color: var(--muted); margin: 0; }
   .muted { color: var(--muted); }
   .mono { font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace; }
+  footer.scoreboard-footer {
+    margin-top: 14px;
+    color: var(--muted);
+    font-size: 12px;
+  }
+  @media (prefers-color-scheme: dark) {
+    .watch-chip { background: rgba(255, 255, 255, .035); }
+  }
   @media (max-width: 820px) {
-    .source-grid, .watch-grid, .detail-grid, .model-summary { grid-template-columns: 1fr; }
-    .rank { font-size: 20px; }
+    body { padding: 18px 14px; }
+    .scoreboard-header, .detail-content { grid-template-columns: 1fr; }
+    .scoreboard-meta { justify-content: flex-start; }
+    .table-scroll { margin-left: -14px; margin-right: -14px; padding-left: 14px; }
+    .notes-list li { grid-template-columns: 1fr; gap: 2px; }
   }
 """
 
@@ -5585,90 +5863,83 @@ def render_free_watchlist(
     events: list[dict[str, Any]] | None = None,
 ) -> str:
     normalized = [normalize_catalog_for_scoreboard(model) for model in catalog_models]
+    catalog_by_id = catalog_models_by_id(normalized)
     free_models = sorted(
         (model for model in normalized if model.get("free")),
         key=lambda item: (-int(item.get("context_length") or 0), str(item.get("id") or "")),
     )
     if free_models:
         free_items = "".join(
-            f"<li>{html_escape(str(model.get('id') or ''))} · {fmt_int(model.get('context_length'))} ctx</li>"
-            for model in free_models[:12]
+            watchlist_chip_html(model)
+            for model in free_models[:6]
         )
     else:
-        free_items = '<li class="muted">no FREE catalog models in the current snapshot</li>'
+        free_items = '<li class="muted">no free catalog models in the current snapshot</li>'
     if events is None:
         events = read_catalog_events(catalog_changes_path(catalog_path), limit=6)
     event_items = "".join(
-        f"<li>{html_escape(describe_catalog_event_humanized(event))}</li>"
-        for event in events[:6]
+        f"<li>{html_escape(humanized_catalog_event_line(event, catalog_by_id))}</li>"
+        for event in events[:3]
     )
     if not event_items:
         event_items = '<li class="muted">no catalog change log found</li>'
-    return f"""<section class="watchlist" aria-labelledby="watchlist-heading">
-    <h2 id="watchlist-heading">Free promo watchlist</h2>
-    <div class="watch-grid">
-      <div><ul class="tag-list">{free_items}</ul></div>
-      <div><ol class="event-list">{event_items}</ol></div>
+    return f"""<section class="watchlist" aria-label="free model watchlist">
+    <div class="watchline">
+      <span class="watch-title">{fmt_int(len(free_models))} models free on OpenRouter right now</span>
+      <ul class="watch-chips">{free_items}</ul>
+      <ul class="event-list">{event_items}</ul>
     </div>
   </section>"""
 
 
-def render_model_card(
+def render_model_table_pair(
     row: dict[str, Any],
     *,
     rank: int,
     catalog_model: dict[str, Any] | None,
     notes_sections: dict[str, list[str]],
+    notes_path: Path,
 ) -> str:
     model_id = str(row.get("model") or "")
     model_display = str(row.get("model_display") or model_id)
     harness = str(row.get("harness") or "unknown")
     access = str(row.get("access") or "unknown")
     notes = model_judgment_notes(model_id, notes_sections)
-    median_tokens = "none" if row.get("median_tokens") is None else fmt_int(row.get("median_tokens"))
     model_id_line = "" if model_id == model_display else f'<div class="model-id">{html_escape(model_id)}</div>'
-    return f"""<article class="model-card" id="model-{html_escape(sanitize_artifact_name(model_id))}">
-  <div class="model-summary">
-    <div>
-      <div class="rank">#{rank}</div>
-      <div class="tier">{html_escape(str(row.get("tier") or ""))}</div>
-    </div>
-    <div>
-      <div class="model-name">{html_escape(model_display)}</div>
-      {model_id_line}
-      <div class="metric-row">
-        <span><b>n={fmt_int(row.get("tasks"))}</b> tasks</span>
-        <span><b>{fmt_int(row.get("attempts"))}</b> attempts</span>
-        <span><b>{fmt_int(row.get("retries"))}</b> retries</span>
-        <span><b>{fmt_percent(row.get("first_try_pass_rate"))}</b> first-try</span>
-        <span><b>{fmt_percent(row.get("pass_rate"))}</b> pass</span>
-      </div>
-      <div class="metric-row">
-        <span><b>{html_escape(humanized_log_date(row.get("last_seen"), prefix="last used: "))}</b></span>
-        <span>median worker_tokens <b>{html_escape(median_tokens)}</b></span>
-      </div>
-    </div>
-    <div class="identity-grid">
-      <span><b>Harness</b>{html_escape(harness)}</span>
-      <span><b>API-Plan</b>{html_escape(access)}</span>
-      <span><b>Cost</b>{catalog_cost_html(row, catalog_model)}</span>
-    </div>
-    <div class="quality">
-      <div><b>Best:</b> {html_escape(derived_quality_text(row, best=True))}</div>
-      <div><b>Worst:</b> {html_escape(derived_quality_text(row, best=False))}</div>
-    </div>
-  </div>
-  <details class="model-detail" open>
-    <summary>usage and judgment notes</summary>
-    <div class="detail-grid">
-      <div>{render_task_breakdown_table(row.get("task_types", []))}</div>
-      <div>
-        <div class="tier">judgment notes from MODEL-NOTES.md</div>
-        {render_notes_list(notes)}
-      </div>
-    </div>
-  </details>
-</article>"""
+    tier = str(row.get("tier") or "")
+    return f"""<tr class="model-row" id="model-{html_escape(sanitize_artifact_name(model_id))}">
+      <td class="rank-cell num">{rank}</td>
+      <td class="model-cell"><div class="model-name">{html_escape(model_display)}</div>{model_id_line}</td>
+      <td>{html_escape(harness)}</td>
+      <td>{html_escape(access)}</td>
+      <td><span class="tier-badge {html_escape(tier)}">{html_escape(tier)}</span></td>
+      <td class="num">{fmt_int(row.get("tasks"))}</td>
+      <td class="num rate-cell">{rate_cell_html(row.get("first_try_pass_rate"))}</td>
+      <td class="num rate-cell">{rate_cell_html(row.get("pass_rate"))}</td>
+      <td class="num">{html_escape(model_task_cost_label(row, catalog_model))}</td>
+      <td>{html_escape(humanized_log_date(row.get("last_seen")))}</td>
+    </tr>
+    <tr class="detail-row">
+      <td colspan="10">
+        <details class="model-detail">
+          <summary>details for {html_escape(model_display)}</summary>
+          <div class="detail-content">
+            <div>
+              <h3 class="detail-heading">Task types</h3>
+              {render_task_breakdown_table(row.get("task_types", []))}
+              <div class="quality-lines">
+                <div><b>Best:</b> {html_escape(derived_quality_text(row, best=True))}</div>
+                <div><b>Worst:</b> {html_escape(derived_quality_text(row, best=False))}</div>
+              </div>
+            </div>
+            <div class="notes-panel">
+              <h3 class="detail-heading">Judgment notes</h3>
+              {render_notes_list(notes, notes_path=notes_path)}
+            </div>
+          </div>
+        </details>
+      </td>
+    </tr>"""
 
 
 def render_model_scoreboard_html(
@@ -5687,17 +5958,18 @@ def render_model_scoreboard_html(
     catalog_by_id = catalog_models_by_id(catalog_models)
     ordered = order_model_scoreboard_rows(rows, catalog_by_id)
     generated = generated_at or datetime.now(timezone.utc).replace(microsecond=0).isoformat()
-    cards = "".join(
-        render_model_card(
+    table_rows = "".join(
+        render_model_table_pair(
             row,
             rank=index,
             catalog_model=catalog_by_id.get(str(row.get("model") or "")),
             notes_sections=notes_sections,
+            notes_path=notes_path,
         )
         for index, row in enumerate(ordered, start=1)
     )
-    if not cards:
-        cards = '<p class="empty-note">No local model evidence matched these filters.</p>'
+    if not table_rows:
+        table_rows = '<tr><td colspan="10" class="muted">No local model evidence matched these filters.</td></tr>'
     return f"""<!doctype html>
 <html lang="en">
 <head>
@@ -5709,27 +5981,41 @@ def render_model_scoreboard_html(
 </head>
 <body>
 <div class="page scoreboard-page">
-  <header class="corner">
-    <span class="live-dot pass" aria-hidden="true"></span>
-    <span class="eyebrow">Ringer &nbsp;·&nbsp; <b>model-scoreboard</b></span>
-    <span class="clock">Generated {html_escape(humanized_log_date(generated))}</span>
+  <header class="scoreboard-header">
+    <h1 class="scoreboard-title">Model performance scoreboard</h1>
+    <div class="scoreboard-meta">
+      <span>Generated {html_escape(humanized_log_date(generated))}</span>
+      <nav class="source-links" aria-label="scoreboard source files">
+        {source_file_link(log_path, "eval log")}
+        {source_file_link(catalog_path, "catalog")}
+        {source_file_link(notes_path, "model notes")}
+      </nav>
+    </div>
   </header>
-  <h1 class="briefing scoreboard-briefing">Model performance scoreboard</h1>
-  <section class="source-grid" aria-label="scoreboard sources">
-    <div class="source-box"><b>Log</b><span>{source_file_link(log_path, "eval log")}</span></div>
-    <div class="source-box"><b>Catalog</b><span>{source_file_link(catalog_path, "catalog")}</span></div>
-    <div class="source-box"><b>Notes</b><span>{source_file_link(notes_path, "model notes")}</span></div>
-    <div class="source-box"><b>Models</b><span>{fmt_int(len(ordered))} ranked</span></div>
-  </section>
   {render_free_watchlist(catalog_models, catalog_path, events=catalog_events)}
-  <section class="models" aria-labelledby="models-heading">
-    <h2 id="models-heading">Ranked models</h2>
-    {cards}
-  </section>
-  <footer>
-    <span>Ranking sorts by evidence tier first: proven n>=3, then probation; ties use first-try pass rate, pass rate, then lower estimated cost.</span>
-    <span>Cost estimate assumes logged worker_tokens are split 50/50 between prompt and completion tokens, using the catalog $/M in/out blend.</span>
-    <span>{fmt_int(rows_read)} rows read, {fmt_int(skipped)} skipped lines.</span>
+  <main>
+    <div class="table-scroll">
+      <table class="ranked-table">
+        <thead>
+          <tr>
+            <th>Rank</th>
+            <th>Model</th>
+            <th>Harness</th>
+            <th>API/Plan</th>
+            <th>Tier</th>
+            <th class="num">Tasks</th>
+            <th class="num">First-try</th>
+            <th class="num">Pass</th>
+            <th class="num">Est. $/task</th>
+            <th>Last used</th>
+          </tr>
+        </thead>
+        <tbody>{table_rows}</tbody>
+      </table>
+    </div>
+  </main>
+  <footer class="scoreboard-footer">
+    <span>{fmt_int(rows_read)} rows read, {fmt_int(skipped)} skipped lines. Ranking sorts by evidence tier first: proven n&gt;=3, then probation; ties use first-try pass rate, pass rate, then lower estimated cost. Cost estimate assumes logged worker_tokens are split 50/50 between prompt and completion tokens, using the catalog $/M in/out blend.</span>
   </footer>
 </div>
 </body>

--- a/ringer.py
+++ b/ringer.py
@@ -4918,15 +4918,40 @@ def connect_read_model_db(path: Path) -> Any:
     return conn
 
 
+def connect_read_model_db_readonly(path: Path) -> Any:
+    sqlite = ensure_sqlite_available()
+    path = path.expanduser().resolve()
+    if not path.exists():
+        raise RuntimeError(f"read model database missing: {path}")
+    uri_path = urllib.parse.quote(path.as_posix(), safe="/")
+    conn = sqlite.connect(f"file:{uri_path}?mode=ro", uri=True)
+    conn.row_factory = sqlite.Row
+    conn.execute("PRAGMA busy_timeout=5000")
+    return conn
+
+
+def read_model_table_exists(conn: Any, name: str) -> bool:
+    row = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?",
+        (name,),
+    ).fetchone()
+    return row is not None
+
+
 def create_read_model_schema(conn: Any) -> None:
+    schema_table_exists = read_model_table_exists(conn, "schema_version")
+    user_version = int(conn.execute("PRAGMA user_version").fetchone()[0] or 0)
+    schema_version = None
+    if schema_table_exists:
+        row = conn.execute("SELECT version FROM schema_version LIMIT 1").fetchone()
+        if row is not None:
+            schema_version = int(row[0])
+    needs_stamp = user_version != 1 or schema_version != 1
     conn.executescript(
         """
         CREATE TABLE IF NOT EXISTS schema_version (
             version INTEGER NOT NULL
         );
-        DELETE FROM schema_version;
-        INSERT INTO schema_version(version) VALUES (1);
-        PRAGMA user_version = 1;
 
         CREATE TABLE IF NOT EXISTS attempts (
             id INTEGER PRIMARY KEY,
@@ -4988,6 +5013,14 @@ def create_read_model_schema(conn: Any) -> None:
         );
         """
     )
+    if needs_stamp:
+        conn.executescript(
+            """
+            DELETE FROM schema_version;
+            INSERT INTO schema_version(version) VALUES (1);
+            PRAGMA user_version = 1;
+            """
+        )
 
 
 def drop_read_model_tables(conn: Any) -> None:
@@ -5011,7 +5044,14 @@ def read_log_rows_from_offset(path: Path, offset: int) -> tuple[list[dict[str, A
     try:
         with path.open("rb") as fh:
             fh.seek(offset)
-            for raw_line in fh:
+            while True:
+                line_start = fh.tell()
+                raw_line = fh.readline()
+                if not raw_line:
+                    break
+                if not raw_line.endswith(b"\n"):
+                    final_offset = line_start
+                    break
                 final_offset = fh.tell()
                 try:
                     line = raw_line.decode("utf-8")
@@ -5026,6 +5066,32 @@ def read_log_rows_from_offset(path: Path, offset: int) -> tuple[list[dict[str, A
     except FileNotFoundError:
         return [], 0, 0
     return rows, skipped, final_offset
+
+
+def read_catalog_events_from_offset(path: Path, offset: int) -> tuple[list[dict[str, Any]], int]:
+    events: list[dict[str, Any]] = []
+    final_offset = offset
+    try:
+        with path.expanduser().open("rb") as fh:
+            fh.seek(offset)
+            while True:
+                line_start = fh.tell()
+                raw_line = fh.readline()
+                if not raw_line:
+                    break
+                if not raw_line.endswith(b"\n"):
+                    final_offset = line_start
+                    break
+                final_offset = fh.tell()
+                try:
+                    event = json.loads(raw_line.decode("utf-8"))
+                except (UnicodeDecodeError, json.JSONDecodeError):
+                    continue
+                if isinstance(event, dict):
+                    events.append(event)
+    except FileNotFoundError:
+        return [], 0
+    return events, final_offset
 
 
 def insert_attempt_rows(conn: Any, rows: list[dict[str, Any]]) -> int:
@@ -5060,47 +5126,41 @@ def insert_attempt_rows(conn: Any, rows: list[dict[str, Any]]) -> int:
     return len(payloads)
 
 
-def refresh_catalog_tables(conn: Any, catalog_path: Path) -> None:
-    conn.execute("DELETE FROM catalog_models")
-    try:
-        catalog_models = load_catalog_snapshot(catalog_path)
-    except (OSError, json.JSONDecodeError, ValueError):
-        catalog_models = []
-    payloads: list[tuple[Any, ...]] = []
-    for model in catalog_models:
-        normalized = normalize_catalog_for_scoreboard(model)
-        model_id = model_log_text(normalized.get("id"))
-        if not model_id:
-            continue
-        payloads.append(
-            (
-                model_id,
-                model_log_text(normalized.get("name")),
-                model_log_int(normalized.get("context_length")),
-                normalized.get("prompt_per_m"),
-                normalized.get("completion_per_m"),
-                1 if normalized.get("free") else 0,
-                1 if normalized.get("variable_pricing") else 0,
-                1 if normalized.get("pricing_unknown") else 0,
-                model_log_text(normalized.get("fetched_at")),
-                model_log_text(normalized.get("modality")),
-            )
-        )
-    if payloads:
-        conn.executemany(
-            """
-            INSERT INTO catalog_models (
-                id, name, context_length, prompt_per_m, completion_per_m, free,
-                variable_pricing, pricing_unknown, fetched_at, modality
-            )
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-            """,
-            payloads,
-        )
+def read_sync_state_value(conn: Any, key: str) -> str | None:
+    row = conn.execute("SELECT value FROM sync_state WHERE key = ?", (key,)).fetchone()
+    if row is None:
+        return None
+    return str(row["value"])
 
-    conn.execute("DELETE FROM catalog_events")
+
+def read_sync_state_int(conn: Any, key: str, default: int = 0) -> int:
+    value = read_sync_state_value(conn, key)
+    if value is None:
+        return default
+    try:
+        return int(value)
+    except ValueError:
+        return default
+
+
+def write_sync_state_values(conn: Any, values: dict[str, int | str]) -> None:
+    conn.executemany(
+        "INSERT OR REPLACE INTO sync_state(key, value) VALUES (?, ?)",
+        [(key, str(value)) for key, value in values.items()],
+    )
+
+
+def file_sync_metadata(path: Path) -> tuple[int, int]:
+    try:
+        stat = path.expanduser().stat()
+    except FileNotFoundError:
+        return -1, 0
+    return int(stat.st_mtime_ns), int(stat.st_size)
+
+
+def insert_catalog_event_rows(conn: Any, events: list[dict[str, Any]]) -> int:
     event_payloads: list[tuple[Any, ...]] = []
-    for event in read_catalog_events(catalog_changes_path(catalog_path), limit=10_000_000):
+    for event in events:
         event_payloads.append(
             (
                 model_log_text(event.get("ts")),
@@ -5113,6 +5173,93 @@ def refresh_catalog_tables(conn: Any, catalog_path: Path) -> None:
         conn.executemany(
             "INSERT INTO catalog_events(ts, kind, model_id, payload) VALUES (?, ?, ?, ?)",
             event_payloads,
+        )
+    return len(event_payloads)
+
+
+def refresh_catalog_tables(conn: Any, catalog_path: Path) -> None:
+    catalog_path = catalog_path.expanduser().resolve()
+    changes_path = catalog_changes_path(catalog_path)
+    catalog_mtime, catalog_size = file_sync_metadata(catalog_path)
+    changes_mtime, changes_size = file_sync_metadata(changes_path)
+    catalog_unchanged = (
+        read_sync_state_int(conn, "catalog_snapshot_mtime_ns", -2) == catalog_mtime
+        and read_sync_state_int(conn, "catalog_snapshot_size", -2) == catalog_size
+    )
+    changes_unchanged = (
+        read_sync_state_int(conn, "catalog_changes_mtime_ns", -2) == changes_mtime
+        and read_sync_state_int(conn, "catalog_changes_size", -2) == changes_size
+    )
+    if catalog_unchanged and changes_unchanged:
+        return
+
+    if not catalog_unchanged:
+        conn.execute("DELETE FROM catalog_models")
+        try:
+            catalog_models = load_catalog_snapshot(catalog_path)
+        except (OSError, json.JSONDecodeError, ValueError):
+            catalog_models = []
+        payloads: list[tuple[Any, ...]] = []
+        for model in catalog_models:
+            normalized = normalize_catalog_for_scoreboard(model)
+            model_id = model_log_text(normalized.get("id"))
+            if not model_id:
+                continue
+            payloads.append(
+                (
+                    model_id,
+                    model_log_text(normalized.get("name")),
+                    model_log_int(normalized.get("context_length")),
+                    normalized.get("prompt_per_m"),
+                    normalized.get("completion_per_m"),
+                    1 if normalized.get("free") else 0,
+                    1 if normalized.get("variable_pricing") else 0,
+                    1 if normalized.get("pricing_unknown") else 0,
+                    model_log_text(normalized.get("fetched_at")),
+                    model_log_text(normalized.get("modality")),
+                )
+            )
+        if payloads:
+            conn.executemany(
+                """
+                INSERT INTO catalog_models (
+                    id, name, context_length, prompt_per_m, completion_per_m, free,
+                    variable_pricing, pricing_unknown, fetched_at, modality
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                payloads,
+            )
+        write_sync_state_values(
+            conn,
+            {
+                "catalog_snapshot_mtime_ns": catalog_mtime,
+                "catalog_snapshot_size": catalog_size,
+            },
+        )
+
+    if not changes_unchanged:
+        previous_changes_mtime = read_sync_state_value(conn, "catalog_changes_mtime_ns")
+        previous_changes_size = read_sync_state_int(conn, "catalog_changes_size", 0)
+        previous_offset = read_sync_state_int(conn, "catalog_changes_offset", 0)
+        append_only = (
+            previous_changes_mtime is not None
+            and changes_size >= previous_changes_size
+            and previous_offset <= changes_size
+        )
+        if append_only:
+            events, new_offset = read_catalog_events_from_offset(changes_path, previous_offset)
+        else:
+            conn.execute("DELETE FROM catalog_events")
+            events, new_offset = read_catalog_events_from_offset(changes_path, 0)
+        insert_catalog_event_rows(conn, events)
+        write_sync_state_values(
+            conn,
+            {
+                "catalog_changes_mtime_ns": changes_mtime,
+                "catalog_changes_size": changes_size,
+                "catalog_changes_offset": new_offset,
+            },
         )
 
 
@@ -5189,10 +5336,7 @@ def rebuild_read_model_db(
             inserted = insert_attempt_rows(conn, rows)
             refresh_catalog_tables(conn, catalog_path)
             refresh_identity_tables(conn, registry_path)
-            conn.execute(
-                "INSERT OR REPLACE INTO sync_state(key, value) VALUES ('log_offset', ?)",
-                (str(offset),),
-            )
+            write_sync_state_values(conn, {"log_offset": offset})
             conn.commit()
         except Exception:
             conn.rollback()
@@ -5219,8 +5363,7 @@ def sync_read_model_db(
         conn.execute("BEGIN IMMEDIATE")
         try:
             create_read_model_schema(conn)
-            row = conn.execute("SELECT value FROM sync_state WHERE key = 'log_offset'").fetchone()
-            offset = int(row["value"]) if row is not None and str(row["value"]).isdigit() else 0
+            offset = read_sync_state_int(conn, "log_offset", 0)
             if log_size < offset:
                 conn.rollback()
                 return rebuild_read_model_db(
@@ -5233,10 +5376,7 @@ def sync_read_model_db(
             inserted = insert_attempt_rows(conn, rows)
             refresh_catalog_tables(conn, catalog_path)
             refresh_identity_tables(conn, registry_path)
-            conn.execute(
-                "INSERT OR REPLACE INTO sync_state(key, value) VALUES ('log_offset', ?)",
-                (str(new_offset),),
-            )
+            write_sync_state_values(conn, {"log_offset": new_offset})
             conn.commit()
         except Exception:
             conn.rollback()
@@ -5245,7 +5385,6 @@ def sync_read_model_db(
 
 
 def load_identity_registry_from_db(conn: Any) -> ModelIdentityRegistry:
-    create_read_model_schema(conn)
     identities: dict[tuple[str, str], ModelIdentity] = {}
     defaults: dict[str, str] = {}
     engine_meta: dict[str, ModelIdentity] = {}
@@ -5282,8 +5421,7 @@ def db_attempt_rows(
     since: str | None = None,
     engine: str | None = None,
 ) -> tuple[list[dict[str, Any]], ModelIdentityRegistry]:
-    with contextlib.closing(connect_read_model_db(db_path)) as conn:
-        create_read_model_schema(conn)
+    with contextlib.closing(connect_read_model_db_readonly(db_path)) as conn:
         query = """
             SELECT run_id, task_key, logged_at, engine, model, task_type, retry,
                    verdict, duration_ms, worker_tokens, orchestrator
@@ -5311,7 +5449,6 @@ def db_attempt_rows(
             for row in conn.execute(query, params)
         ]
         registry = load_identity_registry_from_db(conn)
-        conn.commit()
     if since is not None:
         selected_row_ids: set[int] = set()
         for task_rows in group_model_log_tasks(rows):
@@ -5330,8 +5467,7 @@ def db_attempt_rows(
 
 
 def db_catalog_models(db_path: Path) -> list[dict[str, Any]]:
-    with contextlib.closing(connect_read_model_db(db_path)) as conn:
-        create_read_model_schema(conn)
+    with contextlib.closing(connect_read_model_db_readonly(db_path)) as conn:
         rows = [
             {
                 "id": row["id"],
@@ -5347,18 +5483,15 @@ def db_catalog_models(db_path: Path) -> list[dict[str, Any]]:
             }
             for row in conn.execute("SELECT * FROM catalog_models ORDER BY id")
         ]
-        conn.commit()
         return rows
 
 
 def db_catalog_events(db_path: Path, *, limit: int = 20) -> list[dict[str, Any]]:
-    with contextlib.closing(connect_read_model_db(db_path)) as conn:
-        create_read_model_schema(conn)
+    with contextlib.closing(connect_read_model_db_readonly(db_path)) as conn:
         rows = conn.execute(
             "SELECT payload FROM catalog_events ORDER BY id DESC LIMIT ?",
             (limit,),
         ).fetchall()
-        conn.commit()
     events: list[dict[str, Any]] = []
     for row in rows:
         try:
@@ -6288,7 +6421,7 @@ def render_model_scoreboard_html(
 ) -> str:
     catalog_by_id = catalog_models_by_id(catalog_models)
     ordered = order_model_scoreboard_rows(rows, catalog_by_id)
-    generated = generated_at or datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+    generated = generated_at or datetime.now().astimezone().replace(microsecond=0).isoformat()
     table_rows = "".join(
         render_model_table_pair(
             row,

--- a/tests/test_hud_models_tab.py
+++ b/tests/test_hud_models_tab.py
@@ -61,10 +61,11 @@ class HudModelsTabTests(unittest.TestCase):
         os.environ.clear()
         os.environ.update(self.old_env)
 
-    def start_server(self) -> tuple[PersistentHudServer, int]:
+    def start_server(self, *, use_db: bool = True) -> tuple[PersistentHudServer, int]:
         server = PersistentHudServer(self.state_dir, preferred_port=0, open_viewer=False)
         server.model_log_path = self.log_path
-        server.model_db_path = self.db_path
+        if use_db:
+            server.model_db_path = self.db_path
         port = server.start_background()
         self.addCleanup(server.stop)
         return server, port
@@ -107,6 +108,21 @@ class HudModelsTabTests(unittest.TestCase):
         self.assertEqual(1.0, rollup["pass_rate"])
         self.assertAlmostEqual(2 / 3, rollup["first_try_pass_rate"])
         self.assertEqual("2026-07-06T10:00:00+00:00", rollup["last_seen"])
+
+    def test_api_models_override_log_without_db_does_not_touch_default_db(self) -> None:
+        write_jsonl(self.log_path, [attempt(run_id="run-1", task_key="a", task_type="code-feature")])
+        default_db = Path(os.environ["RINGER_HOME"]) / "ringer.db"
+        _server, port = self.start_server(use_db=False)
+
+        with urlopen(f"http://127.0.0.1:{port}/api/models", timeout=5) as response:
+            self.assertEqual(200, response.status)
+            payload = json.loads(response.read().decode("utf-8"))
+
+        self.assertEqual(1, len(payload["groups"]))
+        self.assertNotIn("error", payload)
+        self.assertFalse(default_db.exists())
+        self.assertFalse(default_db.with_name(default_db.name + "-wal").exists())
+        self.assertFalse(default_db.with_name(default_db.name + "-shm").exists())
 
     def test_api_models_error_path_returns_200(self) -> None:
         bad_parent = self.root / "not-a-directory"

--- a/tests/test_hud_models_tab.py
+++ b/tests/test_hud_models_tab.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from urllib.request import urlopen
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from ringer import PersistentHudServer  # noqa: E402
+
+
+def write_jsonl(path: Path, rows: list[dict[str, object]]) -> None:
+    path.write_text("".join(json.dumps(row) + "\n" for row in rows), encoding="utf-8")
+
+
+def attempt(
+    *,
+    run_id: str,
+    task_key: str,
+    task_type: str,
+    verdict: str = "PASS",
+    retry: bool = False,
+    logged_at: str = "2026-07-06T10:00:00+00:00",
+) -> dict[str, object]:
+    return {
+        "run_id": run_id,
+        "task_key": task_key,
+        "worker_engine": "opencode",
+        "model": "openrouter/acme/small",
+        "task_type": task_type,
+        "verdict": verdict,
+        "retry": retry,
+        "duration_ms": 120,
+        "worker_tokens": 240,
+        "logged_at": logged_at,
+        "orchestrator": "tester",
+    }
+
+
+class HudModelsTabTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.old_env = os.environ.copy()
+        self.addCleanup(self.restore_env)
+        self.root = Path(self.tmp.name)
+        os.environ["HOME"] = str(self.root / "home")
+        os.environ["RINGER_HOME"] = str(self.root / "ringer-home")
+        self.state_dir = self.root / "state"
+        self.state_dir.mkdir(parents=True)
+        self.log_path = self.root / "models.jsonl"
+        self.db_path = self.root / "ringer.db"
+
+    def restore_env(self) -> None:
+        os.environ.clear()
+        os.environ.update(self.old_env)
+
+    def start_server(self) -> tuple[PersistentHudServer, int]:
+        server = PersistentHudServer(self.state_dir, preferred_port=0, open_viewer=False)
+        server.model_log_path = self.log_path
+        server.model_db_path = self.db_path
+        port = server.start_background()
+        self.addCleanup(server.stop)
+        return server, port
+
+    def test_api_models_serves_contract_from_override_log(self) -> None:
+        write_jsonl(
+            self.log_path,
+            [
+                attempt(run_id="run-1", task_key="a", task_type="code-feature"),
+                attempt(run_id="run-2", task_key="b", task_type="research", verdict="FAIL"),
+                attempt(run_id="run-2", task_key="b", task_type="research", retry=True),
+                attempt(run_id="run-3", task_key="c", task_type="code-feature", logged_at="2026-07-05T10:00:00+00:00"),
+            ],
+        )
+        _server, port = self.start_server()
+
+        with urlopen(f"http://127.0.0.1:{port}/api/models", timeout=5) as response:
+            self.assertEqual(200, response.status)
+            self.assertEqual("application/json; charset=utf-8", response.headers["Content-Type"])
+            payload = json.loads(response.read().decode("utf-8"))
+
+        self.assertIn("generated_at", payload)
+        self.assertIn("groups", payload)
+        self.assertIn("rollup", payload)
+        self.assertNotIn("error", payload)
+        groups_by_type = {group["task_type"]: group for group in payload["groups"]}
+        self.assertEqual({"code-feature", "research"}, set(groups_by_type))
+        self.assertEqual(2, groups_by_type["code-feature"]["tasks"])
+        self.assertEqual("acme/small", groups_by_type["code-feature"]["model_display"])
+        self.assertEqual("OpenCode", groups_by_type["code-feature"]["harness"])
+        self.assertEqual("OpenRouter API", groups_by_type["code-feature"]["access"])
+
+        self.assertEqual(1, len(payload["rollup"]))
+        rollup = payload["rollup"][0]
+        self.assertEqual("openrouter/acme/small", rollup["model"])
+        self.assertEqual("acme/small", rollup["model_display"])
+        self.assertEqual("proven", rollup["tier"])
+        self.assertEqual(3, rollup["tasks"])
+        self.assertEqual(4, rollup["attempts"])
+        self.assertEqual(1.0, rollup["pass_rate"])
+        self.assertAlmostEqual(2 / 3, rollup["first_try_pass_rate"])
+        self.assertEqual("2026-07-06T10:00:00+00:00", rollup["last_seen"])
+
+    def test_api_models_error_path_returns_200(self) -> None:
+        bad_parent = self.root / "not-a-directory"
+        bad_parent.write_text("file", encoding="utf-8")
+        self.log_path = bad_parent / "models.jsonl"
+        _server, port = self.start_server()
+
+        with urlopen(f"http://127.0.0.1:{port}/api/models", timeout=5) as response:
+            self.assertEqual(200, response.status)
+            payload = json.loads(response.read().decode("utf-8"))
+
+        self.assertEqual([], payload["groups"])
+        self.assertEqual([], payload["rollup"])
+        self.assertIn("error", payload)
+        self.assertIn("generated_at", payload)
+
+    def test_frontend_sources_include_models_tab_and_api_fetch(self) -> None:
+        dashboard_html = (ROOT / "dashboard" / "dashboard.html").read_text(encoding="utf-8")
+        hud_js = (ROOT / "hud" / "frontend" / "hud.js").read_text(encoding="utf-8")
+
+        self.assertIn('data-view="models"', dashboard_html)
+        self.assertIn("Models", dashboard_html)
+        self.assertTrue("/api/models" in dashboard_html or "/api/models" in hud_js)
+
+    def test_start_background_returns_usable_port(self) -> None:
+        write_jsonl(self.log_path, [attempt(run_id="run-1", task_key="a", task_type="code-feature")])
+        _server, port = self.start_server()
+
+        self.assertIsInstance(port, int)
+        self.assertGreater(port, 0)
+        with urlopen(f"http://127.0.0.1:{port}/", timeout=5) as response:
+            page = response.read().decode("utf-8")
+        self.assertIn('id="models-tab"', page)
+        self.assertIn("/api/models", page)
+        with urlopen(f"http://127.0.0.1:{port}/api/models", timeout=5) as response:
+            self.assertEqual(200, response.status)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_model_db.py
+++ b/tests/test_model_db.py
@@ -1,0 +1,309 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import contextlib
+import io
+import json
+import os
+import sqlite3
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+import ringer  # noqa: E402
+from ringer import (  # noqa: E402
+    AppConfig,
+    ArtifactConfig,
+    EvalConfig,
+    connect_read_model_db,
+    create_read_model_schema,
+    humanized_log_date,
+    load_model_identity_registry,
+    rebuild_read_model_db,
+    run_models_command,
+    sync_read_model_db,
+)
+
+
+def attempt(
+    *,
+    run_id: str,
+    task_key: str = "task",
+    engine: str = "opencode",
+    model: str = "openrouter/z-ai/glm-5.2",
+    task_type: str = "code-feature",
+    verdict: str = "PASS",
+    retry: bool = False,
+    logged_at: str = "2026-07-06T10:00:00+00:00",
+) -> dict[str, object]:
+    return {
+        "run_id": run_id,
+        "task_key": task_key,
+        "worker_engine": engine,
+        "model": model,
+        "task_type": task_type,
+        "verdict": verdict,
+        "retry": retry,
+        "duration_ms": 100,
+        "worker_tokens": 200,
+        "logged_at": logged_at,
+        "orchestrator": "tester",
+    }
+
+
+def write_jsonl(path: Path, rows: list[dict[str, object]], *, extra: str = "") -> None:
+    body = "".join(json.dumps(row) + "\n" for row in rows)
+    path.write_text(body + extra, encoding="utf-8")
+
+
+def write_registry(path: Path) -> None:
+    path.write_text(
+        """
+[engines.codex]
+harness = "Codex CLI"
+access = "OAuth plan"
+default_model_key = "gpt-5.5"
+
+[engines.codex.models."gpt-5.5"]
+display = "GPT-5.5"
+confidence = "unverified"
+source = ""
+
+[engines.opencode]
+harness = "OpenCode"
+access = "OpenRouter API"
+
+[engines.opencode.models."openrouter/z-ai/glm-5.2"]
+display = "GLM 5.2"
+confidence = "verified"
+source = "fixture"
+""",
+        encoding="utf-8",
+    )
+
+
+def write_catalog(path: Path) -> None:
+    path.write_text(
+        json.dumps(
+            {
+                "models": [
+                    {
+                        "id": "openrouter/z-ai/glm-5.2",
+                        "name": "GLM 5.2",
+                        "context_length": 128000,
+                        "prompt_per_m": 0.2,
+                        "completion_per_m": 0.8,
+                        "free": False,
+                        "variable_pricing": False,
+                        "pricing_unknown": False,
+                        "fetched_at": "2026-07-06T00:00:00+00:00",
+                        "modality": "text->text",
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+class ModelDbTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name)
+        self.old_env = os.environ.copy()
+        self.addCleanup(self.restore_env)
+        os.environ["HOME"] = str(self.root / "home")
+        os.environ["RINGER_HOME"] = str(self.root / "ringer-home")
+        self.log_path = self.root / "runs.jsonl"
+        self.db_path = self.root / "ringer.db"
+        self.catalog_path = self.root / "catalog.json"
+        self.registry_path = self.root / "model-identity.toml"
+        write_catalog(self.catalog_path)
+        write_registry(self.registry_path)
+
+    def restore_env(self) -> None:
+        os.environ.clear()
+        os.environ.update(self.old_env)
+
+    def config(self) -> AppConfig:
+        return AppConfig(
+            path=None,
+            identity_default=None,
+            state_dir=self.root / "state",
+            dashboard_port_base=8787,
+            hud_port=8700,
+            hud_app_path=None,
+            allow_full_access=False,
+            eval=EvalConfig(backend="jsonl", jsonl_path=self.log_path),
+            engines={},
+            artifact=ArtifactConfig(
+                enabled=False,
+                out_template=str(self.root / "live.html"),
+                report_template=str(self.root / "report.html"),
+                index_out=self.root / "index.html",
+            ),
+        )
+
+    def model_args(self, *, db_path: Path | None = None) -> argparse.Namespace:
+        return argparse.Namespace(
+            log=self.log_path,
+            db=db_path or self.db_path,
+            task_type=None,
+            model=None,
+            engine=None,
+            since=None,
+            explore=False,
+            catalog_file=self.catalog_path,
+            notes_file=self.root / "missing-notes.md",
+            registry=self.registry_path,
+            html=None,
+            open=False,
+            json=True,
+        )
+
+    def count_attempts(self) -> int:
+        with sqlite3.connect(self.db_path) as conn:
+            return int(conn.execute("SELECT COUNT(*) FROM attempts").fetchone()[0])
+
+    def test_schema_creation_uses_wal_mode(self) -> None:
+        with contextlib.closing(connect_read_model_db(self.db_path)) as conn:
+            create_read_model_schema(conn)
+            journal_mode = conn.execute("PRAGMA journal_mode").fetchone()[0]
+            user_version = conn.execute("PRAGMA user_version").fetchone()[0]
+            version = conn.execute("SELECT version FROM schema_version").fetchone()[0]
+            conn.commit()
+
+        self.assertEqual("wal", str(journal_mode).lower())
+        self.assertEqual(1, user_version)
+        self.assertEqual(1, version)
+
+    def test_rebuild_ingests_rows_and_counts_skipped_lines(self) -> None:
+        write_jsonl(
+            self.log_path,
+            [
+                attempt(run_id="run-1"),
+                attempt(run_id="run-2", verdict="FAIL", logged_at="2026-07-06T11:00:00+00:00"),
+            ],
+            extra="not-json\n",
+        )
+
+        result = rebuild_read_model_db(
+            self.db_path,
+            self.log_path,
+            catalog_path=self.catalog_path,
+            registry_path=self.registry_path,
+        )
+        second = rebuild_read_model_db(
+            self.db_path,
+            self.log_path,
+            catalog_path=self.catalog_path,
+            registry_path=self.registry_path,
+        )
+
+        self.assertEqual(2, result.attempts_inserted)
+        self.assertEqual(1, result.skipped)
+        self.assertEqual(2, second.attempts_inserted)
+        self.assertEqual(2, self.count_attempts())
+        with sqlite3.connect(self.db_path) as conn:
+            self.assertEqual(1, conn.execute("SELECT COUNT(*) FROM catalog_models").fetchone()[0])
+            self.assertEqual(2, conn.execute("SELECT COUNT(*) FROM identity").fetchone()[0])
+
+    def test_sync_consumes_only_new_bytes_and_rebuilds_after_truncation(self) -> None:
+        write_jsonl(self.log_path, [attempt(run_id="run-1")])
+        rebuild_read_model_db(
+            self.db_path,
+            self.log_path,
+            catalog_path=self.catalog_path,
+            registry_path=self.registry_path,
+        )
+        with self.log_path.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(attempt(run_id="run-2")) + "\n")
+
+        result = sync_read_model_db(
+            self.db_path,
+            self.log_path,
+            catalog_path=self.catalog_path,
+            registry_path=self.registry_path,
+        )
+        again = sync_read_model_db(
+            self.db_path,
+            self.log_path,
+            catalog_path=self.catalog_path,
+            registry_path=self.registry_path,
+        )
+        write_jsonl(self.log_path, [attempt(run_id="run-3")])
+        truncated = sync_read_model_db(
+            self.db_path,
+            self.log_path,
+            catalog_path=self.catalog_path,
+            registry_path=self.registry_path,
+        )
+
+        self.assertEqual(1, result.attempts_inserted)
+        self.assertEqual(0, again.attempts_inserted)
+        self.assertTrue(truncated.rebuilt)
+        self.assertEqual(1, self.count_attempts())
+
+    def test_registry_resolution_covers_defaults_openrouter_fallback_and_unknown_engine(self) -> None:
+        registry = load_model_identity_registry(self.registry_path)
+
+        codex = registry.resolve("codex", "")
+        listed = registry.resolve("opencode", "openrouter/z-ai/glm-5.2")
+        unlisted = registry.resolve("opencode", "openrouter/vendor/model")
+        unknown = registry.resolve("custom-engine", "custom-model")
+
+        self.assertEqual(("GPT-5.5", "Codex CLI", "OAuth plan"), (codex.model_display, codex.harness, codex.access))
+        self.assertEqual(("GLM 5.2", "OpenCode", "OpenRouter API"), (listed.model_display, listed.harness, listed.access))
+        self.assertEqual(("vendor/model", "OpenCode", "OpenRouter API"), (unlisted.model_display, unlisted.harness, unlisted.access))
+        self.assertEqual(("custom-engine", "custom-engine", "unknown"), (unknown.model_display, unknown.harness, unknown.access))
+
+    def test_models_json_includes_identity_fields(self) -> None:
+        write_jsonl(
+            self.log_path,
+            [
+                attempt(run_id="run-1", engine="codex", model="", task_type="site-build"),
+                attempt(run_id="run-2", engine="opencode", model="openrouter/vendor/model"),
+            ],
+        )
+        out = io.StringIO()
+
+        with contextlib.redirect_stdout(out):
+            self.assertEqual(0, run_models_command(self.config(), self.model_args()))
+
+        payload = json.loads(out.getvalue())
+        by_model = {row["model"]: row for row in payload}
+        self.assertEqual("GPT-5.5", by_model["codex"]["model_display"])
+        self.assertEqual("Codex CLI", by_model["codex"]["harness"])
+        self.assertEqual("OAuth plan", by_model["codex"]["access"])
+        self.assertEqual("vendor/model", by_model["openrouter/vendor/model"]["model_display"])
+        self.assertEqual("OpenCode", by_model["openrouter/vendor/model"]["harness"])
+        self.assertEqual("OpenRouter API", by_model["openrouter/vendor/model"]["access"])
+
+    def test_humanized_date_helper(self) -> None:
+        self.assertEqual("last used: July 6, 2026", humanized_log_date("2026-07-06T10:00:00.123456+00:00", prefix="last used: "))
+        self.assertEqual("July 6, 2026", humanized_log_date("2026-07-06"))
+
+    def test_models_falls_back_when_db_path_is_unwritable(self) -> None:
+        write_jsonl(self.log_path, [attempt(run_id="run-1")])
+        not_a_directory = self.root / "not-a-directory"
+        not_a_directory.write_text("file", encoding="utf-8")
+        out = io.StringIO()
+        err = io.StringIO()
+
+        with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+            self.assertEqual(0, run_models_command(self.config(), self.model_args(db_path=not_a_directory / "ringer.db")))
+
+        payload = json.loads(out.getvalue())
+        self.assertEqual(1, len(payload))
+        self.assertIn("SQLite read model unavailable; using JSONL fallback", err.getvalue())
+        self.assertEqual("GLM 5.2", payload[0]["model_display"])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_model_db.py
+++ b/tests/test_model_db.py
@@ -285,6 +285,27 @@ class ModelDbTests(unittest.TestCase):
         self.assertEqual("OpenCode", by_model["openrouter/vendor/model"]["harness"])
         self.assertEqual("OpenRouter API", by_model["openrouter/vendor/model"]["access"])
 
+    def test_models_override_log_without_db_does_not_touch_default_db(self) -> None:
+        fixture_log = self.root / "fixture-runs.jsonl"
+        write_jsonl(fixture_log, [attempt(run_id="fixture-run")])
+        default_db = Path(os.environ["RINGER_HOME"]) / "ringer.db"
+        args = self.model_args()
+        args.log = fixture_log
+        args.db = None
+        out = io.StringIO()
+        err = io.StringIO()
+
+        with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+            self.assertEqual(0, run_models_command(self.config(), args))
+
+        payload = json.loads(out.getvalue())
+        self.assertEqual(1, len(payload))
+        self.assertEqual("openrouter/z-ai/glm-5.2", payload[0]["model"])
+        self.assertEqual("", err.getvalue())
+        self.assertFalse(default_db.exists())
+        self.assertFalse(default_db.with_name(default_db.name + "-wal").exists())
+        self.assertFalse(default_db.with_name(default_db.name + "-shm").exists())
+
     def test_humanized_date_helper(self) -> None:
         self.assertEqual("last used: July 6, 2026", humanized_log_date("2026-07-06T10:00:00.123456+00:00", prefix="last used: "))
         self.assertEqual("July 6, 2026", humanized_log_date("2026-07-06"))

--- a/tests/test_model_db.py
+++ b/tests/test_model_db.py
@@ -250,6 +250,176 @@ class ModelDbTests(unittest.TestCase):
         self.assertTrue(truncated.rebuilt)
         self.assertEqual(1, self.count_attempts())
 
+    def test_sync_leaves_trailing_partial_line_for_next_pass(self) -> None:
+        first_line = json.dumps(attempt(run_id="run-1")) + "\n"
+        second_line = json.dumps(attempt(run_id="run-2"))
+        cut_at = len(second_line) // 2
+        partial_second = second_line[:cut_at]
+        partial_start = len(first_line.encode("utf-8"))
+        self.log_path.write_text(first_line + partial_second, encoding="utf-8")
+
+        result = sync_read_model_db(
+            self.db_path,
+            self.log_path,
+            catalog_path=self.catalog_path,
+            registry_path=self.registry_path,
+        )
+
+        self.assertEqual(1, result.attempts_inserted)
+        self.assertEqual(0, result.skipped)
+        self.assertEqual(partial_start, result.offset)
+        self.assertEqual(1, self.count_attempts())
+
+        with self.log_path.open("a", encoding="utf-8") as fh:
+            fh.write(second_line[cut_at:] + "\n")
+        completed = sync_read_model_db(
+            self.db_path,
+            self.log_path,
+            catalog_path=self.catalog_path,
+            registry_path=self.registry_path,
+        )
+
+        self.assertEqual(1, completed.attempts_inserted)
+        self.assertEqual(2, self.count_attempts())
+        with contextlib.closing(sqlite3.connect(self.db_path)) as conn:
+            run_2_count = conn.execute(
+                "SELECT COUNT(*) FROM attempts WHERE run_id = 'run-2'"
+            ).fetchone()[0]
+        self.assertEqual(1, run_2_count)
+
+    def test_catalog_sync_skips_unchanged_files_and_appends_new_events_only(self) -> None:
+        changes_path = ringer.catalog_changes_path(self.catalog_path)
+        event_1 = {
+            "ts": "2026-07-06T10:00:00+00:00",
+            "kind": "price_change",
+            "id": "openrouter/z-ai/glm-5.2",
+            "old_prompt_per_m": 0.3,
+            "new_prompt_per_m": 0.2,
+        }
+        event_2 = {
+            "ts": "2026-07-06T11:00:00+00:00",
+            "kind": "price_change",
+            "id": "openrouter/z-ai/glm-5.2",
+            "old_completion_per_m": 0.9,
+            "new_completion_per_m": 0.8,
+        }
+        changes_path.write_text(json.dumps(event_1, sort_keys=True) + "\n", encoding="utf-8")
+        write_jsonl(self.log_path, [attempt(run_id="run-1")])
+        rebuild_read_model_db(
+            self.db_path,
+            self.log_path,
+            catalog_path=self.catalog_path,
+            registry_path=self.registry_path,
+        )
+
+        with contextlib.closing(sqlite3.connect(self.db_path)) as conn:
+            self.assertEqual(1, conn.execute("SELECT COUNT(*) FROM catalog_events").fetchone()[0])
+            before_state = dict(
+                conn.execute(
+                    "SELECT key, value FROM sync_state WHERE key LIKE 'catalog_%' ORDER BY key"
+                ).fetchall()
+            )
+            conn.executescript(
+                """
+                CREATE TABLE catalog_write_audit(kind TEXT NOT NULL);
+                CREATE TRIGGER audit_catalog_model_insert
+                    AFTER INSERT ON catalog_models
+                    BEGIN
+                        INSERT INTO catalog_write_audit(kind) VALUES ('model_insert');
+                    END;
+                CREATE TRIGGER audit_catalog_model_delete
+                    AFTER DELETE ON catalog_models
+                    BEGIN
+                        INSERT INTO catalog_write_audit(kind) VALUES ('model_delete');
+                    END;
+                CREATE TRIGGER audit_catalog_event_insert
+                    AFTER INSERT ON catalog_events
+                    BEGIN
+                        INSERT INTO catalog_write_audit(kind) VALUES ('event_insert');
+                    END;
+                CREATE TRIGGER audit_catalog_event_delete
+                    AFTER DELETE ON catalog_events
+                    BEGIN
+                        INSERT INTO catalog_write_audit(kind) VALUES ('event_delete');
+                    END;
+                """
+            )
+
+        sync_read_model_db(
+            self.db_path,
+            self.log_path,
+            catalog_path=self.catalog_path,
+            registry_path=self.registry_path,
+        )
+        with contextlib.closing(sqlite3.connect(self.db_path)) as conn:
+            self.assertEqual(0, conn.execute("SELECT COUNT(*) FROM catalog_write_audit").fetchone()[0])
+            after_state = dict(
+                conn.execute(
+                    "SELECT key, value FROM sync_state WHERE key LIKE 'catalog_%' ORDER BY key"
+                ).fetchall()
+            )
+        self.assertEqual(before_state, after_state)
+
+        with changes_path.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(event_2, sort_keys=True) + "\n")
+        sync_read_model_db(
+            self.db_path,
+            self.log_path,
+            catalog_path=self.catalog_path,
+            registry_path=self.registry_path,
+        )
+        with contextlib.closing(sqlite3.connect(self.db_path)) as conn:
+            self.assertEqual(2, conn.execute("SELECT COUNT(*) FROM catalog_events").fetchone()[0])
+            audit_counts = dict(
+                conn.execute(
+                    "SELECT kind, COUNT(*) FROM catalog_write_audit GROUP BY kind"
+                ).fetchall()
+            )
+        self.assertEqual({"event_insert": 1}, audit_counts)
+
+    def test_read_paths_do_not_create_or_stamp_schema_for_missing_tables(self) -> None:
+        missing_db = self.root / "missing.db"
+
+        with self.assertRaises(RuntimeError):
+            ringer.db_catalog_models(missing_db)
+
+        self.assertFalse(missing_db.exists())
+        self.assertFalse(missing_db.with_name(missing_db.name + "-wal").exists())
+        self.assertFalse(missing_db.with_name(missing_db.name + "-shm").exists())
+
+        write_jsonl(self.log_path, [attempt(run_id="run-1")])
+        with contextlib.closing(sqlite3.connect(self.db_path)):
+            pass
+        original_sync = ringer.sync_read_model_db
+
+        def no_op_sync(*_args: object, **_kwargs: object) -> ringer.ReadModelSyncResult:
+            return ringer.ReadModelSyncResult(
+                self.db_path,
+                self.log_path,
+                attempts_inserted=0,
+                skipped=0,
+                offset=0,
+                rebuilt=False,
+            )
+
+        ringer.sync_read_model_db = no_op_sync
+        out = io.StringIO()
+        err = io.StringIO()
+        try:
+            with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+                self.assertEqual(0, run_models_command(self.config(), self.model_args()))
+        finally:
+            ringer.sync_read_model_db = original_sync
+
+        payload = json.loads(out.getvalue())
+        self.assertEqual(1, len(payload))
+        self.assertIn("SQLite read model unavailable; using JSONL fallback", err.getvalue())
+        with contextlib.closing(sqlite3.connect(self.db_path)) as conn:
+            schema_row = conn.execute(
+                "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'schema_version'"
+            ).fetchone()
+        self.assertIsNone(schema_row)
+
     def test_registry_resolution_covers_defaults_openrouter_fallback_and_unknown_engine(self) -> None:
         registry = load_model_identity_registry(self.registry_path)
 

--- a/tests/test_scoreboard_page.py
+++ b/tests/test_scoreboard_page.py
@@ -206,8 +206,13 @@ class ScoreboardPageTests(unittest.TestCase):
 ## Proven lane (`openrouter/proven`)
 
 - Non-dated setup line ignored by the parser.
-- 2026-07-06 - steady code-feature performance across a larger sample.
+- 2026-07-06 — steady `code-feature` performance across a larger sample.
   Continuation line kept with the dated bullet.
+- 2026-07-05 - second newest note.
+- 2026-07-04 - third newest note.
+- 2026-07-03 - fourth newest note.
+- 2026-07-02 - fifth newest note.
+- 2026-07-01 - older note should stay behind the cap.
 
 ## codex
 
@@ -238,28 +243,84 @@ class ScoreboardPageTests(unittest.TestCase):
         self.assertEqual(str(path.resolve()) + "\n", out.getvalue())
         return path.read_text(encoding="utf-8")
 
-    def test_html_render_contains_models_tiers_counts_free_badge_and_notes(self) -> None:
+    def test_html_render_contains_ranked_table_badges_bars_costs_and_normalized_notes(self) -> None:
         html = self.render_to(self.root / "scoreboard.html")
 
+        expected_headers = [
+            "Rank",
+            "Model",
+            "Harness",
+            "API/Plan",
+            "Tier",
+            "Tasks",
+            "First-try",
+            "Pass",
+            "Est. $/task",
+            "Last used",
+        ]
+        last_index = -1
+        for header in expected_headers:
+            index = html.index(f">{header}<")
+            self.assertGreater(index, last_index)
+            last_index = index
+
+        self.assertIn('<table class="ranked-table">', html)
+        self.assertIn('<div class="table-scroll">', html)
+        self.assertNotIn("model-card", html)
+        self.assertNotIn("source-grid", html)
         self.assertIn("openrouter/proven", html)
         self.assertIn("openrouter/probation", html)
         self.assertIn("openrouter/free:free", html)
-        self.assertIn("codex", html)
-        self.assertIn("proven", html)
-        self.assertIn("probation", html)
+        self.assertIn('<div class="model-name">GPT-5.5</div><div class="model-id">codex</div>', html)
+        self.assertIn('<span class="tier-badge proven">proven</span>', html)
+        self.assertIn('<span class="tier-badge probation">probation</span>', html)
         self.assertIn("n=20", html)
-        self.assertIn("FREE", html)
+        self.assertIn('class="rate-bar bar-fill" style="width: 90%"', html)
+        self.assertIn('class="rate-bar bar-fill" style="width: 100%"', html)
+        self.assertIn(">free</td>", html)
         self.assertNotIn("$0/task", html)
-        self.assertIn("steady code-feature performance across a larger sample", html)
-        self.assertIn("Continuation line kept with the dated bullet.", html)
+        self.assertIn(">in plan</td>", html)
+        self.assertIn("<time>July 6</time><span>steady code-feature performance across a larger sample. Continuation line kept with the dated bullet.</span>", html)
+        self.assertNotIn("`code-feature`", html)
+        self.assertIn("fifth newest note", html)
+        self.assertNotIn("older note should stay behind the cap", html)
+        self.assertIn("more in model notes", html)
         self.assertIn("no judgment notes yet", html)
-        self.assertIn("included in plan", html)
+
+    def test_html_header_links_watchlist_and_footer_diagnostics(self) -> None:
+        html = self.render_to(self.root / "scoreboard.html")
+
+        self.assertIn("<h1 class=\"scoreboard-title\">Model performance scoreboard</h1>", html)
+        self.assertIn("Generated July 6, 2026", html)
+        self.assertIn('>eval log</a>', html)
+        self.assertIn('>catalog</a>', html)
+        self.assertIn('>model notes</a>', html)
+        self.assertIn(f'title="{self.log_path.resolve()}"', html)
+        self.assertIn(f'title="{self.catalog_path.resolve()}"', html)
+        self.assertIn(f'title="{self.notes_path.resolve()}"', html)
+        header_html = html[: html.index('<section class="watchlist"')]
+        self.assertNotIn("rows read", header_html)
+        self.assertNotIn("skipped", header_html)
+
+        self.assertEqual(1, html.count('class="watchlist"'))
+        self.assertIn("1 models free on OpenRouter right now", html)
+        self.assertIn('data-model="openrouter/free:free"', html)
+        self.assertIn('title="openrouter/free:free"', html)
+        self.assertIn("Free · 128K ctx", html)
+        self.assertIn("Free went free — July 6", html)
+        self.assertNotIn("went_free", html)
+
+        footer_start = html.index('<footer class="scoreboard-footer">')
+        footer_html = html[footer_start:]
+        self.assertIn("25 rows read, 1 skipped lines.", footer_html)
+        self.assertIn("Ranking sorts by evidence tier first", footer_html)
+        self.assertIn("Cost estimate assumes logged worker_tokens are split 50/50", footer_html)
 
     def test_evidence_floor_orders_probation_after_proven_model(self) -> None:
         html = self.render_to(self.root / "scoreboard.html")
 
         self.assertLess(html.index("openrouter/proven"), html.index("openrouter/probation"))
-        self.assertIn("#1", html[: html.index("openrouter/proven")])
+        self.assertIn('<td class="rank-cell num">1</td>', html[: html.index("openrouter/proven")])
 
     def test_reused_task_identity_does_not_collapse_proven_evidence(self) -> None:
         rows: list[dict[str, object]] = []
@@ -294,7 +355,9 @@ class ScoreboardPageTests(unittest.TestCase):
 
         self.assertLess(html.index("openrouter/proven"), html.index("openrouter/probation"))
         self.assertIn("n=20", html)
-        self.assertIn("proven", html[: html.index("openrouter/proven")])
+        row_start = html.index('<tr class="model-row" id="model-openrouter-proven">')
+        row_end = html.index("</tr>", row_start)
+        self.assertIn('<span class="tier-badge proven">proven</span>', html[row_start:row_end])
 
     def test_html_path_does_not_write_artifact_library(self) -> None:
         html_path = self.root / "custom.html"
@@ -333,14 +396,17 @@ class ScoreboardPageTests(unittest.TestCase):
         self.assertNotRegex(html, r"""(?:src|href)=["']https?://""")
         self.assertNotRegex(html, r"""@import\s+["']https?://""")
         self.assertNotIn("<script", html.lower())
+        self.assertIn("@media (prefers-color-scheme: light)", html)
+        self.assertIn("@media (prefers-color-scheme: dark)", html)
 
     def test_notes_section_parser_matches_heading_and_missing_section_falls_back(self) -> None:
         sections = parse_model_notes_sections(self.notes_path)
 
         proven = model_judgment_notes("openrouter/proven", sections)
-        self.assertEqual(1, len(proven))
-        self.assertIn("steady code-feature performance", proven[0])
+        self.assertEqual(6, len(proven))
+        self.assertIn("steady `code-feature` performance", proven[0])
         self.assertIn("Continuation line kept", proven[0])
+        self.assertNotIn("Non-dated setup", "\n".join(proven))
         self.assertEqual([], model_judgment_notes("openrouter/missing", sections))
 
     def test_notes_matching_uses_id_boundaries_and_best_heading(self) -> None:


### PR DESCRIPTION
The 'real feature' build (Jon-directed, 2026-07-06). Eight commits, built as seven Ringer runs with executed checks plus a 3-lane adversarial review.

## What

1. **SQLite read model** (`~/.ringer/ringer.db`, WAL): derived cache over the append-only JSONL source of truth — `db rebuild`/`db sync` (byte-offset incremental, truncation fallback, mid-append-safe cursor), auto-synced by consumers, pure-JSONL fallback everywhere. An overridden `--log` can never write the default DB (we leaked our own test fixtures into the live DB and made it structurally impossible).
2. **Identity registry** (`registry/model-identity.toml`): engine+model → **Model / Harness / Access** triples, so engines stop masquerading as models. All current identities **verified with citations**: GPT-5.5 is the Codex CLI default (snapshot gpt-5.5-2026-04-23); the grok-build MODEL is officially 'Grok Build 0.1' (xAI overloads the brand across model and CLI); Composer 2.5 Fast is a Cursor/Anysphere model served through xAI.
3. **Capability registry** (`registry/model-capabilities/*.toml`): six research-with-proof packets (GPT-5.5, Grok Build 0.1, Composer 2.5 Fast, GLM 5.2, Kimi K2.7, OpenRouter platform) — API surface, caching (TTLs, cache pricing), tool-calling quirks, reasoning params, limits, pricing — every section cited, every URL fetched live by the executed check. Explicit unknowns, no omissions.
4. **Scoreboard redesign**: ranked identity table (Rank | Model | Harness | API/Plan | Tier | stats), labeled tier badges, inline rate meters, humanized dates/costs, normalized judgment notes, one compact free-promo watchlist, light/dark, self-contained, no-JS readable.
5. **Ringside Models tab**: live scoreboard at :8700 via `/api/models` (never-crash contract), frontend in the true sources (dashboard.html + hud/frontend/hud.js; dist untouched).

## Review

3-lane adversarial swarm on the 4,061-line diff: codex (correctness/concurrency) found a HIGH — the sync cursor could permanently skip a half-written trailing line; GLM (invariants/injection/frontend) verified the four invariants and DOM escaping empirically, found two contention smells. All three findings fixed with regression tests. The free-model audition lane (llama-3.3-70b:free) failed its structured-report check — $0 spent, second data point in the exploration ledger. 22 test suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)