### PR TITLE
harvest: copy regular files only (symlink-safe) + opt-out

### DIFF
--- a/ringer.py
+++ b/ringer.py
@@ -184,6 +184,12 @@ class AppConfig:
     eval: EvalConfig
     engines: dict[str, EngineConfig]
     artifact: ArtifactConfig
+    # When false, the engine's on-PASS deliverable harvest is skipped so a
+    # supervisor outside the worker UID can own a symlink-safe copy-out (run
+    # evidence stays root-owned, outside the worker-writable output dir). The
+    # harvest that does run is symlink-safe regardless — see
+    # _harvest_deliverables_on_pass.
+    harvest_deliverables: bool = True
 
     @classmethod
     def load(cls, path: Path | None = None) -> "AppConfig":
@@ -210,6 +216,7 @@ class AppConfig:
         eval_config = load_eval_config(data.get("eval"), state_dir)
         engines = load_engines(data.get("engines"))
         artifact_config = load_artifact_config(data.get("artifact"), state_dir)
+        harvest_deliverables = bool(data.get("harvest_deliverables", True))
         return cls(
             path=config_path if config_path.exists() else None,
             identity_default=identity_default,
@@ -221,6 +228,7 @@ class AppConfig:
             eval=eval_config,
             engines=engines,
             artifact=artifact_config,
+            harvest_deliverables=harvest_deliverables,
         )
 
 
@@ -6921,6 +6929,11 @@ class RingerRunner:
                 return
 
     def _harvest_deliverables_on_pass(self, runtime: TaskRuntime) -> None:
+        if not self.config.harvest_deliverables:
+            # A supervisor outside the worker UID owns the (symlink-safe)
+            # copy-out so deliverables and run evidence land root-owned outside
+            # the worker-writable output dir. Skip the engine's own harvest.
+            return
         harvested: list[dict[str, Any]] = []
         notes: list[str] = []
         target_dir = artifact_deliverables_dir(
@@ -6941,6 +6954,7 @@ class RingerRunner:
                 path.name
                 for path in runtime.taskdir.glob("*")
                 if path.is_file()
+                and not path.is_symlink()
                 and not path.name.startswith(".")
                 and path.suffix.lower() in FALLBACK_HARVEST_SUFFIXES
             )
@@ -6953,6 +6967,25 @@ class RingerRunner:
             expect_files = tuple(candidates)
         for expect_path in expect_files:
             source = Verifier._expect_file_path(runtime.taskdir, expect_path)
+            # Symlink-safe harvest (rig containment, probe 12): the worker's only
+            # writable path is its taskdir, so a "deliverable" that is — or
+            # resolves through — a symlink can point at a secret outside the
+            # sandbox, and shutil.copy2 follows symlinks. Copy regular files
+            # only; for in-tree (relative) deliverables also require the real
+            # path to stay beneath the taskdir (rejects escape via a symlinked
+            # directory component).
+            if source.is_symlink():
+                notes.append(f"{source.name} was not copied: it is a symlink (skipped for safety).")
+                continue
+            if not Path(expect_path).expanduser().is_absolute():
+                real = os.path.realpath(source)
+                taskdir_real = os.path.realpath(runtime.taskdir)
+                if os.path.commonpath((real, taskdir_real)) != taskdir_real:
+                    notes.append(
+                        f"{source.name} was not copied: it resolves outside the task "
+                        "directory via a symlink (skipped for safety)."
+                    )
+                    continue
             try:
                 stat = source.stat()
             except OSError:

--- a/tests/test_deliverables.py
+++ b/tests/test_deliverables.py
@@ -273,6 +273,85 @@ class DeliverableTests(unittest.TestCase):
         self.assertTrue(copied.exists())
         self.assertEqual("<h1>done</h1>\n", copied.read_text(encoding="utf-8"))
 
+    def test_harvest_refuses_symlinked_deliverable(self) -> None:
+        # A worker whose only writable path is its taskdir can name a symlink
+        # like a deliverable and point it at a secret outside the sandbox.
+        # shutil.copy2 follows symlinks, so stock harvest would copy the target
+        # out. Harvest must copy regular files only and skip symlinks (note it).
+        secret = self.root / "outside-sandbox" / "provider.auth"
+        secret.parent.mkdir(parents=True)
+        secret.write_text("SECRET-PROVIDER-KEY\n", encoding="utf-8")
+        task = TaskSpec(
+            key="task-one",
+            spec="Create the requested outputs.",
+            check="true",
+            engine="mock",
+            expect_files=("out.css",),
+        )
+        runner, runtime = self.runtime_for(task)
+        (runtime.taskdir / "out.css").symlink_to(secret)
+
+        runner._harvest_deliverables_on_pass(runtime)
+
+        dest = self.artifacts_dir / "deliverables" / runner.run_id / "task-one" / "out.css"
+        self.assertFalse(
+            dest.exists() and "SECRET-PROVIDER-KEY" in dest.read_text(encoding="utf-8"),
+            "harvest exfiltrated a symlink target",
+        )
+        self.assertNotIn("out.css", [item["name"] for item in runtime.deliverables])
+        self.assertTrue(
+            any("symlink" in note.lower() for note in runtime.deliverable_notes),
+            runtime.deliverable_notes,
+        )
+
+    def test_harvest_refuses_deliverable_escaping_via_symlinked_dir(self) -> None:
+        # The escape also works one level up: symlink a *directory* component so
+        # a relative expect_file resolves outside the taskdir. Resolve-beneath
+        # must reject it.
+        secret = self.root / "outside-sandbox" / "provider.auth"
+        secret.parent.mkdir(parents=True)
+        secret.write_text("SECRET-PROVIDER-KEY\n", encoding="utf-8")
+        task = TaskSpec(
+            key="task-one",
+            spec="Create the requested outputs.",
+            check="true",
+            engine="mock",
+            expect_files=("sub/provider.auth",),
+        )
+        runner, runtime = self.runtime_for(task)
+        (runtime.taskdir / "sub").symlink_to(secret.parent)
+
+        runner._harvest_deliverables_on_pass(runtime)
+
+        self.assertEqual([], runtime.deliverables)
+        self.assertTrue(
+            any("symlink" in note.lower() for note in runtime.deliverable_notes),
+            runtime.deliverable_notes,
+        )
+
+    def test_harvest_disabled_is_a_noop(self) -> None:
+        # With harvest_deliverables=false a supervisor owns the copy-out; the
+        # engine must not harvest at all.
+        import dataclasses
+
+        task = TaskSpec(
+            key="task-one",
+            spec="Create the requested outputs.",
+            check="true",
+            engine="mock",
+            expect_files=("site-final.html",),
+        )
+        runner, runtime = self.runtime_for(task)
+        (runtime.taskdir / "site-final.html").write_text("<h1>done</h1>\n", encoding="utf-8")
+        runner.config = dataclasses.replace(self.config, harvest_deliverables=False)
+
+        runner._harvest_deliverables_on_pass(runtime)
+
+        self.assertEqual([], runtime.deliverables)
+        self.assertFalse(
+            (self.artifacts_dir / "deliverables" / runner.run_id / "task-one" / "site-final.html").exists()
+        )
+
     def harvested_state(self) -> dict[str, object]:
         run_id = "run-123"
         task_key = "task-one"


### PR DESCRIPTION
## What

On PASS, `_harvest_deliverables_on_pass()` copies declared deliverables with
`shutil.copy2`, which **follows symlinks**. A task whose only writable directory
is its taskdir can create a symlink named like a declared deliverable
(`expect_files: ["out.css"]`, `out.css -> /etc/secret` or `-> ~/.config/...`),
and harvest will copy the *target's contents* out into the results/deliverables
area. The escape also works one level up: a symlinked directory component in a
relative `expect_file` (`sub/out.css` where `sub` is a symlink) resolves outside
the taskdir.

This matters most when the engine runs tasks under any kind of sandbox/uid
separation where the taskdir is the only thing the task is supposed to reach.

## Change

- Harvest copies **regular files only**; a symlinked deliverable is skipped with
  a note (no silent drop).
- For in-tree (relative) `expect_files`, the resolved real path must stay
  **beneath the taskdir** — rejects the symlinked-directory escape. Absolute and
  `~` `expect_files` keep their existing out-of-tree semantics.
- New `harvest_deliverables` config (default `true`, unchanged behavior) so a
  supervisor that runs the engine outside the task's UID can turn the built-in
  harvest off and own a symlink-safe copy-out itself.

## Tests

`tests/test_deliverables.py`: a symlinked deliverable and a symlinked-dir escape
are both refused; disabling harvest is a no-op; all existing harvest tests
(absolute/`~`/missing/oversize/fallback) still pass.
