### PR TITLE
Sandboxed Claude + Gemini engine lanes, and a shared credential read deny-list

### DIFF
--- a/config.sample.toml
+++ b/config.sample.toml
@@ -141,6 +141,65 @@ token_regex = "tokens\\s+used\\s*:?\\s*([0-9][0-9,]*)"
 # full_access_args = ["--no-sandbox"]
 # token_regex = '"tokens":\{"total":([0-9]+)'
 
+# Gemini CLI, direct to Google AI Studio (no OpenRouter). Install:
+# `brew install gemini-cli` or `npm i -g @google/gemini-cli`, then authenticate
+# (OAuth via `gemini` then /auth, or a GEMINI_API_KEY in the environment).
+# Gemini ships no verified OS sandbox for this use, so `bin` points at
+# engines/gemini-sandboxed.sh (macOS Seatbelt: network + reads open minus a
+# credential deny-list, writes confined to the task dir, scratch, and ~/.gemini).
+# --skip-trust is MANDATORY: Gemini 0.46 downgrades yolo approval to "default" in
+# an untrusted folder, and ringer task dirs are fresh temp dirs never trusted.
+# Uncomment and set an absolute path for `bin` to enable.
+# [engines.gemini]
+# bin = "/absolute/path/to/ringer/engines/gemini-sandboxed.sh"
+# model_default = "gemini-2.5-flash"
+# args_template = [
+#   "{taskdir}",
+#   "{access_args}",
+#   "-m",
+#   "{model}",
+#   "--approval-mode",
+#   "yolo",
+#   "--skip-trust",
+#   "-o",
+#   "json",
+#   "{engine_args}",
+#   "-p",
+#   "{spec}",
+# ]
+# sandbox_args = []
+# full_access_args = ["--no-sandbox"]
+
+# Claude Code as a worker lane. NOT a cheap lane: a headless Claude worker loads
+# the operator's global CLAUDE.md, hooks, and skills, so a trivial verified task
+# can run 100k+ input tokens. Route here only for tasks a cheaper lane has failed.
+# Claude ships no OS sandbox, so `bin` points at engines/claude-sandboxed.sh
+# (macOS Seatbelt). Claude stores its OAuth token in the macOS login Keychain, so
+# that wrapper keeps ~/.claude and ~/Library/Keychains readable and denies every
+# other credential store; see the header of claude-sandboxed.sh for the trade-off.
+# Uncomment and set an absolute path for `bin` to enable.
+# [engines.claude]
+# bin = "/absolute/path/to/ringer/engines/claude-sandboxed.sh"
+# model_default = "sonnet"
+# args_template = [
+#   "{taskdir}",
+#   "{access_args}",
+#   "-p",
+#   "{spec}",
+#   "--model",
+#   "{model}",
+#   "--permission-mode",
+#   "bypassPermissions",
+#   "--output-format",
+#   "json",
+#   "--strict-mcp-config",
+#   "{engine_args}",
+# ]
+# sandbox_args = []
+# full_access_args = ["--no-sandbox"]
+# Claude's JSON usage block has no total; this captures OUTPUT tokens only.
+# token_regex = '"output_tokens":\s*([0-9]+)'
+
 [artifact]
 # Zero-LLM, self-contained HTML artifacts rendered directly from state — no model calls, no
 # network. Three files per config, all pure stdlib templates:

--- a/engines/claude-sandboxed.sh
+++ b/engines/claude-sandboxed.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+# Ringer engine wrapper: run Claude Code under a macOS Seatbelt sandbox.
+#
+# Claude Code has no OS-level sandbox of its own. Its --permission-mode
+# bypassPermissions (required for headless runs that write files) disables ALL
+# of its interactive approval prompts; its own --help says the equivalent
+# --dangerously-skip-permissions is "recommended only for sandboxes". This
+# wrapper supplies the real containment: full network and reads, writes confined
+# to the task dir, a per-run scratch dir, and Claude's own state.
+#
+# NOTE ON CONFIG DIR: Claude's credentials live inside $HOME/.claude, and
+# pointing CLAUDE_CONFIG_DIR elsewhere yields "Not logged in". So the worker
+# must be allowed to write $HOME/.claude, and it therefore inherits whatever
+# global CLAUDE.md, hooks, and skills live there. That is a real cost, in tokens
+# and in blast radius. Route heavy batches to a cheaper, dumber lane.
+#
+# Usage (as a ringer engine bin):
+#   claude-sandboxed.sh <taskdir> [--no-sandbox] <claude args...>
+#
+# macOS only (sandbox-exec); on other platforms only --no-sandbox mode works.
+set -euo pipefail
+
+TASKDIR="${1:?usage: claude-sandboxed.sh <taskdir> [--no-sandbox] <args...>}"; shift
+SANDBOX=1
+if [ "${1:-}" = "--no-sandbox" ]; then SANDBOX=0; shift; fi
+
+if ! CLAUDE_BIN="$(command -v claude)" || [ -z "$CLAUDE_BIN" ]; then
+  echo "claude-sandboxed.sh: claude not found on PATH" >&2
+  exit 127
+fi
+
+if [ "$SANDBOX" = "0" ]; then
+  exec "$CLAUDE_BIN" "$@" < /dev/null
+fi
+
+if [ ! -x /usr/bin/sandbox-exec ]; then
+  echo "claude-sandboxed.sh: /usr/bin/sandbox-exec not available (macOS only)." >&2
+  exit 1
+fi
+
+TASKDIR_REAL="$(cd "$TASKDIR" && pwd -P)"
+
+# Per-run scratch root, wired as TMPDIR so we never open all of /private/tmp.
+SCRATCH="$(cd "$(mktemp -d -t ringer-claude-scratch)" && pwd -P)"
+PROFILE="$(mktemp -t ringer-claude-prof)"
+cleanup() { rm -rf "$SCRATCH" "$PROFILE"; }
+trap cleanup EXIT
+
+# Paths reach the profile as sandbox-exec -D parameters, not string
+# interpolation, so a task dir containing quotes or parens cannot inject rules.
+cat > "$PROFILE" <<'SBEOF'
+(version 1)
+(allow default)
+(deny file-write*)
+(allow file-write*
+  (subpath (param "TASKDIR"))
+  (subpath (param "SCRATCH"))
+  (subpath (param "CLAUDE_STATE")))
+; Claude rewrites $HOME/.claude.json atomically, which needs the file itself
+; plus sibling temp files in $HOME. Scope to the literal names, not all of $HOME.
+(allow file-write*
+  (literal (param "CLAUDE_JSON"))
+  (regex (string-append "^" (param "HOMEDIR") "/\\.claude\\.json\\.")))
+(allow file-write-data
+  (literal "/dev/null")
+  (literal "/dev/dtracehelper")
+  (literal "/dev/tty")
+  (literal "/dev/stdout")
+  (literal "/dev/stderr"))
+SBEOF
+
+export TMPDIR="$SCRATCH"
+
+# Deny credential reads. The worker keeps readable only what Claude Code needs to
+# authenticate: ~/.claude, ~/.claude.json, and ~/Library/Keychains (Claude stores
+# its OAuth token in the macOS login Keychain; verified: denying it yields "Not
+# logged in"). Every OTHER credential store is denied, so a Claude worker cannot
+# read ~/.ssh, ~/.codex, ~/.gemini, or gh/gcloud tokens.
+#
+# TRADE-OFF: keeping the Keychain readable means a malicious prompt to THIS worker
+# could read other Keychain items. Accepted because this lane runs Claude Code, a
+# first-party CLI on the operator's own account, not an untrusted catalog model.
+# The opencode lane, where arbitrary OpenRouter models run, denies the Keychain.
+# shellcheck source=deny-read-creds.sh
+source "$(dirname "$0")/deny-read-creds.sh"
+build_deny_read_args "$HOME/.claude" "$HOME/.claude.json" "$HOME/Library/Keychains"
+
+set +e
+/usr/bin/sandbox-exec \
+  -D "TASKDIR=$TASKDIR_REAL" \
+  -D "SCRATCH=$SCRATCH" \
+  -D "CLAUDE_STATE=$HOME/.claude" \
+  -D "CLAUDE_JSON=$HOME/.claude.json" \
+  -D "HOMEDIR=$HOME" \
+  "${DENY_ARGS[@]}" \
+  -f "$PROFILE" "$CLAUDE_BIN" "$@" < /dev/null
+status=$?
+set -e
+exit "$status"

--- a/engines/deny-read-creds.sh
+++ b/engines/deny-read-creds.sh
@@ -1,0 +1,115 @@
+# Shared credential read deny-list for the ringer Seatbelt wrappers.
+#
+# Adapted from ringer PR #15 (mjskinner82, "opencode sandbox: deny reads of
+# credential paths"), generalised so opencode-, claude-, and gemini-sandboxed.sh
+# all share one source of truth.
+#
+# The wrappers' base profile is `(allow default)` plus write confinement, so a
+# worker (running a model of the operator's choosing, possibly an untrusted free
+# one from the catalog) can otherwise READ ~/.ssh, ~/.aws, ~/.codex, ~/.claude,
+# gh/gcloud tokens, and the Keychain, with the network open to exfiltrate them.
+# Workers never legitimately need those paths.
+#
+# KEY FINDING (verified on macOS): Seatbelt matches the path as PRESENTED, not
+# the symlink-resolved target. Denying only realpath(p) leaves the symlinked
+# spelling (the one real accesses use) readable. So every deny covers BOTH the
+# path as written and its resolved target, each as subpath (dirs) and literal
+# (files).
+#
+# Usage from a wrapper, after PROFILE is written and before sandbox-exec:
+#   source "$(dirname "$0")/deny-read-creds.sh"
+#   build_deny_read_args        # sets array DENY_ARGS and appends to $PROFILE
+#   ... /usr/bin/sandbox-exec ... "${DENY_ARGS[@]}" -f "$PROFILE" ...
+#
+# IMPORTANT: pass the ENGINE'S OWN credential paths as arguments so they are NOT
+# denied; the worker must read its own auth to function. The claude wrapper keeps
+# ~/.claude readable, the gemini wrapper keeps ~/.gemini, etc. A blanket deny of
+# every store would break whichever engine owns one:
+#   build_deny_read_args "$HOME/.claude" "$HOME/.claude.json"
+#
+# Extend per machine (work cloud drives, extra credential stores) without editing
+# this file:
+#   - one path per line in ~/.config/ringer/ringer-deny-read.txt ('#' comments,
+#     leading '~' expanded), or
+#   - RINGER_DENY_READ, colon-separated.
+
+# Populates the global DENY_ARGS array with `-D` parameters and appends a
+# `(deny file-read* ...)` block to the file named by $PROFILE. No-op-safe:
+# missing paths are skipped, duplicates de-duplicated, and if nothing exists the
+# profile is left unchanged.
+build_deny_read_args() {
+  # Any argument is a path to KEEP readable (the engine's own credential store),
+  # matched against both the candidate as written and its resolved target.
+  local keep=("$@") k
+  _is_kept() {
+    # "${keep[@]}" on an empty array trips `set -u` on bash 3.2 (macOS default),
+    # so guard on element count before expanding.
+    [ "${#keep[@]}" -eq 0 ] && return 1
+    for k in "${keep[@]}"; do [ "$1" = "$k" ] && return 0; done
+    return 1
+  }
+
+  local candidates=(
+    "$HOME/.ssh"
+    "$HOME/.aws"
+    "$HOME/.gnupg"
+    "$HOME/.secrets"
+    "$HOME/.netrc"
+    "$HOME/.npmrc"
+    "$HOME/.config/gh"
+    "$HOME/.config/gcloud"
+    "$HOME/.codex"
+    "$HOME/.claude"
+    "$HOME/.gemini"
+    "$HOME/.grok"
+    "$HOME/.config/ringer"
+    "$HOME/Library/Keychains"
+  )
+
+  local deny_file="${RINGER_DENY_READ_FILE:-$HOME/.config/ringer/ringer-deny-read.txt}"
+  if [ -f "$deny_file" ]; then
+    local line
+    while IFS= read -r line || [ -n "$line" ]; do
+      case "$line" in ''|'#'*) continue ;; esac
+      candidates+=("${line/#\~/$HOME}")
+    done < "$deny_file"
+  fi
+  if [ -n "${RINGER_DENY_READ:-}" ]; then
+    local saved_ifs="$IFS" extra
+    IFS=':'
+    for extra in $RINGER_DENY_READ; do
+      [ -n "$extra" ] && candidates+=("${extra/#\~/$HOME}")
+    done
+    IFS="$saved_ifs"
+  fi
+
+  DENY_ARGS=()
+  local rules="" idx=0 seen="|" p real
+
+  _add_one() {
+    case "$seen" in *"|$1|"*) return 0 ;; esac
+    seen="${seen}$1|"
+    DENY_ARGS+=( -D "DENY_READ_${idx}=$1" )
+    rules="${rules}  (subpath (param \"DENY_READ_${idx}\"))
+  (literal (param \"DENY_READ_${idx}\"))
+"
+    idx=$((idx + 1))
+  }
+
+  for p in "${candidates[@]}"; do
+    [ -e "$p" ] || continue
+    _is_kept "$p" && continue
+    real="$(/bin/realpath "$p" 2>/dev/null || true)"
+    { [ -n "$real" ] && _is_kept "$real"; } && continue
+    _add_one "$p"
+    [ -n "$real" ] && [ "$real" != "$p" ] && _add_one "$real"
+  done
+
+  if [ -n "$rules" ]; then
+    {
+      printf '(deny file-read*\n'
+      printf '%s' "$rules"
+      printf ')\n'
+    } >> "$PROFILE"
+  fi
+}

--- a/engines/gemini-sandboxed.sh
+++ b/engines/gemini-sandboxed.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+# Ringer engine wrapper: run the Gemini CLI under a macOS Seatbelt sandbox.
+#
+# Gemini CLI has a -s/--sandbox flag of its own, but it delegates to Docker or
+# Podman unless GEMINI_SANDBOX=sandbox-exec, and its behaviour is not verified
+# here. We supply our own containment, matching the opencode and claude wrappers:
+# full network and reads, writes confined to the task dir, a per-run scratch dir,
+# and Gemini's own state dir.
+#
+# Two Gemini-specific quirks this wrapper handles:
+#
+#  1. FOLDER TRUST. Gemini 0.46 silently downgrades --approval-mode yolo to
+#     "default" when the working directory is not a trusted folder, then exits
+#     nonzero without doing the work. Ringer task dirs are freshly-created temp
+#     directories and will never be trusted, so --skip-trust is mandatory and is
+#     supplied by the engine's args_template, not here.
+#
+#  2. GEMINI_API_KEY. Auth is the API key exported by ~/.zshrc line 5, which is
+#     valid (HTTP 200, 50 models). Until 2026-07-09 a 13-character placeholder
+#     appended by Antigravity at line 104 shadowed it, so every call returned
+#     API_KEY_INVALID; that line is now commented out. The key is INHERITED from
+#     the environment, so ringer must be launched from a shell that sourced the
+#     fixed .zshrc. GOOGLE_API_KEY is stripped because, when set, it can take
+#     precedence and reintroduce exactly this class of shadowing bug.
+#
+# Usage (as a ringer engine bin):
+#   gemini-sandboxed.sh <taskdir> [--no-sandbox] <gemini args...>
+set -euo pipefail
+
+TASKDIR="${1:?usage: gemini-sandboxed.sh <taskdir> [--no-sandbox] <args...>}"; shift
+SANDBOX=1
+if [ "${1:-}" = "--no-sandbox" ]; then SANDBOX=0; shift; fi
+
+if ! GEMINI_BIN="$(command -v gemini)" || [ -z "$GEMINI_BIN" ]; then
+  echo "gemini-sandboxed.sh: gemini not found on PATH" >&2
+  exit 127
+fi
+
+if [ "$SANDBOX" = "0" ]; then
+  exec env -u GOOGLE_API_KEY "$GEMINI_BIN" "$@" < /dev/null
+fi
+
+if [ ! -x /usr/bin/sandbox-exec ]; then
+  echo "gemini-sandboxed.sh: /usr/bin/sandbox-exec not available (macOS only)." >&2
+  exit 1
+fi
+
+TASKDIR_REAL="$(cd "$TASKDIR" && pwd -P)"
+SCRATCH="$(cd "$(mktemp -d -t ringer-gemini-scratch)" && pwd -P)"
+PROFILE="$(mktemp -t ringer-gemini-prof)"
+cleanup() { rm -rf "$SCRATCH" "$PROFILE"; }
+trap cleanup EXIT
+
+# Paths reach the profile as sandbox-exec -D parameters, never string
+# interpolation, so a task dir containing quotes or parens cannot inject rules.
+cat > "$PROFILE" <<'SBEOF'
+(version 1)
+(allow default)
+(deny file-write*)
+(allow file-write*
+  (subpath (param "TASKDIR"))
+  (subpath (param "SCRATCH"))
+  (subpath (param "GEMINI_STATE")))
+(allow file-write-data
+  (literal "/dev/null")
+  (literal "/dev/dtracehelper")
+  (literal "/dev/tty")
+  (literal "/dev/stdout")
+  (literal "/dev/stderr"))
+SBEOF
+
+export TMPDIR="$SCRATCH"
+export XDG_CACHE_HOME="$SCRATCH/cache"
+mkdir -p "$XDG_CACHE_HOME"
+
+# Deny credential reads. The worker keeps ~/.gemini readable (its OAuth lives
+# there); every OTHER credential store is denied, so a Gemini worker cannot read
+# ~/.ssh, ~/.codex, ~/.claude, gh tokens, or the Keychain.
+# shellcheck source=deny-read-creds.sh
+source "$(dirname "$0")/deny-read-creds.sh"
+build_deny_read_args "$HOME/.gemini"
+
+set +e
+/usr/bin/sandbox-exec \
+  -D "TASKDIR=$TASKDIR_REAL" \
+  -D "SCRATCH=$SCRATCH" \
+  -D "GEMINI_STATE=$HOME/.gemini" \
+  "${DENY_ARGS[@]}" \
+  -f "$PROFILE" \
+  env -u GOOGLE_API_KEY "$GEMINI_BIN" "$@" < /dev/null
+status=$?
+set -e
+exit "$status"

--- a/engines/opencode-sandboxed.sh
+++ b/engines/opencode-sandboxed.sh
@@ -72,6 +72,13 @@ export TMPDIR="$SCRATCH"
 export XDG_CACHE_HOME="$SCRATCH/cache"
 mkdir -p "$XDG_CACHE_HOME"
 
+# Append a credential read deny-list to the profile (base profile allows reads,
+# so a worker could otherwise read ~/.ssh, ~/.codex, gh tokens, the Keychain,
+# and exfiltrate over the open network). Sets DENY_ARGS, extends $PROFILE.
+# shellcheck source=deny-read-creds.sh
+source "$(dirname "$0")/deny-read-creds.sh"
+build_deny_read_args
+
 # Run as a child (not exec) so the EXIT trap fires and cleans up the profile +
 # scratch dir even on the success path; propagate the child's exit status.
 set +e
@@ -81,6 +88,7 @@ set +e
   -D "OC_SHARE=$HOME/.local/share/opencode" \
   -D "OC_STATE=$HOME/.local/state/opencode" \
   -D "OC_CONFIG=$HOME/.config/opencode" \
+  "${DENY_ARGS[@]}" \
   -f "$PROFILE" "$OPENCODE_BIN" "$@" < /dev/null
 status=$?
 set -e


### PR DESCRIPTION
## What

Adds two headless engine wrappers, `engines/claude-sandboxed.sh` and `engines/gemini-sandboxed.sh`, following the `opencode-sandboxed.sh` pattern, plus a shared read deny-list (`engines/deny-read-creds.sh`) that hardens all three. `config.sample.toml` gains commented `[engines.claude]` and `[engines.gemini]` blocks.

## Relationship to #15

#15 denies credential reads for the OpenCode wrapper inline. This PR generalises that same fix into a reusable module and wires it into three wrappers. Full credit to @mjskinner82 for the finding, **including the key insight that Seatbelt matches the path as presented, not the symlink-resolved target** — every deny here covers both forms for exactly that reason. If #15 merges first I am happy to rebase this on top of it and drop the overlapping opencode hunk.

## Why the deny-list

The wrappers' base profile is `(allow default)` + write confinement, so a worker — a model of the operator's choosing, possibly an untrusted free one from the catalog — can **read** `~/.ssh`, `~/.aws`, `~/.codex`, `~/.claude`, gh/gcloud tokens, and the Keychain, with network egress to exfiltrate them. Workers never legitimately need those paths.

Each wrapper passes its **own** credential store as a keep-path, so the engine can still authenticate; a blanket deny of every store would break whichever engine owns one. Denied paths reach the profile as `sandbox-exec -D` parameters, never interpolated. Extendable per machine via `~/.config/ringer/ringer-deny-read.txt` or `RINGER_DENY_READ`.

## Two engine-specific gotchas, documented in the wrapper headers

- **Claude** stores its OAuth token in the macOS login Keychain, so `claude-sandboxed.sh` keeps `~/Library/Keychains` readable; denying it yields `Not logged in`. Trade-off noted in the header: that lane runs first-party Claude Code, while the opencode lane, where arbitrary OpenRouter models run, keeps the Keychain denied.
- **Gemini** 0.46 silently downgrades `yolo` approval to `default` in an untrusted folder and exits nonzero; ringer task dirs are fresh temp dirs, so `--skip-trust` is mandatory.

## Testing

Verified on macOS. Each of the three lanes runs a real write-a-script-and-pass-the-check task to a passing executed check with the deny-list active, and a probe confirms every worker is blocked from every credential store **except its own**. One `set -u` empty-array edge case on macOS bash 3.2 was caught by a live run and fixed. Non-macOS installs need their own sandbox or full-access mode, same as the existing wrapper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)