### PR TITLE
docs: state that the orchestrator must not be its own worker lane

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,8 @@ args_template = ["run", "{spec}", "--dir", "{taskdir}"]
 
 Per-task `"engine": "mymodel"` routes work to it — the invariants (stdin closed, process-group kill, executed verification, raw logs) apply to every engine identically.
 
+One lane you should never wire up: **the orchestrator must not be its own worker.** No engine block should point at the model that is writing the specs and reading the results. The economics of ringer are the split between an expensive model that plans and cheap models that type; routing the work back to the orchestrator collapses that split and quietly restores the inline edit-test-edit loop this tool exists to break — at frontier prices, with the swarm as decoration.
+
 ### The universal harness: OpenCode + OpenRouter
 
 Unless a model ships its own first-class harness (Codex does), OpenCode is the harness that runs it — one engine block covers every OpenRouter-served model. `config.sample.toml` includes a ready-to-uncomment engine whose `{model}` placeholder is filled per task from the manifest's `"model"` field, with `model_default` as the fallback. The shipped default is OpenRouter's `z-ai/glm-5.2` — roughly $0.74/M input and $2.33/M output (2026-07), about 20-30x cheaper output than frontier coding models; a complete write-code-and-pass-the-check task lands around a penny.


### PR DESCRIPTION
Your [guide](https://unlock-ai.natebjones.com/guides/ringer) lists "never make the orchestrator its own worker lane" among the key warnings, but the rule doesn't appear anywhere in the repo — not in the README, not in `docs/`, not in `config.sample.toml`.

That matters because the sentence most likely to prompt someone to add a lane is in the README: *"Anything else with a headless CLI is a config block away."* A reader who arrives via `git clone` rather than the guide has nothing telling them the one engine they shouldn't wire up.

This adds a short paragraph immediately after that line, in the README's voice, framing it the way the guide does — as economics rather than a taboo. Docs only; no code touched.

I found this while diffing my install against the guide. Happy to move it under "Hard-won invariants" instead if you'd rather keep that list as the home for load-bearing rules, though it reads to me as an engine-configuration rule more than a worker-invocation one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sjt567haxEQyQqX2XDU6Cd