### PR TITLE
Ship a real Grok Build CLI engine block (three-lane promise)

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ For CI and evals, `config.sample.toml` includes `[engines.mock]` so the enforcem
 
 ![Identical workers, each under its own light](docs/engines.png)
 
-Codex is built in. Anything with a headless CLI is a config block away:
+Ringer ships with three worker lanes: **Codex CLI** is the built-in default, and `config.sample.toml` carries ready-to-uncomment engine blocks for **Grok Build CLI** and **OpenCode + OpenRouter** (both verified working, not sketches). Anything else with a headless CLI is a config block away:
 
 ```toml
 [engines.mymodel]
@@ -150,7 +150,7 @@ bin = "/usr/local/bin/mycli"
 args_template = ["run", "{spec}", "--dir", "{taskdir}"]
 ```
 
-Per-task `"engine": "mymodel"` routes work to it. `config.sample.toml` ships commented examples for Grok and OpenCode setups — the invariants (stdin closed, process-group kill, executed verification, raw logs) apply to every engine identically.
+Per-task `"engine": "mymodel"` routes work to it — the invariants (stdin closed, process-group kill, executed verification, raw logs) apply to every engine identically.
 
 ### The universal harness: OpenCode + OpenRouter
 
@@ -177,11 +177,28 @@ opencode auth login   # select OpenRouter, paste the key
 
 Route with per-task `"engine": "opencode"`, pick the model with per-task `"model": "openrouter/<any-model>"`, and set reasoning effort via `engine_args`: `["--variant", "low|high|max"]`. A sensible split: mechanical or tightly-specced tasks on the cheap lane, gnarly ones on your frontier engine — the executed check catches shortfalls either way, and `swarm_runs` rows tell you whether the cheap lane's pass rate holds.
 
+### The plan lane: Grok Build CLI
+
+If you already pay for SuperGrok or X Premium Plus, Grok Build is a second flat-rate worker lane — no per-token bill:
+
+```bash
+# 1) Install (pick one)
+curl -fsSL https://x.ai/cli/install.sh | bash
+# or: npm install -g @xai-official/grok
+
+# 2) Sign in — OAuth on a SuperGrok or X Premium Plus plan
+grok login
+
+# 3) In ~/.config/ringer/config.toml, uncomment [engines.grok]
+```
+
+Route with per-task `"engine": "grok"` and pick the model with `"model": "grok-build"` or `"model": "grok-composer-2.5-fast"` (the shipped default — the speed pick). Grok brings its own OS sandbox on macOS (profile `workspace`: read everywhere, writes confined to the task dir, temp, and `~/.grok`), and its JSON output exposes no token counts — plan-billed workers report cost as included in plan.
+
 ## Ringside — mission control
 
 ![Ringside in the browser: a run's live results page with per-worker status and verification](docs/ringside.png)
 
-Ringside is a local web page — no install, no account, nothing leaves your machine — that every run opens automatically:
+Ringside is a local web page — no install, no account, nothing leaves your machine. Your first run opens it automatically; every later run streams into the same tab:
 
 ```bash
 ./ringer.py run manifest.json   # starts Ringside and opens the tab for you

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ For CI and evals, `config.sample.toml` includes `[engines.mock]` so the enforcem
 
 ![Identical workers, each under its own light](docs/engines.png)
 
-Ringer ships with three worker lanes: **Codex CLI** is the built-in default, and `config.sample.toml` carries ready-to-uncomment engine blocks for **Grok Build CLI** and **OpenCode + OpenRouter** (both verified working, not sketches). Anything else with a headless CLI is a config block away:
+Ringer ships with three worker lanes: **Codex CLI** is the built-in default, and `config.sample.toml` carries verified engine blocks for **Grok Build CLI** (works as-is once you `grok login`) and **OpenCode + OpenRouter** (one edit: point `bin` at the sandbox wrapper in your clone). Anything else with a headless CLI is a config block away:
 
 ```toml
 [engines.mymodel]

--- a/config.sample.toml
+++ b/config.sample.toml
@@ -63,13 +63,36 @@ full_access_args = ["--dangerously-bypass-approvals-and-sandbox"]
 # First capture group should be the integer token count.
 token_regex = "tokens\\s+used\\s*:?\\s*([0-9][0-9,]*)"
 
-# Example: Grok CLI. Adjust flags to whatever your installed CLI actually uses.
+# Grok Build CLI (xAI). Install: curl -fsSL https://x.ai/cli/install.sh | bash
+# (or: npm install -g @xai-official/grok), then `grok login` — OAuth on a
+# SuperGrok or X Premium Plus plan. Headless mode (-p) runs a full agentic
+# loop with tools and exits. Grok brings its own OS sandbox (Seatbelt on
+# macOS): profile "workspace" = read everywhere, write CWD + temp + ~/.grok,
+# network allowed. Models: grok-build, grok-composer-2.5-fast (route with the
+# per-task "model" field). Verified against Grok Build v0.2.81 (2026-07-06).
+# Uncomment to enable.
 # [engines.grok]
 # bin = "grok"
-# args_template = ["run", "--cwd", "{taskdir}", "{spec}"]
-# sandbox_args = []
-# full_access_args = ["--dangerous"]
-# token_regex = "tokens\\s*:?\\s*([0-9][0-9,]*)"
+# model_default = "grok-composer-2.5-fast"
+# args_template = [
+#   "--cwd",
+#   "{taskdir}",
+#   "{access_args}",
+#   "-m",
+#   "{model}",
+#   "--always-approve",
+#   "--no-auto-update",
+#   "--output-format",
+#   "json",
+#   "{engine_args}",
+#   "-p",
+#   "{spec}",
+# ]
+# sandbox_args = ["--sandbox", "workspace"]
+# full_access_args = ["--sandbox", "off", "--permission-mode", "bypassPermissions"]
+# Grok's JSON output carries no usage/token fields (verified v0.2.81) — plan
+# CLIs report cost as "included in plan"; regex is a harmless no-match.
+# token_regex = "\"total_tokens\"\\s*:\\s*([0-9]+)"
 
 # For CI, acceptance evals, and trying Ringer without an API bill.
 # [engines.mock]

--- a/config.sample.toml
+++ b/config.sample.toml
@@ -70,6 +70,9 @@ token_regex = "tokens\\s+used\\s*:?\\s*([0-9][0-9,]*)"
 # macOS): profile "workspace" = read everywhere, write CWD + temp + ~/.grok,
 # network allowed. Models: grok-build, grok-composer-2.5-fast (route with the
 # per-task "model" field). Verified against Grok Build v0.2.81 (2026-07-06).
+# Note: --no-auto-update is accepted but absent from --help in v0.2.81 (grok
+# rejects unknown flags, so this is a hidden flag, not a typo) — it stops the
+# CLI self-updating mid-swarm.
 # Uncomment to enable.
 # [engines.grok]
 # bin = "grok"


### PR DESCRIPTION
Makes the "ships with Codex CLI, OpenCode, and Grok Build CLI" promise true in the repo. The sample config's grok block was a guessed sketch ("Adjust flags to whatever your installed CLI actually uses") — this replaces it with the proven block from today's runs.

**config.sample.toml**
- Real `[engines.grok]` block: headless `-p` agentic loop, `--sandbox workspace` (Grok's own macOS Seatbelt: read everywhere, writes confined to task dir + temp + ~/.grok), `model_default = "grok-composer-2.5-fast"`, per-task `model` routing to `grok-build`, full-access wired as `--sandbox off --permission-mode bypassPermissions`.
- Install/login guidance in comments: `curl -fsSL https://x.ai/cli/install.sh | bash` or `npm install -g @xai-official/grok`, then `grok login` (OAuth, SuperGrok / X Premium Plus). Verified against docs.x.ai and the npm registry today (latest 0.2.87; block verified against v0.2.81).
- Documents the verified quirk: grok's JSON output carries no usage/token fields — plan CLIs report cost as included in plan; token_regex is a harmless no-match by design.

**README**
- Engines section states the three-lane promise (Codex built in; Grok Build CLI + OpenCode/OpenRouter ready-to-uncomment, both verified working) and adds a "plan lane: Grok Build CLI" subsection mirroring the OpenCode quickstart.
- Ringside line updated for the single-tab fix (first run opens the tab, later runs reuse it).

**Verification (executed, not eyeballed)**: a check script uncomments the sample grok block exactly as a user would and loads it through `ringer.AppConfig.load`, asserting the full engine shape and that the token regex compiles and no-matches real grok JSON. All 19 test suites pass.

Companion: unlock-ai PR #22 updates the public guide to the same promise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)