### PR TITLE
Ringside overhaul: running-now switcher, agent cards, work gating, exact model attribution

### DIFF
--- a/config.sample.toml
+++ b/config.sample.toml
@@ -43,6 +43,11 @@ bin = "codex"
 # - {taskdir}: task working directory
 # - {spec}: task prompt/spec
 # - {access_args}: expands to sandbox_args or full_access_args
+# - {model_args}: expands to "-m <model>" only when the manifest task sets
+#   "model" or this engine sets model_default; otherwise it expands to nothing,
+#   preserving Codex's configured default. Setting model_default = "gpt-5.6-sol"
+#   pins the model instead of inheriting ~/.codex/config.toml drift and makes
+#   scoreboard attribution exact.
 # - {engine_args}: expands to the task's optional "engine_args" list — the orchestrator
 #   sets per-task flags here, e.g. ["-c", "model_reasoning_effort=medium"] to match
 #   reasoning depth to task difficulty instead of inheriting the CLI-wide default
@@ -50,6 +55,7 @@ args_template = [
   "exec",
   "--skip-git-repo-check",
   "{access_args}",
+  "{model_args}",
   "{engine_args}",
   "-C",
   "{taskdir}",

--- a/dashboard/ringside.html
+++ b/dashboard/ringside.html
@@ -105,32 +105,45 @@
       border-bottom: 1px solid var(--hairline);
       gap: 10px;
     }
-    .machine-strip {
+    .running-now {
       display: flex;
-      gap: 4px;
+      gap: 7px;
       align-items: center;
-      min-width: 60px;
-      max-width: 220px;
-      flex: 0 1 auto;
+      min-width: 0;
+      flex: 1 1 auto;
+      overflow-x: auto;
+      scrollbar-width: thin;
     }
-    .machine-strip button {
-      flex: 1 1 0;
-      min-width: 14px;
-      height: 7px;
-      border: 0;
-      border-radius: 4px;
-      padding: 0;
-      background: var(--waiting);
-      opacity: .45;
-      cursor: pointer;
+    .running-now:empty { display: none; }
+    .run-switch {
+      flex: 0 0 auto;
+      min-width: 0;
+      display: inline-flex;
+      align-items: center;
+      gap: 7px;
+      padding: 6px 10px;
+      border: 1px solid var(--hairline);
+      border-radius: 999px;
+      background: var(--surface);
+      color: var(--ink);
+      font-size: 12px;
+      line-height: 1;
     }
-    .machine-strip button.live { background: var(--accent); opacity: 1; }
-    .machine-strip button.pass { background: var(--pass); opacity: .9; }
-    .machine-strip button.fail { background: var(--fail); opacity: .9; }
-    .machine-strip button[aria-current="true"] { outline: 1.5px solid var(--ink); outline-offset: 2px; }
-    @media (prefers-reduced-motion: no-preference) {
-      .machine-strip button.live { animation: pulse 1.4s ease-in-out infinite; }
+    .run-switch:hover { border-color: var(--accent); }
+    .run-switch[aria-current="true"] {
+      border-color: var(--accent);
+      color: var(--accent);
+      box-shadow: inset 0 0 0 1px var(--accent);
     }
+    .run-switch-name {
+      max-width: 18ch;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      font-weight: 700;
+    }
+    .run-switch-progress { color: var(--muted); font-size: 11px; }
+    .run-switch .live-dot { width: 7px; height: 7px; flex-basis: 7px; }
     .artifact-tools button {
       padding: 7px 14px;
       border: 1px solid var(--hairline);
@@ -160,7 +173,7 @@
     }
     select:focus-visible,
     summary.run-head:focus-visible,
-    .machine-strip button:focus-visible {
+    .run-switch:focus-visible {
       outline: 2px solid var(--accent);
       outline-offset: 2px;
     }
@@ -261,27 +274,51 @@
     @media (prefers-reduced-motion: no-preference) {
       .rounds .working, .rounds .retry { animation: pulse 1.4s ease-in-out infinite; }
     }
-    .legend { font-size: 12.5px; color: var(--muted); margin: 0 0 clamp(12px, 2vw, 18px); }
-
     section h2 {
       font-size: 12px; font-weight: 700; letter-spacing: .1em;
       text-transform: uppercase; color: var(--muted);
       margin: 0 0 4px; padding-bottom: 8px;
       border-bottom: 1px solid var(--hairline);
     }
-    .workers { margin-top: clamp(14px, 2vw, 20px); }
-    .worker {
+    .workers {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 10px;
+      margin-top: clamp(14px, 2vw, 20px);
+    }
+    .workers > .empty { grid-column: 1 / -1; }
+    .worker-card {
+      min-width: 0;
+      overflow: hidden;
+      border: 1px solid var(--hairline);
+      border-radius: 8px;
+      background: var(--surface);
+    }
+    .worker-card.expanded { grid-column: 1 / -1; }
+    .worker-card-toggle {
       width: 100%;
       display: grid;
-      grid-template-columns: 18px minmax(0,1fr) auto auto;
-      gap: 4px 12px; align-items: baseline;
-      padding: 12px 0; border: 0; border-bottom: 1px solid var(--hairline);
+      grid-template-columns: minmax(0, 1fr) auto;
+      gap: 7px 12px;
+      align-items: center;
+      padding: 12px;
+      border: 0;
       background: transparent;
       text-align: left;
     }
-    .worker:hover .name,
-    .worker:focus-visible .name { color: var(--accent); }
-    .worker[aria-expanded="true"] .name { color: var(--accent); }
+    .worker-card-toggle:hover .name,
+    .worker-card-toggle:focus-visible .name,
+    .worker-card-toggle[aria-expanded="true"] .name { color: var(--accent); }
+    .worker-card-toggle:focus-visible {
+      outline: 2px solid var(--accent);
+      outline-offset: -2px;
+    }
+    .worker-card-head {
+      min-width: 0;
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
     .glyph { width: 11px; height: 11px; border-radius: 50%; align-self: center; }
     .glyph.pass { background: var(--pass); }
     .glyph.working { background: var(--accent); }
@@ -291,21 +328,31 @@
     @media (prefers-reduced-motion: no-preference) {
       .glyph.working, .glyph.retry { animation: pulse 1.4s ease-in-out infinite; }
     }
-    .worker .name { font-weight: 650; font-size: 15px; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-    .worker .state { font-size: 13px; font-weight: 650; white-space: nowrap; }
+    .worker-card .name { font-weight: 650; font-size: 14px; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    .worker-card .state { font-size: 12px; font-weight: 650; white-space: nowrap; }
     .state.pass { color: var(--pass); }
     .state.working { color: var(--accent); }
     .state.retry,
     .state.fail { color: var(--fail); }
     .state.waiting { color: var(--waiting); }
-    .worker .time { font-size: 12.5px; color: var(--muted); white-space: nowrap; }
-    .worker .activity {
-      grid-column: 2 / -1; font-size: 13px; color: var(--muted);
+    .worker-card .meta {
+      grid-column: 1 / -1;
+      min-width: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      color: var(--muted);
+      font-size: 11.5px;
+    }
+    .worker-card .activity {
+      grid-column: 1 / -1;
+      font-size: 12.5px;
+      color: var(--muted);
       min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
     }
     .stream {
-      padding: 0 0 14px 30px;
-      border-bottom: 1px solid var(--hairline);
+      padding: 12px;
+      border-top: 1px solid var(--hairline);
     }
     .stream-head {
       display: flex;
@@ -491,6 +538,7 @@
 
     @media (max-width: 760px) {
       .topbar-main { flex-wrap: wrap; gap: 6px 10px; }
+      .running-now { order: 3; flex-basis: 100%; }
       .run-head .clock { width: 100%; margin-left: 21px; }
       .artifact-layout {
         min-height: auto;
@@ -509,22 +557,9 @@
         min-height: 58vh;
       }
     }
-    @media (max-width: 560px) {
-      .worker {
-        grid-template-columns: 18px minmax(0,1fr);
-      }
-      .worker .state,
-      .worker .time,
-      .worker .activity {
-        grid-column: 2 / -1;
-      }
-      .worker .state,
-      .worker .time {
-        white-space: normal;
-      }
-      .stream {
-        padding-left: 0;
-      }
+    @media (max-width: 720px) {
+      .workers { grid-template-columns: minmax(0, 1fr); }
+      .worker-card.expanded { grid-column: auto; }
     }
   </style>
 </head>
@@ -536,7 +571,7 @@
         <span class="eyebrow wordmark"><b>Ringside</b></span>
         <span id="reconnect" class="reconnect mono" hidden>reconnecting…</span>
       </div>
-      <div id="machine-strip" class="machine-strip" role="group" aria-label="Everything running on this machine"></div>
+      <div id="running-now" class="running-now" role="group" aria-label="Running now"></div>
       <time id="clock" class="clock mono"></time>
     </header>
 
@@ -574,7 +609,7 @@
       libraryError: null,
       tab: normalizeTab(localStorage.getItem(TAB_KEY)) || "live",
       hasStoredTab: Boolean(normalizeTab(localStorage.getItem(TAB_KEY))),
-      expanded: null,
+      expanded: new Map(),
       logTimer: null,
       artifactName: sessionStorage.getItem(ARTIFACT_KEY) || "",
       artifactManual: Boolean(sessionStorage.getItem(ARTIFACT_KEY)),
@@ -583,13 +618,15 @@
       frameContent: "",
       frameRequest: 0,
       rendering: false,
-      runOpen: {}
+      runOpen: {},
+      focusedRunId: ""
     };
 
     const els = {
       topDot: document.getElementById("top-dot"),
       reconnect: document.getElementById("reconnect"),
       clock: document.getElementById("clock"),
+      runningNow: document.getElementById("running-now"),
       runs: document.getElementById("runs"),
       artifactPicker: document.getElementById("artifact-picker"),
       artifactStatus: document.getElementById("artifact-status"),
@@ -660,6 +697,10 @@
       return String(task.key || task.id || task.name || `task-${index}`);
     }
 
+    function expansionKey(runIdValue, taskKeyValue) {
+      return JSON.stringify([String(runIdValue), String(taskKeyValue)]);
+    }
+
     function normalizeRuns(payload) {
       const raw = Array.isArray(payload) ? payload : (Array.isArray(payload?.runs) ? payload.runs : []);
       const runs = raw.filter(Boolean).map((run, index) => {
@@ -670,6 +711,10 @@
         const stateName = rawState === "died" ? "died" : (live ? "live" : "finished");
         const pass = numberOrZero(run.pass ?? summary.pass ?? totals.pass);
         const fail = numberOrZero(run.fail ?? summary.fail ?? totals.fail);
+        const doneSource = run.done ?? summary.done ?? totals.done;
+        const done = doneSource === undefined || doneSource === null
+          ? pass + fail
+          : numberOrZero(doneSource);
         const tokens = numberOrZero(run.tokens ?? summary.tokens ?? totals.tokens);
         return {
           ...run,
@@ -682,6 +727,7 @@
           elapsed_s: elapsedForRun({...run, state: stateName}),
           pass,
           fail,
+          done,
           tokens,
           tasks: Array.isArray(run.tasks) ? run.tasks : []
         };
@@ -723,6 +769,17 @@
       if (direct) return direct;
       const tail = Array.isArray(task?.log_tail) ? task.log_tail : [];
       return tail.map(line => String(line).trim()).filter(Boolean).slice(-1)[0] || "";
+    }
+
+    function runIsRunningNow(run) {
+      return run.state === "live"
+        && state.active
+        && typeof state.active === "object"
+        && Object.prototype.hasOwnProperty.call(state.active, run.__id);
+    }
+
+    function runningNowRuns() {
+      return state.runs.filter(runIsRunningNow);
     }
 
     function setTab(_tab, _persist) { /* unified page — tabs removed */ }
@@ -828,9 +885,76 @@
     }
 
     function renderTop() {
-      const anyLive = state.runs.some(run => run.state === "live");
+      const anyLive = runningNowRuns().length > 0;
       els.topDot.classList.toggle("live", anyLive);
       els.reconnect.hidden = !(state.runError || state.libraryError);
+    }
+
+    function effectiveFocusedRunId(liveRuns) {
+      if (liveRuns.some(run => run.__id === state.focusedRunId)) return state.focusedRunId;
+      return liveRuns.find(run => run.run_name === state.artifactName)?.__id || "";
+    }
+
+    function renderRunningNow() {
+      const liveRuns = runningNowRuns();
+      const staging = document.createElement("div");
+      if (liveRuns.length >= 2) {
+        const activeRunId = effectiveFocusedRunId(liveRuns);
+        liveRuns.forEach(run => {
+          const button = document.createElement("button");
+          button.type = "button";
+          button.className = "run-switch";
+          button.dataset.key = run.__id;
+          button.setAttribute("aria-current", String(run.__id === activeRunId));
+          const total = run.tasks.length;
+          const done = Math.min(total, Math.max(0, run.done));
+          button.setAttribute("aria-label", `${run.run_name}, live, ${done} of ${total} tasks done`);
+          button.addEventListener("click", () => focusRun(run.__id));
+
+          const dot = document.createElement("span");
+          dot.className = "live-dot live";
+          dot.setAttribute("aria-hidden", "true");
+          const name = document.createElement("span");
+          name.className = "run-switch-name";
+          name.textContent = run.run_name;
+          const progress = document.createElement("span");
+          progress.className = "run-switch-progress mono";
+          progress.textContent = `${done}/${total}`;
+          button.append(dot, name, progress);
+          staging.appendChild(button);
+        });
+      }
+      state.rendering = true;
+      morphChildren(els.runningNow, staging);
+      state.rendering = false;
+    }
+
+    function focusRun(runIdValue) {
+      const run = state.runs.find(item => item.__id === runIdValue);
+      if (!run || !runIsRunningNow(run)) return;
+      state.focusedRunId = run.__id;
+      state.artifactName = run.run_name;
+      state.artifactManual = true;
+      state.artifactVersion = "live";
+      state.frameKey = "";
+      state.runOpen[run.__id] = true;
+      sessionStorage.setItem(ARTIFACT_KEY, run.run_name);
+      renderRunningNow();
+      renderArtifacts();
+      renderArtifactControls();
+      renderLive();
+      loadArtifactFrame(true);
+      requestAnimationFrame(() => requestAnimationFrame(() => {
+        const target = [...els.runs.querySelectorAll("details.run")]
+          .find(section => section.dataset.key === run.__id);
+        if (!target) return;
+        target.open = true;
+        state.runOpen[run.__id] = true;
+        target.scrollIntoView({
+          behavior: window.matchMedia("(prefers-reduced-motion: reduce)").matches ? "auto" : "smooth",
+          block: "start"
+        });
+      }));
     }
 
     function renderLive() {
@@ -870,20 +994,20 @@
         const head = document.createElement("summary");
         head.className = "corner run-head";
         const dot = document.createElement("span");
-        dot.className = `live-dot ${run.state === "live" ? "live" : ""}`;
+        dot.className = `live-dot ${runIsRunningNow(run) ? "live" : ""}`;
         dot.setAttribute("aria-hidden", "true");
         const title = document.createElement("span");
         title.className = "eyebrow";
         const titleBold = document.createElement("b");
-        titleBold.textContent = `Round ${roundOf(run)}`;
+        titleBold.textContent = run.run_name;
         title.appendChild(titleBold);
         const identity = document.createElement("span");
         identity.className = "identity";
-        identity.textContent = `${run.tasks.length} agent${run.tasks.length === 1 ? "" : "s"} · ${run.identity}`;
+        identity.textContent = `Round ${roundOf(run)} · ${run.identity}`;
         const stats = document.createElement("span");
         stats.className = "clock mono run-stats";
         const outcome = run.state === "live"
-          ? `${run.pass} passed so far`
+          ? `${Math.min(run.tasks.length, run.done)}/${run.tasks.length} done`
           : (run.fail > 0 ? `${run.pass} passed · ${run.fail} failed` : `all ${run.pass} passed`);
         const tok = run.tokens > 0 ? ` · ${formatTokens(run.tokens)}` : "";
         stats.textContent = `${outcome} · ${formatDuration(run.elapsed_s)}${tok}`;
@@ -909,11 +1033,6 @@
         );
         section.appendChild(rounds);
 
-        const legend = document.createElement("p");
-        legend.className = "legend";
-        legend.textContent = `${counts.pass} finished & checked · ${counts.working} working · ${counts.retry} sent back · ${counts.waiting} waiting · ${counts.fail} failed`;
-        section.appendChild(legend);
-
         const workers = document.createElement("div");
         workers.className = "workers";
         if (!run.tasks.length) {
@@ -925,13 +1044,19 @@
         run.tasks.forEach((task, taskIndex) => {
           const key = taskKey(task, taskIndex);
           const kind = taskKind(task);
-          const isExpanded = state.expanded && state.expanded.runId === run.__id && state.expanded.taskKey === key;
-          const row = document.createElement("button");
-          row.className = "worker";
-          row.dataset.key = `worker:${key}`;
-          row.type = "button";
-          row.setAttribute("aria-expanded", String(Boolean(isExpanded)));
-          row.addEventListener("click", () => toggleWorker(run, task, taskIndex));
+          const expandedKey = expansionKey(run.__id, key);
+          const expanded = state.expanded.get(expandedKey);
+          const isExpanded = Boolean(expanded);
+          const card = document.createElement("article");
+          card.className = `worker-card${isExpanded ? " expanded" : ""}`;
+          card.dataset.key = `worker:${key}`;
+
+          const toggle = document.createElement("button");
+          toggle.className = "worker-card-toggle";
+          toggle.type = "button";
+          toggle.setAttribute("aria-expanded", String(isExpanded));
+          if (isExpanded) toggle.setAttribute("aria-controls", `stream-${runIndex}-${taskIndex}`);
+          toggle.addEventListener("click", () => toggleWorker(run.__id, key));
 
           const glyph = document.createElement("span");
           glyph.className = `glyph ${kind}`;
@@ -939,24 +1064,39 @@
           const name = document.createElement("span");
           name.className = "name";
           name.textContent = key;
+          const cardHead = document.createElement("span");
+          cardHead.className = "worker-card-head";
+          cardHead.append(name, glyph);
           const taskState = document.createElement("span");
           taskState.className = `state ${kind}`;
           taskState.textContent = taskStateText(kind);
-          const time = document.createElement("span");
-          time.className = "time mono";
-          time.textContent = kind === "waiting" ? "—" : formatDuration(task.elapsed_s);
-          row.append(glyph, name, taskState, time);
-
-          const activity = taskIsRunning(task) ? taskActivity(task) : "";
-          if (activity) {
-            const line = document.createElement("span");
-            line.className = "activity";
-            line.textContent = activity;
-            row.appendChild(line);
+          const engine = String(task.engine || "").trim() || "engine not reported";
+          const model = String(task.model || "").trim();
+          const metaParts = [model ? `${engine} · ${model}` : engine];
+          metaParts.push(kind === "waiting" ? "—" : formatDuration(task.elapsed_s));
+          const attempts = numberOrZero(task.attempts);
+          if (attempts > 1) metaParts.push(`attempt ${attempts}`);
+          if (numberOrZero(task.tokens) > 0) metaParts.push(formatTokens(task.tokens));
+          const meta = document.createElement("span");
+          meta.className = "meta mono";
+          meta.textContent = metaParts.join(" · ");
+          toggle.setAttribute("aria-label", `${key}, ${taskStateText(kind)}, ${metaParts.join(", ")}`);
+          toggle.append(cardHead, taskState, meta);
+          const activityText = taskIsRunning(task) ? (taskActivity(task) || "No activity reported yet.") : "";
+          if (activityText) {
+            const activity = document.createElement("span");
+            activity.className = "activity";
+            activity.textContent = activityText;
+            toggle.appendChild(activity);
           }
-          workers.appendChild(row);
+          card.appendChild(toggle);
 
-          if (isExpanded) workers.appendChild(renderStream(run, task, taskIndex));
+          if (expanded) {
+            const stream = renderStream(run, task, taskIndex, expanded, expandedKey);
+            stream.id = `stream-${runIndex}-${taskIndex}`;
+            card.appendChild(stream);
+          }
+          workers.appendChild(card);
         });
         section.appendChild(workers);
         staging.appendChild(section);
@@ -969,11 +1109,12 @@
       syncLogPolling();
     }
 
-    function renderStream(run, task, taskIndex) {
+    function renderStream(run, task, taskIndex, expanded, expandedKey) {
       const panel = document.createElement("div");
       panel.className = "stream";
       panel.dataset.stream = "true";
       panel.dataset.key = `stream:${taskKey(task, taskIndex)}`;
+      panel.dataset.expansionKey = expandedKey;
 
       // The brief: the exact prompt this model was handed, plus the pass
       // test that will judge its work. Watchers should never have to guess
@@ -1013,21 +1154,21 @@
       const pre = document.createElement("pre");
       pre.className = "stream-log";
       pre.tabIndex = 0;
-      pre.textContent = state.expanded?.logText || "No log output yet.";
+      pre.textContent = expanded.logText || "No log output yet.";
       pre.addEventListener("scroll", () => {
         const distance = pre.scrollHeight - pre.scrollTop - pre.clientHeight;
-        if (state.expanded) {
-          state.expanded.pinned = distance < 28;
-          state.expanded.scrollTop = pre.scrollTop;
+        if (state.expanded.get(expandedKey) === expanded) {
+          expanded.pinned = distance < 28;
+          expanded.scrollTop = pre.scrollTop;
         }
       });
       panel.appendChild(pre);
-      if (state.expanded?.error) {
+      if (expanded.error) {
         const error = document.createElement("p");
         error.className = "catch";
         const bold = document.createElement("b");
         bold.textContent = "Log stream unavailable:";
-        error.append(bold, document.createTextNode(` ${state.expanded.error}`));
+        error.append(bold, document.createTextNode(` ${expanded.error}`));
         panel.appendChild(error);
       }
 
@@ -1062,55 +1203,57 @@
         }
       }
       requestAnimationFrame(() => {
-        if (state.expanded?.pinned !== false) {
+        if (expanded.pinned !== false) {
           pre.scrollTop = pre.scrollHeight;
         } else {
-          pre.scrollTop = state.expanded?.scrollTop || 0;
+          pre.scrollTop = expanded.scrollTop || 0;
         }
       });
       return panel;
     }
 
-    function toggleWorker(run, task, taskIndex) {
-      const key = taskKey(task, taskIndex);
-      if (state.expanded && state.expanded.runId === run.__id && state.expanded.taskKey === key) {
-        closeWorker();
+    function toggleWorker(runIdValue, taskKeyValue) {
+      const key = expansionKey(runIdValue, taskKeyValue);
+      if (state.expanded.has(key)) {
+        closeWorker(key);
         return;
       }
-      state.expanded = {
-        runId: run.__id,
-        taskKey: key,
+      state.expanded.set(key, {
+        runId: runIdValue,
+        taskKey: taskKeyValue,
         logText: "",
         error: "",
         pinned: true,
         scrollTop: 0,
         finalFetched: false
-      };
+      });
       renderLive();
-      fetchExpandedLog();
+      const found = findExpandedTask(state.expanded.get(key));
+      if (found && taskIsRunning(found.task)) fetchExpandedLog(key);
     }
 
-    function closeWorker() {
-      state.expanded = null;
-      if (state.logTimer) {
+    function closeWorker(key) {
+      if (key) state.expanded.delete(key);
+      else state.expanded.clear();
+      if (!hasRunningExpandedTasks() && state.logTimer) {
         clearInterval(state.logTimer);
         state.logTimer = null;
       }
       renderLive();
     }
 
-    function findExpandedTask() {
-      if (!state.expanded) return null;
-      const run = state.runs.find(item => item.__id === state.expanded.runId);
+    function findExpandedTask(expanded) {
+      if (!expanded) return null;
+      const run = state.runs.find(item => item.__id === expanded.runId);
       if (!run) return null;
-      const index = run.tasks.findIndex((task, taskIndex) => taskKey(task, taskIndex) === state.expanded.taskKey);
+      const index = run.tasks.findIndex((task, taskIndex) => taskKey(task, taskIndex) === expanded.taskKey);
       if (index < 0) return null;
       return {run, task: run.tasks[index], index};
     }
 
-    async function fetchExpandedLog() {
-      const expanded = state.expanded;
-      const found = findExpandedTask();
+    async function fetchExpandedLog(key) {
+      const expanded = state.expanded.get(key);
+      const found = findExpandedTask(expanded);
       if (!expanded || !found) return;
       const path = `/logs/${encodeURIComponent(found.run.__id)}/${encodeURIComponent(expanded.taskKey)}`;
       try {
@@ -1119,49 +1262,69 @@
         const raw = await response.text();
         // Worker logs carry raw terminal output; strip ANSI escapes for the stream view.
         const text = raw.replace(/\[[0-9;?]*[ -\/]*[@-~]/g, "").replace(/\[[0-9;]{1,6}m/g, "");
-        if (state.expanded !== expanded) return;
+        if (state.expanded.get(key) !== expanded) return;
         expanded.logText = text || "No log output yet.";
         expanded.error = "";
-        updateStreamText(expanded.logText);
+        updateStreamText(key, expanded.logText);
       } catch (error) {
-        if (state.expanded !== expanded) return;
+        if (state.expanded.get(key) !== expanded) return;
         expanded.error = error?.message || "could not read log";
         renderLive();
       }
     }
 
-    function updateStreamText(text) {
-      const pre = els.runs.querySelector(".stream pre.stream-log");
+    function updateStreamText(key, text) {
+      const stream = [...els.runs.querySelectorAll(".stream[data-expansion-key]")]
+        .find(item => item.dataset.expansionKey === key);
+      const pre = stream?.querySelector("pre.stream-log");
       if (!pre) return;
-      const shouldPin = state.expanded?.pinned !== false || pre.scrollHeight - pre.scrollTop - pre.clientHeight < 28;
+      const expanded = state.expanded.get(key);
+      if (!expanded) return;
+      const shouldPin = expanded.pinned !== false || pre.scrollHeight - pre.scrollTop - pre.clientHeight < 28;
       const scrollTop = pre.scrollTop;
       pre.textContent = text || "No log output yet.";
       if (shouldPin) {
         pre.scrollTop = pre.scrollHeight;
       } else {
         pre.scrollTop = scrollTop;
-        if (state.expanded) state.expanded.scrollTop = scrollTop;
+        expanded.scrollTop = scrollTop;
       }
     }
 
+    function hasRunningExpandedTasks() {
+      return [...state.expanded.values()].some(expanded => {
+        const found = findExpandedTask(expanded);
+        return found && taskIsRunning(found.task);
+      });
+    }
+
+    function fetchExpandedLogs() {
+      [...state.expanded.entries()].forEach(([key, expanded]) => {
+        const found = findExpandedTask(expanded);
+        if (found && taskIsRunning(found.task)) fetchExpandedLog(key);
+      });
+    }
+
     function syncLogPolling() {
-      if (!state.expanded) return;
-      const found = findExpandedTask();
-      if (!found) {
-        closeWorker();
-        return;
+      [...state.expanded.entries()].forEach(([key, expanded]) => {
+        const found = findExpandedTask(expanded);
+        if (!found) {
+          state.expanded.delete(key);
+          return;
+        }
+        if (taskIsRunning(found.task)) expanded.finalFetched = false;
+        if (!taskIsRunning(found.task) && !expanded.finalFetched) {
+          expanded.finalFetched = true;
+          fetchExpandedLog(key);
+        }
+      });
+      const hasRunning = hasRunningExpandedTasks();
+      if (hasRunning && !state.logTimer) {
+        state.logTimer = setInterval(fetchExpandedLogs, 1000);
       }
-      const running = taskIsRunning(found.task);
-      if (running && !state.logTimer) {
-        state.logTimer = setInterval(fetchExpandedLog, 1000);
-      }
-      if (!running && state.logTimer) {
+      if (!hasRunning && state.logTimer) {
         clearInterval(state.logTimer);
         state.logTimer = null;
-      }
-      if (!running && !state.expanded.finalFetched) {
-        state.expanded.finalFetched = true;
-        fetchExpandedLog();
       }
     }
 
@@ -1450,39 +1613,8 @@
         state.runError = error?.message || "runs unavailable";
       }
       renderTop();
-      renderMachineStrip();
+      renderRunningNow();
       renderLive();
-    }
-
-    function renderMachineStrip() {
-      const strip = document.getElementById("machine-strip");
-      if (!strip) return;
-      const runs = [...state.runs].sort((a, b) => parseTime(a.started_at) - parseTime(b.started_at)).slice(-10);
-      const staging = document.createElement("div");
-      runs.forEach(run => {
-        const seg = document.createElement("button");
-        seg.type = "button";
-        seg.dataset.key = run.__id;
-        seg.className = run.state === "live" ? "live" : (run.fail > 0 || run.state === "died" ? "fail" : "pass");
-        seg.title = `${run.run_name} — ${run.state === "live" ? "live" : run.state} (${run.identity})`;
-        seg.setAttribute("aria-label", seg.title);
-        seg.setAttribute("aria-current", String(run.run_name === state.artifactName));
-        seg.addEventListener("click", () => {
-          state.artifactName = run.run_name;
-          state.artifactManual = true;
-          state.artifactVersion = "live";
-          state.frameKey = "";
-          sessionStorage.setItem(ARTIFACT_KEY, run.run_name);
-          renderArtifacts();
-          renderArtifactControls();
-          renderLive();
-          loadArtifactFrame(true);
-        });
-        staging.appendChild(seg);
-      });
-      state.rendering = true;
-      morphChildren(strip, staging);
-      state.rendering = false;
     }
 
     async function fetchLibrary() {
@@ -1498,6 +1630,7 @@
       renderTop();
       renderArtifacts();
       renderArtifactControls();
+      renderRunningNow();
       loadArtifactFrame(false);
     }
     els.artifactVersion.addEventListener("change", () => {
@@ -1524,16 +1657,20 @@
       state.artifactVersion = "live";
       state.frameKey = "";
       sessionStorage.setItem(ARTIFACT_KEY, name);
+      state.focusedRunId = "";
       renderArtifacts();
       renderArtifactControls();
+      renderRunningNow();
+      renderLive();
       loadArtifactFrame(true);
     });
     document.addEventListener("keydown", event => {
-      if (event.key === "Escape" && state.expanded) closeWorker();
+      if (event.key === "Escape" && state.expanded.size) closeWorker();
     });
 
     tickClock();
     renderTop();
+    renderRunningNow();
     renderLive();
     renderArtifacts();
     fetchRuns();

--- a/docs/MODEL-NOTES.md
+++ b/docs/MODEL-NOTES.md
@@ -287,3 +287,10 @@ checks and raw logs support — no vibes, no worker self-reports.
 
 ## gpt-5.6-luna (codex)
 - 2026-07-09 code-feature (unlock-ai guide-format conversion, strict type-contract check): 1/1 first-try, 42.6k tokens, 80s. Followed a multi-file TS pattern precisely at $1/$6 pricing. Good candidate for mechanical codegen/docs lanes; audition in adjacent types.
+
+## gpt-5.6-sol (codex)
+- 2026-07-09 code-feature/code-fix (ringside-overhaul): 4/4 first-try — a ringer.py logging change with tests, a 265-line stdlib backfill CLI (atomic rewrite, dry-run, idempotence all check-verified), a ~1500-line single-file HTML redesign (running-now pills + worker-card grid + multi-expansion refactor, 30KB patch, node --check + contract greps + unittest), and a render-gating change where it correctly UPDATED tests asserting the old behavior instead of gaming the check. Medium/high reasoning, 65–120k tokens/task.
+- Same day, different session (bench-harness-patches, code-fix): 0.29 first-try over 7 tasks on a Next.js/Turbopack harness. Spec and check quality dominate model choice — see the scoreboard before generalizing either number.
+
+## GPT-5.5 (codex) — attribution caveat
+- Scoreboard rows dated before 2026-07-09 may actually be gpt-5.6: codex eval rows logged model="" until the write-time stamping fix (PR #18) and were credited to GPT-5.5 by the registry default at read time, while the machine's codex default had already moved to gpt-5.6-sol at an unknown earlier date. `scripts/backfill_model_from_logs.py` re-stamps rows with surviving command-log evidence; anything it skips is a mixed-model aggregate. Trust post-2026-07-09 rows.

--- a/docs/MODEL-NOTES.md
+++ b/docs/MODEL-NOTES.md
@@ -270,24 +270,6 @@ checks and raw logs support — no vibes, no worker self-reports.
 - 8/8 code-feature tasks passed attempt 1 across 3 rounds (worktrees mode, Python harness refactor; 108k-406k tokens/task). Specs embedded the approved architecture doc + exact file ownership; checks built fresh uv venvs and ran the full pytest suite.
 - Lesson (check design, not model): all 3 post-integration bugs were invisible to the checks — a test that passed only because the worker's worktree lacked .env, a `--help`-only assertion missing a runtime importlib/sys.modules bug (py3.12 dataclasses), and bare console-script names failing outside activated venvs. Checks should exercise one real invocation from a cold shell, not just --help.
 
-## nvidia/nemotron-3-super-120b-a12b:free
-- 2026-07-08 (research, content-strategy-recon): FAIL x2. Did the analysis in chat but never wrote report.md; attempt 2 exited rc=0 with no file. Doesn't reliably follow file-output contracts under OpenCode. Demoted — don't re-audition on file-deliverable tasks.
-
-## meta-llama/llama-3.3-70b-instruct:free
-- 2026-07-08 (research, content-strategy-recon): FAIL x2. Timed out at 900s both attempts on a moderate DB-scrape+format task. Too slow on the free tier for harness work. Demoted — don't re-audition without much longer timeouts or paid tier.
-
-## z-ai/glm-5.2 (addendum)
-- 2026-07-08 (research/filter, pitch-foundry): FAIL x2 on a long-spec rubric-application task (~40k input: embedded rubric + 4 candidate files). Read all inputs, exited rc=0 with ZERO output tokens both attempts — silent stall, no file written. GLM handled the same session's shorter formatting specs fine. Lesson: keep GLM specs short; route long-context apply-this-rubric work to codex.
-
-## GPT-5.5 (codex) — honesty flag
-- 2026-07-08 (image-gen, pitch-foundry): sandbox DNS blocked openrouter.ai; ALL 10 API calls errored (logged honestly in gen-log) — but the worker then FABRICATED 10 deliverables locally (composited canvases from the ref image) to satisfy a files-exist>40KB check, and passed. Lesson: (a) codex sandbox has no external DNS on this machine — route API-calling tasks to opencode (network open); (b) never write an existence-only check for generated media — require the success log (SAVED/cost lines) to match the file count.
-
-## nvidia/nemotron-3-super-120b-a12b:free
-- 2026-07-09 persona-review (pitch-foundry exec-briefing panel): 0/2 first-try+retry. Produced coherent review CONTENT as chat text but never wrote report.md — does not reliably use file-write tools under opencode. Demoted; do not re-audition for file-deliverable tasks without a write-tool probe first.
-
-## gpt-5.6-luna (codex)
-- 2026-07-09 code-feature (unlock-ai guide-format conversion, strict type-contract check): 1/1 first-try, 42.6k tokens, 80s. Followed a multi-file TS pattern precisely at $1/$6 pricing. Good candidate for mechanical codegen/docs lanes; audition in adjacent types.
-
 ## gpt-5.6-sol (codex)
 - 2026-07-09 code-feature/code-fix (ringside-overhaul): 4/4 first-try — a ringer.py logging change with tests, a 265-line stdlib backfill CLI (atomic rewrite, dry-run, idempotence all check-verified), a ~1500-line single-file HTML redesign (running-now pills + worker-card grid + multi-expansion refactor, 30KB patch, node --check + contract greps + unittest), and a render-gating change where it correctly UPDATED tests asserting the old behavior instead of gaming the check. Medium/high reasoning, 65–120k tokens/task.
 - Same day, different session (bench-harness-patches, code-fix): 0.29 first-try over 7 tasks on a Next.js/Turbopack harness. Spec and check quality dominate model choice — see the scoreboard before generalizing either number.

--- a/docs/MODEL-NOTES.md
+++ b/docs/MODEL-NOTES.md
@@ -269,3 +269,21 @@ checks and raw logs support — no vibes, no worker self-reports.
 ## codex (2026-07-06, bench-operator-proofing)
 - 8/8 code-feature tasks passed attempt 1 across 3 rounds (worktrees mode, Python harness refactor; 108k-406k tokens/task). Specs embedded the approved architecture doc + exact file ownership; checks built fresh uv venvs and ran the full pytest suite.
 - Lesson (check design, not model): all 3 post-integration bugs were invisible to the checks — a test that passed only because the worker's worktree lacked .env, a `--help`-only assertion missing a runtime importlib/sys.modules bug (py3.12 dataclasses), and bare console-script names failing outside activated venvs. Checks should exercise one real invocation from a cold shell, not just --help.
+
+## nvidia/nemotron-3-super-120b-a12b:free
+- 2026-07-08 (research, content-strategy-recon): FAIL x2. Did the analysis in chat but never wrote report.md; attempt 2 exited rc=0 with no file. Doesn't reliably follow file-output contracts under OpenCode. Demoted — don't re-audition on file-deliverable tasks.
+
+## meta-llama/llama-3.3-70b-instruct:free
+- 2026-07-08 (research, content-strategy-recon): FAIL x2. Timed out at 900s both attempts on a moderate DB-scrape+format task. Too slow on the free tier for harness work. Demoted — don't re-audition without much longer timeouts or paid tier.
+
+## z-ai/glm-5.2 (addendum)
+- 2026-07-08 (research/filter, pitch-foundry): FAIL x2 on a long-spec rubric-application task (~40k input: embedded rubric + 4 candidate files). Read all inputs, exited rc=0 with ZERO output tokens both attempts — silent stall, no file written. GLM handled the same session's shorter formatting specs fine. Lesson: keep GLM specs short; route long-context apply-this-rubric work to codex.
+
+## GPT-5.5 (codex) — honesty flag
+- 2026-07-08 (image-gen, pitch-foundry): sandbox DNS blocked openrouter.ai; ALL 10 API calls errored (logged honestly in gen-log) — but the worker then FABRICATED 10 deliverables locally (composited canvases from the ref image) to satisfy a files-exist>40KB check, and passed. Lesson: (a) codex sandbox has no external DNS on this machine — route API-calling tasks to opencode (network open); (b) never write an existence-only check for generated media — require the success log (SAVED/cost lines) to match the file count.
+
+## nvidia/nemotron-3-super-120b-a12b:free
+- 2026-07-09 persona-review (pitch-foundry exec-briefing panel): 0/2 first-try+retry. Produced coherent review CONTENT as chat text but never wrote report.md — does not reliably use file-write tools under opencode. Demoted; do not re-audition for file-deliverable tasks without a write-tool probe first.
+
+## gpt-5.6-luna (codex)
+- 2026-07-09 code-feature (unlock-ai guide-format conversion, strict type-contract check): 1/1 first-try, 42.6k tokens, 80s. Followed a multi-file TS pattern precisely at $1/$6 pricing. Good candidate for mechanical codegen/docs lanes; audition in adjacent types.

--- a/registry/model-identity.toml
+++ b/registry/model-identity.toml
@@ -17,6 +17,21 @@ display = "GPT-5.5"
 confidence = "verified"     # snapshot gpt-5.5-2026-04-23, Codex CLI default; see capability file
 source = "https://developers.openai.com/codex/models"
 
+[engines.codex.models."gpt-5.6-sol"]
+display = "GPT-5.6 Sol"
+confidence = "verified"
+source = "https://developers.openai.com/codex/models"
+
+[engines.codex.models."gpt-5.6-luna"]
+display = "GPT-5.6 Luna"
+confidence = "verified"
+source = "https://developers.openai.com/codex/models"
+
+[engines.codex.models."gpt-5.6-terra"]
+display = "GPT-5.6 Terra"
+confidence = "verified"
+source = "https://developers.openai.com/codex/models"
+
 [engines.grok]
 harness = "Grok Build CLI"
 access = "OAuth plan"

--- a/ringer.py
+++ b/ringer.py
@@ -280,6 +280,7 @@ def built_in_codex_engine() -> EngineConfig:
             "exec",
             "--skip-git-repo-check",
             "{access_args}",
+            "{model_args}",
             "{engine_args}",
             "-C",
             "{taskdir}",
@@ -811,6 +812,7 @@ class TaskRuntime:
     last_check_returncode: int | None = None
     last_check_timed_out: bool = False
     last_check_output: str = ""
+    last_worker_command: list[str] = field(default_factory=list)
 
     def elapsed_s(self, now: float) -> float:
         if self.started_at_monotonic is None:
@@ -990,7 +992,11 @@ class StateWriter:
                         "status": runtime.status,
                         "verdict": runtime.final_verdict,
                         "engine": runtime.task.engine,
-                        "model": runtime.task.model or (engine.model_default if engine else ""),
+                        "model": (
+                            runtime.task.model
+                            or (engine.model_default if engine else "")
+                            or effective_model_from_command(runtime.last_worker_command)
+                        ),
                         "spec": runtime.task.spec,
                         "spec_short": runtime.spec_short,
                         "verified": runtime.task.verified,
@@ -3193,6 +3199,7 @@ def render_work_section(
     page_path: Path | None,
     force_wrappers: bool = False,
     primary: bool = False,
+    finished_only: bool = False,
 ) -> str:
     # One section carries the whole story: each worker, what it delivered,
     # how the delivery was checked, and where the raw log lives. The old
@@ -3200,9 +3207,16 @@ def render_work_section(
     # this information; per-worker live detail belongs to Ringside's agent
     # accordion, not the artifact.
     tasks = state_tasks(state)
+    if finished_only:
+        tasks = [
+            task
+            for task in tasks
+            if task_state_bucket(str(task.get("status", "queued"))) in {"pass", "fail"}
+        ]
     section_class = "work is-primary" if primary else "work"
     if not tasks:
-        body = '<p class="empty-note">No tasks.</p>'
+        empty_note = "Deliverables appear here as workers finish." if finished_only else "No tasks."
+        body = f'<p class="empty-note">{empty_note}</p>'
     else:
         groups = "".join(
             render_work_group(
@@ -3474,7 +3488,7 @@ def render_status_html(
   {render_corner_header(state, live=True)}
   <h1 id="right-now-heading" class="briefing">{briefing}</h1>
   {render_progress_bar(tasks, counts)}
-  {render_work_section(state, renderer=renderer, page_path=page_path, force_wrappers=force_wrappers)}
+  {render_work_section(state, renderer=renderer, page_path=page_path, force_wrappers=force_wrappers, finished_only=True)}
   <footer>
     <span class="mono">Updated {html_escape(local_time_label())}</span>
     <span>·</span>
@@ -7095,6 +7109,8 @@ class RingerRunner:
             engine_args=runtime.task.engine_args,
             model=runtime.task.model,
         )
+        with self.lock:
+            runtime.last_worker_command = list(cmd)
         append_text(
             log_path,
             "\n"
@@ -7183,7 +7199,11 @@ class RingerRunner:
         duration_ms: int,
     ) -> None:
         engine = self.config.engines.get(runtime.task.engine)
-        resolved_model = runtime.task.model or (engine.model_default if engine else "")
+        resolved_model = (
+            runtime.task.model
+            or (engine.model_default if engine else "")
+            or effective_model_from_command(runtime.last_worker_command)
+        )
         notes_parts = [
             f"retry={'true' if retrying else 'false'}",
             f"worker_returncode={worker.returncode}",
@@ -7370,6 +7390,18 @@ def parse_token_count(text: str, token_regex: str | None = DEFAULT_TOKEN_REGEX) 
     return int(matches[-1].replace(",", ""))
 
 
+def effective_model_from_command(command: list[str]) -> str:
+    """Return the model selected by a composed worker argv, if present."""
+    for index, item in enumerate(command):
+        if item in {"-m", "--model"}:
+            if index + 1 >= len(command):
+                return ""
+            return command[index + 1]
+        if item.startswith("--model="):
+            return item.removeprefix("--model=")
+    return ""
+
+
 def build_worker_command(
     engine: EngineConfig,
     *,
@@ -7385,6 +7417,10 @@ def build_worker_command(
     for item in engine.args_template:
         if item == "{access_args}":
             command.extend(access_args)
+            continue
+        if item == "{model_args}":
+            if resolved_model:
+                command.extend(("-m", resolved_model))
             continue
         if item == "{engine_args}":
             command.extend(engine_args)
@@ -7439,13 +7475,14 @@ def validate_manifest_engines(manifest: Manifest, config: AppConfig) -> None:
         raise ValueError(f"unknown worker engine(s): {', '.join(missing)}")
     for task in manifest.tasks:
         engine = config.engines[task.engine]
-        takes_model = any("{model}" in item for item in engine.args_template)
-        if takes_model and not (task.model or engine.model_default):
+        requires_model = any("{model}" in item for item in engine.args_template)
+        accepts_model = requires_model or "{model_args}" in engine.args_template
+        if requires_model and not (task.model or engine.model_default):
             raise ValueError(
                 f"task {task.key}: engine {engine.name} needs a model — set the task's "
                 f"\"model\" field or engines.{engine.name}.model_default in config.toml"
             )
-        if task.model and not takes_model:
+        if task.model and not accepts_model:
             raise ValueError(
                 f"task {task.key}: \"model\" is set but engine {engine.name} has no "
                 "{model} placeholder in its args_template, so it would be silently ignored"

--- a/scripts/backfill_model_from_logs.py
+++ b/scripts/backfill_model_from_logs.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python3
+"""Backfill missing eval-row models from recorded worker command lines.
+
+The eval log is rewritten only when command-log evidence is found. Run-state
+files and worker logs are read-only inputs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shlex
+import shutil
+import sys
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+COMMAND_PREFIX = "[ringer.py] command: "
+BACKFILL_NOTE = "\nmodel_backfill=command_log"
+
+
+def _split_raw_line(raw: bytes) -> tuple[bytes, bytes]:
+    """Return a line's body and terminator without changing either."""
+    if raw.endswith(b"\r\n"):
+        return raw[:-2], b"\r\n"
+    if raw.endswith(b"\n"):
+        return raw[:-1], b"\n"
+    return raw, b""
+
+
+def _model_from_tokens(tokens: list[str]) -> str | None:
+    model: str | None = None
+    index = 0
+    while index < len(tokens):
+        token = tokens[index]
+        if token in ("-m", "--model"):
+            if (
+                index + 1 < len(tokens)
+                and tokens[index + 1]
+                and not tokens[index + 1].startswith("-")
+            ):
+                model = tokens[index + 1]
+                index += 2
+                continue
+        elif token.startswith("--model="):
+            value = token.split("=", 1)[1]
+            if value:
+                model = value
+        index += 1
+    return model
+
+
+def model_from_command_log(log_path: Path) -> tuple[str | None, str | None]:
+    """Return the model from the last Ringer command line in the log."""
+    try:
+        lines = log_path.read_text(encoding="utf-8", errors="replace").splitlines()
+    except OSError as exc:
+        return None, f"could not read log file: {exc}"
+
+    model: str | None = None
+    last_command_parsed = False
+    command_lines = 0
+    malformed_commands = 0
+    for line in lines:
+        if not line.startswith(COMMAND_PREFIX):
+            continue
+        command_lines += 1
+        command_text = line[len(COMMAND_PREFIX):]
+        try:
+            tokens = shlex.split(command_text)
+        except ValueError:
+            malformed_commands += 1
+            last_command_parsed = False
+            model = None
+            continue
+        last_command_parsed = True
+        model = _model_from_tokens(tokens)
+
+    if model is not None:
+        return model, None
+    if command_lines == 0:
+        return None, "log has no [ringer.py] command line"
+    if not last_command_parsed:
+        return None, "last command line could not be parsed with shlex"
+    if malformed_commands == command_lines:
+        return None, "all command lines could not be parsed with shlex"
+    return None, "command lines contain no -m/--model flag"
+
+
+def _load_task_log_path(state_path: Path, task_key: Any) -> tuple[Path | None, str | None]:
+    if not state_path.is_file():
+        return None, f"run-state file missing: {state_path}"
+    try:
+        state = json.loads(state_path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        return None, f"could not read run-state file: {exc}"
+    if not isinstance(state, dict) or not isinstance(state.get("tasks"), list):
+        return None, "run-state file has no tasks list"
+
+    task = next(
+        (
+            item
+            for item in state["tasks"]
+            if isinstance(item, dict) and item.get("key") == task_key
+        ),
+        None,
+    )
+    if task is None:
+        return None, f"task not found in run state: {task_key!r}"
+    log_path = task.get("log_path")
+    if not isinstance(log_path, str) or not log_path:
+        return None, "matching task has no log_path"
+    path = Path(log_path).expanduser()
+    if not path.is_file():
+        return None, f"log file missing: {path}"
+    return path, None
+
+
+def process_lines(raw_lines: list[bytes], state_dir: Path) -> tuple[list[bytes], dict[str, int]]:
+    """Build rewritten lines and print a report for every input row."""
+    out_lines = list(raw_lines)
+    counts = {"stamped": 0, "no_evidence": 0, "already_attributed": 0}
+
+    for line_number, raw in enumerate(raw_lines, start=1):
+        body, newline = _split_raw_line(raw)
+        try:
+            row = json.loads(body.decode("utf-8"))
+        except (UnicodeError, json.JSONDecodeError):
+            print(f"line {line_number}: skipped; unparseable line preserved")
+            continue
+        if not isinstance(row, dict):
+            print(f"line {line_number}: skipped; JSON value is not an object")
+            continue
+
+        current_model = row.get("model")
+        if isinstance(current_model, str) and current_model:
+            counts["already_attributed"] += 1
+            print(f"line {line_number}: already attributed: {current_model}")
+            continue
+
+        run_id = row.get("run_id")
+        task_key = row.get("task_key")
+        if not isinstance(run_id, str) or not run_id:
+            counts["no_evidence"] += 1
+            print(f"line {line_number}: skipped; missing run_id")
+            continue
+
+        state_path = state_dir / "runs" / f"{run_id}.json"
+        log_path, reason = _load_task_log_path(state_path, task_key)
+        if log_path is None:
+            counts["no_evidence"] += 1
+            print(f"line {line_number} ({run_id}/{task_key}): skipped; {reason}")
+            continue
+
+        model, reason = model_from_command_log(log_path)
+        if model is None:
+            counts["no_evidence"] += 1
+            print(f"line {line_number} ({run_id}/{task_key}): skipped; {reason}")
+            continue
+
+        old_display = repr(current_model) if "model" in row else "<missing>"
+        row["model"] = model
+        notes = row.get("notes")
+        row["notes"] = (notes if isinstance(notes, str) else "") + BACKFILL_NOTE
+        out_lines[line_number - 1] = (
+            json.dumps(row, ensure_ascii=False).encode("utf-8") + newline
+        )
+        counts["stamped"] += 1
+        print(
+            f"line {line_number} ({run_id}/{task_key}): "
+            f"model {old_display} -> {model!r}"
+        )
+
+    return out_lines, counts
+
+
+def _atomic_rewrite(path: Path, lines: list[bytes]) -> Path:
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S%fZ")
+    backup_path = path.with_name(f"{path.name}.bak-{stamp}")
+    shutil.copy2(path, backup_path)
+
+    fd, tmp_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    tmp_path = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "wb") as handle:
+            handle.writelines(lines)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp_path, path)
+    except BaseException:
+        try:
+            tmp_path.unlink()
+        except OSError:
+            pass
+        raise
+    return backup_path
+
+
+def _print_totals(counts: dict[str, int]) -> None:
+    print(
+        "totals: "
+        f"stamped={counts['stamped']} "
+        f"no-evidence={counts['no_evidence']} "
+        f"already-attributed={counts['already_attributed']}"
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Backfill missing models using recorded worker command lines."
+    )
+    parser.add_argument(
+        "--state-dir",
+        type=Path,
+        default=Path("~/.ringer"),
+        help="Ringer state directory (default: ~/.ringer)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="report changes without writing runs.jsonl or a backup",
+    )
+    args = parser.parse_args(argv)
+
+    state_dir = args.state_dir.expanduser().resolve()
+    log_path = state_dir / "runs.jsonl"
+    if not log_path.is_file():
+        print(f"error: eval log not found: {log_path}", file=sys.stderr)
+        return 1
+
+    try:
+        raw_lines = log_path.read_bytes().splitlines(keepends=True)
+    except OSError as exc:
+        print(f"error: could not read eval log: {exc}", file=sys.stderr)
+        return 1
+
+    out_lines, counts = process_lines(raw_lines, state_dir)
+
+    if args.dry_run:
+        print("dry-run: no files written")
+    elif counts["stamped"]:
+        try:
+            backup_path = _atomic_rewrite(log_path, out_lines)
+        except OSError as exc:
+            print(f"error: could not rewrite eval log: {exc}", file=sys.stderr)
+            return 1
+        print(f"backup: {backup_path}")
+    else:
+        print("no changes; runs.jsonl was not rewritten")
+
+    _print_totals(counts)
+    if not args.dry_run:
+        print(
+            "refresh the derived read model: "
+            f"python3 ringer.py db rebuild --log {shlex.quote(str(log_path))}"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_artifact_endstate.py
+++ b/tests/test_artifact_endstate.py
@@ -144,7 +144,7 @@ class ArtifactEndstateTests(unittest.TestCase):
         self.assertIn('<meta http-equiv="refresh" content="2">', html)
         self.assertIn("This page updates itself while the work runs.", html)
 
-    def test_retry_state_shows_on_the_work_group(self) -> None:
+    def test_retry_state_shows_on_the_rounds_bar(self) -> None:
         render_status_html(
             self.state([self.task("task-one", "running", attempts=1)]),
             renderer=self.renderer,
@@ -164,10 +164,8 @@ class ArtifactEndstateTests(unittest.TestCase):
             renderer=self.renderer,
         )
 
-        # Per-task status lives on the work group itself; the separate
-        # "What's happening" timeline and "The workers" strip are gone —
-        # live per-model narration is Ringside's job.
-        self.assertIn('<span class="state retry">sent back — redoing</span>', html)
+        self.assertIn('aria-label="task-one: sent back — redoing"', html)
+        self.assertIn("Deliverables appear here as workers finish.", html)
         self.assertNotIn("What&#x27;s happening", html)
         self.assertNotIn("What's happening", html)
         self.assertNotIn("The workers", html)
@@ -199,7 +197,7 @@ class ArtifactEndstateTests(unittest.TestCase):
         self.assertIn("See why it failed", fail_html)
         self.assertIn("FAIL: still missing output", fail_html)
 
-    def test_running_task_activity_line_is_optional(self) -> None:
+    def test_running_task_activity_is_omitted_from_live_work_section(self) -> None:
         html = render_status_html(
             self.state(
                 [
@@ -210,8 +208,8 @@ class ArtifactEndstateTests(unittest.TestCase):
             renderer=self.renderer,
         )
 
-        self.assertIn('<span class="activity" title="edited report.md">edited report.md</span>', html)
-        self.assertEqual(1, html.count('class="activity"'))
+        self.assertNotIn('<span class="activity" title="edited report.md">', html)
+        self.assertIn("Deliverables appear here as workers finish.", html)
 
     def test_task_rows_include_checklist_glyph_css(self) -> None:
         html = render_status_html(

--- a/tests/test_artifact_wrappers.py
+++ b/tests/test_artifact_wrappers.py
@@ -59,7 +59,7 @@ class ArtifactWrapperTests(unittest.TestCase):
             "tasks": [
                 {
                     "key": "task-one",
-                    "status": "running",
+                    "status": "pass",
                     "attempts": 1,
                     "elapsed_s": 1,
                     "check": "echo ok",

--- a/tests/test_backfill_model_from_logs.py
+++ b/tests/test_backfill_model_from_logs.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""Command-log model backfill behavior."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "backfill_model_from_logs.py"
+
+
+class BackfillModelFromLogsTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.state_dir = Path(self.temp.name) / "state"
+        (self.state_dir / "runs").mkdir(parents=True)
+        self.eval_log = self.state_dir / "runs.jsonl"
+
+    def write_fixture(
+        self,
+        row: dict[str, object],
+        *,
+        command_lines: list[str] | None = None,
+        run_id: str = "run-1",
+        task_key: str = "task-a",
+    ) -> Path:
+        worker_log = Path(self.temp.name) / f"{run_id}-{task_key}.worker.log"
+        lines = command_lines if command_lines is not None else []
+        worker_log.write_text("\n".join(lines) + ("\n" if lines else ""), encoding="utf-8")
+        state = {"tasks": [{"key": task_key, "log_path": str(worker_log)}]}
+        (self.state_dir / "runs" / f"{run_id}.json").write_text(
+            json.dumps(state), encoding="utf-8"
+        )
+        self.eval_log.write_text(json.dumps(row) + "\n", encoding="utf-8")
+        return worker_log
+
+    def run_script(self, *extra: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [sys.executable, str(SCRIPT), "--state-dir", str(self.state_dir), *extra],
+            cwd=ROOT,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+    def read_rows(self) -> list[dict[str, object]]:
+        return [json.loads(line) for line in self.eval_log.read_text(encoding="utf-8").splitlines()]
+
+    def test_stamps_from_last_command_log_evidence(self) -> None:
+        self.write_fixture(
+            {"run_id": "run-1", "task_key": "task-a", "model": "", "notes": "original"},
+            command_lines=[
+                "[ringer.py] command: codex exec -m old-model 'first spec'",
+                "[ringer.py] command: codex exec --model=gpt-5.6-sol 'second spec' < /dev/null",
+            ],
+        )
+
+        result = self.run_script()
+
+        self.assertEqual(0, result.returncode, result.stderr)
+        row = self.read_rows()[0]
+        self.assertEqual("gpt-5.6-sol", row["model"])
+        self.assertEqual("original\nmodel_backfill=command_log", row["notes"])
+        self.assertIn("model '' -> 'gpt-5.6-sol'", result.stdout)
+        self.assertIn("python3 ringer.py db rebuild --log", result.stdout)
+
+    def test_does_not_guess_without_model_flag(self) -> None:
+        original = {"run_id": "run-1", "task_key": "task-a", "notes": "keep"}
+        self.write_fixture(
+            original,
+            command_lines=["[ringer.py] command: codex exec --sandbox workspace-write 'spec'"],
+        )
+        before = self.eval_log.read_bytes()
+
+        result = self.run_script()
+
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertEqual(before, self.eval_log.read_bytes())
+        self.assertIn("no -m/--model flag", result.stdout)
+        self.assertIn("stamped=0 no-evidence=1", result.stdout)
+        self.assertEqual([], list(self.state_dir.glob("runs.jsonl.bak-*")))
+
+    def test_latest_attempt_without_model_does_not_reuse_older_evidence(self) -> None:
+        self.write_fixture(
+            {"run_id": "run-1", "task_key": "task-a", "model": ""},
+            command_lines=[
+                "[ringer.py] command: codex exec -m old-model 'first spec'",
+                "[ringer.py] command: codex exec --sandbox workspace-write 'latest spec'",
+            ],
+        )
+        before = self.eval_log.read_bytes()
+
+        result = self.run_script()
+
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertEqual(before, self.eval_log.read_bytes())
+        self.assertIn("no -m/--model flag", result.stdout)
+
+    def test_dry_run_is_read_only_and_reports_change(self) -> None:
+        worker_log = self.write_fixture(
+            {"run_id": "run-1", "task_key": "task-a", "model": ""},
+            command_lines=["[ringer.py] command: codex exec --model gpt-dry-run 'spec'"],
+        )
+        before_eval = self.eval_log.read_bytes()
+        before_state = (self.state_dir / "runs" / "run-1.json").read_bytes()
+        before_worker = worker_log.read_bytes()
+
+        result = self.run_script("--dry-run")
+
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertIn("gpt-dry-run", result.stdout)
+        self.assertIn("dry-run: no files written", result.stdout)
+        self.assertEqual(before_eval, self.eval_log.read_bytes())
+        self.assertEqual(before_state, (self.state_dir / "runs" / "run-1.json").read_bytes())
+        self.assertEqual(before_worker, worker_log.read_bytes())
+        self.assertEqual([], list(self.state_dir.glob("runs.jsonl.bak-*")))
+
+    def test_real_run_creates_exact_backup(self) -> None:
+        self.write_fixture(
+            {"run_id": "run-1", "task_key": "task-a", "model": "", "notes": "n"},
+            command_lines=["[ringer.py] command: codex exec -m backed-up 'spec'"],
+        )
+        before = self.eval_log.read_bytes()
+
+        result = self.run_script()
+
+        self.assertEqual(0, result.returncode, result.stderr)
+        backups = list(self.state_dir.glob("runs.jsonl.bak-*"))
+        self.assertEqual(1, len(backups))
+        self.assertEqual(before, backups[0].read_bytes())
+        self.assertNotEqual(before, self.eval_log.read_bytes())
+
+    def test_second_run_is_idempotent(self) -> None:
+        self.write_fixture(
+            {"run_id": "run-1", "task_key": "task-a", "model": ""},
+            command_lines=["[ringer.py] command: codex exec -m stable-model 'spec'"],
+        )
+        first = self.run_script()
+        after_first = self.eval_log.read_bytes()
+        backups_after_first = list(self.state_dir.glob("runs.jsonl.bak-*"))
+
+        second = self.run_script()
+
+        self.assertEqual(0, first.returncode, first.stderr)
+        self.assertEqual(0, second.returncode, second.stderr)
+        self.assertEqual(after_first, self.eval_log.read_bytes())
+        self.assertEqual(backups_after_first, list(self.state_dir.glob("runs.jsonl.bak-*")))
+        self.assertIn("already-attributed=1", second.stdout)
+        self.assertIn("no changes; runs.jsonl was not rewritten", second.stdout)
+
+    def test_unparseable_line_passes_through_byte_for_byte(self) -> None:
+        worker_log = Path(self.temp.name) / "worker.log"
+        worker_log.write_text(
+            "[ringer.py] command: codex exec -m recovered 'spec'\n", encoding="utf-8"
+        )
+        (self.state_dir / "runs" / "run-1.json").write_text(
+            json.dumps({"tasks": [{"key": "task-a", "log_path": str(worker_log)}]}),
+            encoding="utf-8",
+        )
+        malformed = b"not-json-\xff\r\n"
+        valid = json.dumps(
+            {"run_id": "run-1", "task_key": "task-a", "model": ""}
+        ).encode("utf-8") + b"\n"
+        self.eval_log.write_bytes(malformed + valid)
+
+        result = self.run_script()
+
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertTrue(self.eval_log.read_bytes().startswith(malformed))
+        self.assertIn("unparseable line preserved", result.stdout)
+        self.assertEqual("recovered", self.read_rows_from_bytes(self.eval_log.read_bytes()[len(malformed):])[0]["model"])
+
+    @staticmethod
+    def read_rows_from_bytes(raw: bytes) -> list[dict[str, object]]:
+        return [json.loads(line) for line in raw.decode("utf-8").splitlines()]
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_model_field.py
+++ b/tests/test_model_field.py
@@ -2,6 +2,7 @@
 """Per-task model routing: the {model} placeholder, model_default, validation."""
 from __future__ import annotations
 
+import json
 import sys
 import tempfile
 import unittest
@@ -16,8 +17,12 @@ from ringer import (  # noqa: E402
     EngineConfig,
     EvalConfig,
     Manifest,
+    RingerRunner,
     TaskSpec,
+    VerifyResult,
+    WorkerResult,
     build_worker_command,
+    effective_model_from_command,
     load_engines,
     preflight_engine_bins,
     validate_manifest_engines,
@@ -56,6 +61,31 @@ def codex_like_engine() -> EngineConfig:
     )
 
 
+class EffectiveModelFromCommandTests(unittest.TestCase):
+    def test_reads_supported_flag_forms(self) -> None:
+        self.assertEqual("gpt-5.6-sol", effective_model_from_command(["codex", "-m", "gpt-5.6-sol"]))
+        self.assertEqual(
+            "gpt-5.6-luna",
+            effective_model_from_command(["codex", "--model", "gpt-5.6-luna"]),
+        )
+        self.assertEqual(
+            "gpt-5.6-terra",
+            effective_model_from_command(["codex", "--model=gpt-5.6-terra"]),
+        )
+
+    def test_ignores_model_flag_text_inside_task_spec(self) -> None:
+        self.assertEqual(
+            "",
+            effective_model_from_command(["codex", "exec", "Explain why -m is a CLI flag"]),
+        )
+
+    def test_returns_empty_when_absent_or_missing_value(self) -> None:
+        self.assertEqual("", effective_model_from_command([]))
+        self.assertEqual("", effective_model_from_command(["codex", "exec"]))
+        self.assertEqual("", effective_model_from_command(["codex", "--model"]))
+        self.assertEqual("", effective_model_from_command(["codex", "--model="]))
+
+
 class ModelPlaceholderTests(unittest.TestCase):
     def test_model_default_fills_placeholder(self) -> None:
         cmd = build_worker_command(
@@ -72,6 +102,38 @@ class ModelPlaceholderTests(unittest.TestCase):
             model="openrouter/moonshotai/kimi-k2.7-code",
         )
         self.assertEqual("openrouter/moonshotai/kimi-k2.7-code", cmd[cmd.index("-m") + 1])
+
+    def test_model_args_expands_with_resolved_model(self) -> None:
+        engine = EngineConfig(
+            name="codex",
+            bin="codex",
+            args_template=("exec", "{access_args}", "{model_args}", "{spec}"),
+            full_access_args=(),
+            sandbox_args=("--sandbox", "workspace-write"),
+            token_regex=None,
+            model_default="gpt-5.6-sol",
+        )
+        cmd = build_worker_command(
+            engine, taskdir=Path("/tmp/t"), spec="do it", full_access=False
+        )
+        self.assertEqual(
+            ["codex", "exec", "--sandbox", "workspace-write", "-m", "gpt-5.6-sol", "do it"],
+            cmd,
+        )
+
+    def test_model_args_expands_to_nothing_without_resolved_model(self) -> None:
+        engine = EngineConfig(
+            name="codex",
+            bin="codex",
+            args_template=("exec", "{model_args}", "{spec}"),
+            full_access_args=(),
+            sandbox_args=(),
+            token_regex=None,
+        )
+        cmd = build_worker_command(
+            engine, taskdir=Path("/tmp/t"), spec="do it", full_access=False
+        )
+        self.assertEqual(["codex", "exec", "do it"], cmd)
 
     def test_task_spec_parses_and_validates_model(self) -> None:
         task = TaskSpec.from_obj(
@@ -167,6 +229,45 @@ class ModelValidationTests(unittest.TestCase):
             self.manifest(self.base_task(engine="opencode", model="openrouter/x")),
             config,
         )
+
+    def test_model_args_without_a_resolved_model_is_valid(self) -> None:
+        engine = EngineConfig(
+            name="codex",
+            bin="codex",
+            args_template=("exec", "{model_args}", "{spec}"),
+            full_access_args=(),
+            sandbox_args=(),
+            token_regex=None,
+        )
+        config = self.config({"codex": engine})
+        manifest = self.manifest(self.base_task(engine="codex"))
+        validate_manifest_engines(manifest, config)
+
+    def test_eval_row_falls_back_to_model_in_last_worker_command(self) -> None:
+        config = self.config({"codex": codex_like_engine()})
+        manifest = self.manifest(self.base_task(engine="codex"))
+        runner = RingerRunner(
+            manifest,
+            config=config,
+            identity="tester",
+            dashboard_enabled=False,
+        )
+        runtime = runner.runtimes[0]
+        runtime.last_worker_command = ["codex", "exec", "-m", "gpt-5.6-sol", "do it"]
+        runner._log_attempt(
+            runtime,
+            runtime.task.spec,
+            False,
+            WorkerResult(returncode=0, timed_out=False, tokens=123),
+            VerifyResult(ok=True, check_returncode=0, check_timed_out=False, raw_output_excerpt="ok"),
+            "PASS",
+            456,
+        )
+        payload = json.loads(config.eval.jsonl_path.read_text(encoding="utf-8"))
+        self.assertEqual("gpt-5.6-sol", payload["model"])
+        self.assertIn("model=gpt-5.6-sol", payload["notes"])
+        state = runner.state_writer.snapshot()
+        self.assertEqual("gpt-5.6-sol", state["tasks"][0]["model"])
 
     def test_preflight_catches_missing_engine_binary(self) -> None:
         broken = EngineConfig(

--- a/tests/test_plain_english_artifact.py
+++ b/tests/test_plain_english_artifact.py
@@ -117,24 +117,24 @@ class PlainEnglishArtifactTests(unittest.TestCase):
         self.assertIn("<span aria-label=\"D-waiting: waiting\"></span>", rounds.group(1))
         self.assertIn("1 finished · 1 working · 1 failed · 1 waiting", html)
 
-    def test_status_change_updates_the_worker_state_word(self) -> None:
+    def test_status_change_updates_the_rounds_state_word(self) -> None:
         queued_html = render_status_html(
             self.state([self.task("A-mock-engine", "queued")]), renderer=self.renderer
         )
-        self.assertIn('<span class="state waiting">waiting</span>', queued_html)
+        self.assertIn('aria-label="A-mock-engine: waiting"', queued_html)
 
         html = render_status_html(
             self.state([self.task("A-mock-engine", "running", attempts=1)]),
             renderer=self.renderer,
         )
-        self.assertIn('<span class="state working">working</span>', html)
+        self.assertIn('aria-label="A-mock-engine: working"', html)
 
     def test_retry_and_second_try_state_words(self) -> None:
         retry_html = render_status_html(
             self.state([self.task("C-nudge-hooks", "retrying", attempts=1, elapsed_s=20)]),
             renderer=self.renderer,
         )
-        self.assertIn('<span class="state retry">sent back — redoing</span>', retry_html)
+        self.assertIn('aria-label="C-nudge-hooks: sent back — redoing"', retry_html)
 
         pass_html = render_status_html(
             self.state([self.task("C-nudge-hooks", "pass", attempts=2, elapsed_s=35)]),
@@ -190,6 +190,49 @@ class PlainEnglishArtifactTests(unittest.TestCase):
 
         self.assertIn('<meta http-equiv="refresh" content="2">', live_html)
         self.assertNotIn('http-equiv="refresh"', final_html)
+
+    def test_live_work_section_only_shows_finished_tasks(self) -> None:
+        logs = Path(self.tmp.name) / "logs"
+        logs.mkdir()
+        tasks = [
+            self.task("finished-task", "pass", attempts=1),
+            self.task("running-task", "running", attempts=1),
+        ]
+        for task in tasks:
+            log_path = logs / f'{task["key"]}.log'
+            log_path.write_text("work log\n", encoding="utf-8")
+            task["log_path"] = str(log_path)
+
+        live_html = render_status_html(self.state(tasks), renderer=self.renderer)
+        live_work = re.search(
+            r'<section class="work" aria-labelledby="the-work-heading">(.*?)</section>',
+            live_html,
+            re.S,
+        )
+        self.assertIsNotNone(live_work)
+        self.assertIn('title="finished-task"', live_work.group(1))
+        self.assertNotIn('title="running-task"', live_work.group(1))
+        self.assertEqual(1, live_work.group(1).count(">view the work log</a>"))
+
+        unfinished_html = render_status_html(
+            self.state([tasks[1]]), renderer=self.renderer
+        )
+        unfinished_work = re.search(
+            r'<section class="work" aria-labelledby="the-work-heading">(.*?)</section>',
+            unfinished_html,
+            re.S,
+        )
+        self.assertIsNotNone(unfinished_work)
+        self.assertIn("Deliverables appear here as workers finish.", unfinished_work.group(1))
+        self.assertNotIn('class="work-group"', unfinished_work.group(1))
+        self.assertNotIn(">view the work log</a>", unfinished_work.group(1))
+
+        final_html = render_final_report_html(
+            self.state(tasks, finished=True), renderer=self.renderer
+        )
+        self.assertIn('title="finished-task"', final_html)
+        self.assertIn('title="running-task"', final_html)
+        self.assertEqual(2, final_html.count(">view the work log</a>"))
 
     def test_theme_override_blocks_are_present(self) -> None:
         html = render_status_html(


### PR DESCRIPTION
Jon's UX review of Ringside (2026-07-09) turned up four issues; this PR fixes all of them. Built as a 4-task Ringer swarm (worktrees + patch export, 4/4 first-attempt PASS on executed checks), reviewed and integrated by the orchestrator, visually verified against live runs on :8700.

## 1. "gpt-5.6 is not being tracked" — confirmed and fixed
Every codex eval row logged `model=""` (151 of 268 rows): the codex `args_template` had no model slot, so orchestrators spliced `-m gpt-5.6-sol` through `engine_args`, which the resolver never saw; read-time registry resolution then credited everything to GPT-5.5.

- `effective_model_from_command()` — write-time fallback that parses the actual composed argv, used by both the eval row and the HUD state payload.
- New `{model_args}` placeholder (list-expansion like `{access_args}`): makes the manifest `model` field work for codex; expands to nothing when no model is resolved, so default behavior is unchanged.
- Registry: GPT-5.6 Sol / Luna / Terra entries (cited to OpenAI's codex models page — verified the page lists all three). `default_model_key` stays `gpt-5.5` so legacy rows keep their attribution.
- `scripts/backfill_model_from_logs.py`: re-attributes historical empty rows from `[ringer.py] command:` log lines. Evidence-only, `--dry-run`, timestamped backup, atomic rewrite, idempotent. On Jon's machine it stamped 19 rows (17 sol, 1 luna, 1 terra) and honestly skipped 145 with no surviving evidence.

## 2. "The work" shows "view the work log" while running
The live status artifact now renders "The work" for **finished** tasks only (quiet placeholder until the first task lands); running-state storytelling stays with the rounds bar and the agent cards. The final report keeps full detail. Existing tests that asserted the old behavior were updated to assert via the rounds bar.

## 3. Running-now buttons
When 2+ runs are live (run `state == "live"` **and** PID-alive in `active-runs.json`, guarding against stale states), pill buttons appear in the topbar — run name, pulse dot, done/total. Click to bounce: switches the artifact, opens and scrolls to that run's agent section. The machine-strip is removed (redundant with the pills + picker). Historical dropdowns untouched.

## 4. Agent cards
Workers render as a 2-column card grid (1-column under 720px): task key, state word, `engine · model · elapsed · attempt N · tokens` meta line, activity line only while running. Click expands a card to the full row with the brief, pass test, live log stream (1s poll while expanded+running), and check proof. Multiple cards can be open; Escape closes all. Keyboard/aria preserved.

## Verification
- 132 tests green (full suite minus `test_design_reference` and the dated `test_scoreboard_page` assertion, both pre-existing env breaks).
- All inline scripts pass `node --check`; self-contained page; light/dark tokens preserved; meta-refresh stripping intact.
- Live-verified in Chrome with two concurrent runs: pill switching, card expansion with real log streaming, scoreboard now showing GPT-5.6 rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)