### PR TITLE
evidence: configurable worker_log_dir + standalone check-output sink

### DIFF
--- a/ringer.py
+++ b/ringer.py
@@ -184,6 +184,11 @@ class AppConfig:
     eval: EvalConfig
     engines: dict[str, EngineConfig]
     artifact: ArtifactConfig
+    # When set, worker.log and a standalone full check-output sink are written
+    # here — a supervisor-owned directory outside the worker-writable taskdir —
+    # instead of into taskdir/worker.log, so the worker cannot tamper with the
+    # evidence that becomes its own trust record. Independent of worktrees.
+    worker_log_dir: Path | None = None
 
     @classmethod
     def load(cls, path: Path | None = None) -> "AppConfig":
@@ -210,6 +215,7 @@ class AppConfig:
         eval_config = load_eval_config(data.get("eval"), state_dir)
         engines = load_engines(data.get("engines"))
         artifact_config = load_artifact_config(data.get("artifact"), state_dir)
+        worker_log_dir = optional_path(data.get("worker_log_dir"))
         return cls(
             path=config_path if config_path.exists() else None,
             identity_default=identity_default,
@@ -221,6 +227,7 @@ class AppConfig:
             eval=eval_config,
             engines=engines,
             artifact=artifact_config,
+            worker_log_dir=worker_log_dir,
         )
 
 
@@ -6711,8 +6718,20 @@ def run_models_command(config: AppConfig, args: argparse.Namespace) -> int:
 
 
 class Verifier:
-    async def verify(self, task: TaskSpec, taskdir: Path) -> VerifyResult:
+    async def verify(
+        self, task: TaskSpec, taskdir: Path, check_output_sink: Path | None = None
+    ) -> VerifyResult:
         check_returncode, check_timed_out, output = await self._run_check(task.check, taskdir)
+        if check_output_sink is not None:
+            # A standalone, untruncated sink for the raw (worker-influenced)
+            # check output, written supervisor-side. runs.jsonl keeps only the
+            # bounded excerpt below; the full bytes live here as a clearly-
+            # untrusted blob for a later reader to sanitize before trusting.
+            try:
+                check_output_sink.parent.mkdir(parents=True, exist_ok=True)
+                check_output_sink.write_text(output, encoding="utf-8")
+            except OSError:
+                pass
         missing_files = tuple(
             rel for rel in task.expect_files if not self._is_nonempty_file(self._expect_file_path(taskdir, rel))
         )
@@ -6891,7 +6910,14 @@ class RingerRunner:
                     runtime.status = "verifying"
                     if worker.tokens is not None:
                         runtime.tokens = (runtime.tokens or 0) + worker.tokens
-                verify = await self.verifier.verify(runtime.task, runtime.taskdir)
+                check_output_sink = (
+                    self.config.worker_log_dir / f"{runtime.task.key}.check-output.txt"
+                    if self.config.worker_log_dir is not None
+                    else None
+                )
+                verify = await self.verifier.verify(
+                    runtime.task, runtime.taskdir, check_output_sink=check_output_sink
+                )
                 verdict = verdict_for(worker, verify)
                 with self.lock:
                     runtime.last_check_returncode = verify.check_returncode
@@ -7236,6 +7262,14 @@ class RingerRunner:
         return taskdir
 
     def _log_path(self, task: TaskSpec, taskdir: Path) -> Path:
+        external = self.config.worker_log_dir
+        if external is not None:
+            external.mkdir(parents=True, exist_ok=True)
+            external_real = external.resolve()
+            log_path = (external_real / f"{task.key}.worker.log").resolve()
+            if log_path != external_real and external_real not in log_path.parents:
+                raise ValueError(f"task key escapes worker log dir: {task.key}")
+            return log_path
         if not self.manifest.worktrees:
             return taskdir / "worker.log"
         logs_dir = (self.manifest.workdir / "logs").resolve()

--- a/tests/test_worker_log_dir.py
+++ b/tests/test_worker_log_dir.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import asyncio
+import os
+import shlex
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from ringer import (  # noqa: E402
+    AppConfig,
+    ArtifactConfig,
+    EngineConfig,
+    EvalConfig,
+    Manifest,
+    RingerRunner,
+    TaskSpec,
+    Verifier,
+)
+
+
+class WorkerLogDirTests(unittest.TestCase):
+    """worker_log_dir relocates worker.log (and a standalone check-output sink)
+    to a supervisor-owned directory outside the worker-writable taskdir, so the
+    worker cannot tamper with the evidence that becomes its own trust record."""
+
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.root = Path(self.tmp.name)
+        self.state_dir = self.root / "state"
+        self.workdir = self.root / "work"
+        self.engine = EngineConfig(
+            name="mock",
+            bin=sys.executable,
+            args_template=("-c", "{spec}"),
+            full_access_args=(),
+            sandbox_args=(),
+        )
+
+    def make_config(self, worker_log_dir: Path | None) -> AppConfig:
+        artifacts_dir = self.state_dir / "artifacts"
+        return AppConfig(
+            path=None,
+            identity_default=None,
+            state_dir=self.state_dir,
+            dashboard_port_base=8787,
+            hud_port=8700,
+            hud_app_path=None,
+            allow_full_access=False,
+            eval=EvalConfig(backend="jsonl", jsonl_path=self.root / "eval.jsonl"),
+            engines={"mock": self.engine},
+            artifact=ArtifactConfig(
+                enabled=True,
+                out_template=str(artifacts_dir / "{run_id}.html"),
+                report_template=str(artifacts_dir / "{run_id}-report.html"),
+                index_out=artifacts_dir / "index.html",
+            ),
+            worker_log_dir=worker_log_dir,
+        )
+
+    def manifest(self, task: TaskSpec) -> Manifest:
+        return Manifest.from_obj(
+            {
+                "run_name": "Rig Run",
+                "workdir": str(self.workdir),
+                "max_parallel": 1,
+                "worktrees": False,
+                "tasks": [
+                    {
+                        "key": task.key,
+                        "spec": task.spec,
+                        "check": task.check,
+                        "engine": task.engine,
+                        "expect_files": list(task.expect_files),
+                    }
+                ],
+            }
+        )
+
+    def runner(self, worker_log_dir: Path | None) -> RingerRunner:
+        task = TaskSpec(key="t1", spec="noop", check="true", engine="mock")
+        return RingerRunner(
+            self.manifest(task),
+            self.make_config(worker_log_dir),
+            "test-agent",
+            dashboard_enabled=False,
+        )
+
+    def test_worker_log_lands_outside_taskdir_when_configured(self) -> None:
+        evidence = self.root / "evidence"
+        runner = self.runner(evidence)
+        runtime = runner.runtimes[0]
+        taskdir = runtime.taskdir
+        # The log must not live inside the worker-writable taskdir.
+        self.assertNotEqual(taskdir / "worker.log", runtime.log_path)
+        self.assertFalse(str(runtime.log_path).startswith(str(taskdir) + os.sep))
+        self.assertEqual(evidence.resolve(), runtime.log_path.parent)
+        self.assertEqual("t1.worker.log", runtime.log_path.name)
+
+    def test_worker_log_default_stays_in_taskdir(self) -> None:
+        runner = self.runner(None)
+        runtime = runner.runtimes[0]
+        self.assertEqual(runtime.taskdir / "worker.log", runtime.log_path)
+
+    def test_worker_planted_symlink_at_log_path_is_not_written_through(self) -> None:
+        evidence = self.root / "evidence"
+        secret = self.root / "secret.txt"
+        secret.write_text("SECRET\n", encoding="utf-8")
+        runner = self.runner(evidence)
+        runtime = runner.runtimes[0]
+        runtime.taskdir.mkdir(parents=True, exist_ok=True)
+        planted = runtime.taskdir / "worker.log"
+        planted.symlink_to(secret)
+        # The engine writes to the external path, never the planted symlink.
+        self.assertNotEqual(planted, runtime.log_path)
+        self.assertEqual(evidence.resolve(), runtime.log_path.parent)
+
+    def test_verify_writes_full_untruncated_check_output_sink(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            taskdir = Path(root) / "task"
+            taskdir.mkdir()
+            sink = Path(root) / "evidence" / "t1.check-output.txt"
+            pycode = "import sys; sys.stdout.write('LINE\\n' * 1000)"
+            task = TaskSpec(
+                key="t1",
+                spec="noop",
+                check=f"{shlex.quote(sys.executable)} -c {shlex.quote(pycode)}",
+                expect_files=(),
+            )
+            result = asyncio.run(
+                Verifier().verify(task, taskdir, check_output_sink=sink)
+            )
+            self.assertTrue(sink.exists())
+            self.assertGreater(len(sink.read_text(encoding="utf-8")), 2000)
+            # The in-band excerpt stays bounded; the sink holds the full evidence.
+            self.assertLessEqual(len(result.raw_output_excerpt), 2000)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## What

With `worktrees = false`, `worker.log` is written to `taskdir/worker.log` — the
same directory the task itself writes. A task can therefore unlink, replace, or
symlink its own run log. Separately, the check's output is only kept as a
2000-char excerpt embedded in `runs.jsonl`; there is no standalone record of what
the check actually saw.

For anyone running the engine as a supervisor outside the task's UID (so the run
log/evidence should be trustworthy), both are gaps.

## Change

New `worker_log_dir` config (default unset = current behavior). When set:

- `worker.log` is written to `<worker_log_dir>/<key>.worker.log`, outside the
  task-writable taskdir.
- `verify()` writes the **full, untruncated** check output to a standalone sink
  `<worker_log_dir>/<key>.check-output.txt`; `runs.jsonl` keeps the bounded
  excerpt as before.

`Verifier.verify()` gains an optional `check_output_sink` argument (default
`None`), so existing callers are unaffected.

## Tests

`tests/test_worker_log_dir.py`: the log lands outside the taskdir when
configured (and stays in the taskdir when not); a symlink planted where the log
would have gone is not written through; the sink holds the full output while the
excerpt stays bounded.
