### PR TITLE
docs: track the Claude-Code-via-PTY subscription lane

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,10 @@ grok login
 
 Route with per-task `"engine": "grok"` and pick the model with `"model": "grok-build"` or `"model": "grok-composer-2.5-fast"` (the shipped default — the speed pick). Grok brings its own OS sandbox on macOS (profile `workspace`: read everywhere, writes confined to the task dir, temp, and `~/.grok`), and its JSON output exposes no token counts — plan-billed workers report cost as included in plan.
 
+### The subscription lane: Claude Code via PTY (in progress)
+
+Claude Code can be a third flat-rate lane, but it can't join the closed-stdin subprocess model without losing its subscription subsidy — interactive `claude` bills as `cc_entrypoint=cli` (Max/Pro-subsidized) while `claude -p` does not. That needs a **PTY execution path**, not just a config block. The pattern and its reference implementation (env scrubbing, trust-dialog seeding, prompt-answering, sentinel-based completion) are proven and spun out to **[`will-sargent-dbtlabs/claude-pty`](https://github.com/will-sargent-dbtlabs/claude-pty)**; the ringer-side engine design, the four-invariant reconciliation, and where it hooks into `ringer.py` are written up in [`docs/claude-pty.md`](docs/claude-pty.md).
+
 ## Ringside — mission control
 
 ![Ringside in the browser: a run's live results page with per-worker status and verification](docs/ringside.png)

--- a/docs/claude-pty.md
+++ b/docs/claude-pty.md
@@ -1,0 +1,68 @@
+# Claude Code as a subscription worker lane (PTY) — design & status
+
+Ringer's worker lanes are all fire-and-forget subprocesses with **stdin closed**.
+Claude Code can't join that way without giving up its subscription subsidy:
+interactive `claude` bills as `cc_entrypoint=cli` (subsidized by a Max/Pro plan),
+while `claude -p`/`--print` — the only mode that fits the closed-stdin model —
+loses that subsidy. Subscription billing requires the interactive TUI, which
+requires a real terminal. So a Claude lane needs a **PTY execution path**, not just
+a config block.
+
+## Status
+
+The pattern and its reference implementation are spun out to a standalone repo:
+
+**→ [`will-sargent-dbtlabs/claude-pty`](https://github.com/will-sargent-dbtlabs/claude-pty)**
+
+Executed-verified there (via Ringer probes):
+
+- A real `claude` turn driven through a `pty.fork()` PTY, authenticating on the
+  **machine subscription** with `ANTHROPIC_API_KEY`/`ANTHROPIC_AUTH_TOKEN` scrubbed
+  from the child — no API key present, so it used the subscription session.
+- The PTY plumbing in isolation (spawn, env scrub, bracketed-paste injection,
+  filesystem-sentinel completion) against a stand-in CLI.
+- `pty.fork()` works under the codex `workspace-write` sandbox; only network forces
+  `full_access`.
+
+Prototype (proof-pending): two-way, multi-turn sessions with `--resume`.
+
+## How it would land in ringer
+
+A `claude-pty` engine would be a new **execution path**, opted into by a single
+engine field, reusing everything else:
+
+1. Add `pty: bool = False` to `EngineConfig` beside `args_template` / `sandbox_args`
+   / `full_access_args`; parse it in `load_engines`.
+2. Branch in `RingerRunner._run_worker`: when `engine.pty`, open a PTY and spawn the
+   worker with the slave as std streams, reading the master into the **same** log /
+   rolling-capture path used today. Reuse the existing process-group timeout/kill.
+3. Completion via a Claude Code `Stop` hook (injected through a temp `--settings`
+   file) that writes a sentinel the runner polls for — ringer already writes
+   Claude-hook-shaped settings in `merge_ringer_hook`. No HTTP server, no output
+   parsing.
+
+The full extension map (with `ringer.py` line citations) and the jinn teardown it
+draws on live in the external repo under `docs/`.
+
+## Invariant reconciliation
+
+Ringer's four baked-in invariants survive:
+
+- **stdin closed (`/dev/null`)** — the PTY master *replaces* `/dev/null` as the
+  runner-owned stdin for this one engine class (a deliberate, documented
+  exception); intent preserved (never wired to the user's terminal, sentinel-driven
+  completion, same timeout + process-group kill).
+- **sandbox explicit** — unchanged; still from `sandbox_args`/`full_access_args`.
+- **verification executes the artifact** — unchanged, and it's *why* ringer needs
+  none of jinn's output-extraction: the check reads the files the worker wrote.
+- **logs carry raw worker output** — the raw PTY stream (ANSI and all) is the log.
+
+## Gotchas (from the live proofs)
+
+- Interactive `claude` never self-exits — never wait on child exit for completion.
+- `--dangerously-skip-permissions` does **not** suppress every in-TUI confirmation;
+  a headless driver must answer prompts or the turn stalls to timeout.
+- First-run trust/onboarding dialogs hang a headless PTY — seed and restore the
+  `~/.claude.json` flags.
+
+See the external repo's `docs/findings.md` for the full account.


### PR DESCRIPTION
Tracks the PTY research spun out to **[will-sargent-dbtlabs/claude-pty](https://github.com/will-sargent-dbtlabs/claude-pty)**.

## What
- `docs/claude-pty.md` — design for a `claude-pty` engine lane: why a PTY is required (subscription `cc_entrypoint=cli` vs metered `-p`), where it hooks into `ringer.py` (`EngineConfig` + `_run_worker` branch + Stop-hook sentinel via `merge_ringer_hook`), reconciliation of all four baked-in invariants, and the live-proof gotchas.
- README: a "subscription lane" subsection alongside the OpenCode and Grok lanes.

## Provenance
Produced via Ringer `research-with-proof` swarms (3× codex, all PASS first-try) plus a live `full_access` probe that drove real `claude` in a PTY and confirmed **subscription auth with no API key in the child env**. Checks execute the claim.

## Status
- ✅ one-shot subscription-auth over PTY — executed-verified
- ⏳ two-way / `--resume` — prototype, ready-to-run proof manifest in the repo

Docs-only; no `ringer.py` behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)