### PR TITLE
check: optional launcher to run checks through a sandbox

### DIFF
--- a/ringer.py
+++ b/ringer.py
@@ -184,6 +184,10 @@ class AppConfig:
     eval: EvalConfig
     engines: dict[str, EngineConfig]
     artifact: ArtifactConfig
+    # When set, each `check` is run as: <check_launcher...> <check-command>, so
+    # a fixed reviewed launcher can sandbox the check instead of the engine
+    # running the task-controlled command with a bare `sh -c`.
+    check_launcher: tuple[str, ...] | None = None
 
     @classmethod
     def load(cls, path: Path | None = None) -> "AppConfig":
@@ -210,6 +214,12 @@ class AppConfig:
         eval_config = load_eval_config(data.get("eval"), state_dir)
         engines = load_engines(data.get("engines"))
         artifact_config = load_artifact_config(data.get("artifact"), state_dir)
+        check_launcher_raw = data.get("check_launcher")
+        check_launcher = (
+            as_string_tuple(check_launcher_raw, key="check_launcher")
+            if check_launcher_raw
+            else None
+        )
         return cls(
             path=config_path if config_path.exists() else None,
             identity_default=identity_default,
@@ -221,6 +231,7 @@ class AppConfig:
             eval=eval_config,
             engines=engines,
             artifact=artifact_config,
+            check_launcher=check_launcher,
         )
 
 
@@ -6711,6 +6722,14 @@ def run_models_command(config: AppConfig, args: argparse.Namespace) -> int:
 
 
 class Verifier:
+    def __init__(self, check_launcher: tuple[str, ...] | None = None) -> None:
+        # When set, `check` is run as: <launcher...> <check-command>, so a
+        # fixed reviewed launcher can sandbox the check (its own UID, no
+        # network, dropped caps, read-only input) instead of the engine running
+        # the task-controlled command with a bare `sh -c`. None keeps the
+        # plain-shell behavior.
+        self.check_launcher = check_launcher
+
     async def verify(self, task: TaskSpec, taskdir: Path) -> VerifyResult:
         check_returncode, check_timed_out, output = await self._run_check(task.check, taskdir)
         missing_files = tuple(
@@ -6749,16 +6768,30 @@ class Verifier:
         # Keep runtime verification aligned with lint's treatment of "~" paths.
         return candidate if candidate.is_absolute() else taskdir / candidate
 
-    @staticmethod
-    async def _run_check(command: str, cwd: Path) -> tuple[int | None, bool, str]:
-        proc = await asyncio.create_subprocess_shell(
-            command,
-            cwd=str(cwd),
-            stdin=asyncio.subprocess.DEVNULL,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.STDOUT,
-            start_new_session=True,
-        )
+    async def _run_check(self, command: str, cwd: Path) -> tuple[int | None, bool, str]:
+        if self.check_launcher:
+            # Hand the raw check command to the reviewed launcher as one arg; it
+            # owns how (and whether) the command runs inside its sandbox. No
+            # bare `sh -c` here, so a task's auto-loaded config (conftest.py /
+            # Makefile / …) never executes in the engine's context.
+            proc = await asyncio.create_subprocess_exec(
+                *self.check_launcher,
+                command,
+                cwd=str(cwd),
+                stdin=asyncio.subprocess.DEVNULL,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.STDOUT,
+                start_new_session=True,
+            )
+        else:
+            proc = await asyncio.create_subprocess_shell(
+                command,
+                cwd=str(cwd),
+                stdin=asyncio.subprocess.DEVNULL,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.STDOUT,
+                start_new_session=True,
+            )
         timed_out = False
         try:
             stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=CHECK_TIMEOUT_S)
@@ -6816,7 +6849,7 @@ class RingerRunner:
             else None
         )
         self.logger = EvalLogger(config.eval)
-        self.verifier = Verifier()
+        self.verifier = Verifier(check_launcher=config.check_launcher)
         self.semaphore = asyncio.Semaphore(manifest.max_parallel)
         self.active_processes: dict[int, asyncio.subprocess.Process] = {}
 

--- a/tests/test_verify_order.py
+++ b/tests/test_verify_order.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import asyncio
+import shlex
 import sys
 import tempfile
 import unittest
@@ -74,6 +75,52 @@ class VerifyOrderTests(unittest.TestCase):
             result.raw_output_excerpt.startswith("[ringer] check failed silently"),
             result.raw_output_excerpt,
         )
+
+
+class CheckLauncherTests(unittest.TestCase):
+    def test_check_launcher_wraps_the_check_command(self) -> None:
+        # `check` is an arbitrary shell command run over task-controlled output;
+        # a task that plants a conftest.py/Makefile gets code-exec from an
+        # auto-loading check (pytest/make). A configured launcher must receive
+        # the check command and decide how (and whether) to run it, instead of
+        # a bare `sh -c` in the taskdir — so the sandbox, not the task's planted
+        # config, owns the checker context.
+        with tempfile.TemporaryDirectory() as root:
+            root = Path(root)
+            taskdir = root / "task"
+            taskdir.mkdir()
+            # Hostile auto-loaded config: `import conftest` in taskdir runs this.
+            (taskdir / "conftest.py").write_text(
+                f"open({str(root / 'PWNED')!r}, 'w').close()\n", encoding="utf-8"
+            )
+            check = f"{shlex.quote(sys.executable)} -c 'import conftest'"
+            task = TaskSpec(key="t1", spec="noop", check=check, expect_files=())
+
+            # Sanity: bare (no launcher) — the planted conftest.py DOES execute,
+            # proving this is a real auto-load code-exec vector.
+            asyncio.run(Verifier().verify(task, taskdir))
+            self.assertTrue((root / "PWNED").exists())
+            (root / "PWNED").unlink()
+
+            invoked = root / "LAUNCHER_INVOKED"
+            launcher = root / "launcher.sh"
+            launcher.write_text(
+                "#!/bin/sh\n"
+                f'printf "%s\\n" "$@" > {shlex.quote(str(invoked))}\n'
+                "exit 0\n",  # sandbox stand-in: does NOT run the check bare
+                encoding="utf-8",
+            )
+            launcher.chmod(0o755)
+
+            verifier = Verifier(check_launcher=(str(launcher),))
+            asyncio.run(verifier.verify(task, taskdir))
+
+            self.assertTrue(invoked.exists(), "check was not routed through the launcher")
+            self.assertIn("import conftest", invoked.read_text(encoding="utf-8"))
+            self.assertFalse(
+                (root / "PWNED").exists(),
+                "planted conftest.py executed — check ran bare, not via the launcher",
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What

`check` is an arbitrary shell command run over task-controlled output via
`create_subprocess_shell`. When a check auto-loads task-authored config —
pytest's `conftest.py`, make's `Makefile`, npm's `scripts.test`, `.eslintrc.js` —
running it bare gives the task code execution in the checker's context, which may
be less sandboxed than the task itself.

## Change

New `check_launcher` config (default unset = current bare `sh -c`). When set, the
check is invoked as `<check_launcher...> <check-command>` via `exec` (no
intermediate shell), so a fixed, reviewed launcher owns **how and whether** the
command runs — e.g. under a dedicated UID, no network, dropped caps, read-only
input, a resource envelope.

The launcher itself is deployment-specific and intentionally out of scope here;
this PR is just the seam (`Verifier(check_launcher=...)` + config plumbing).

## Tests

`tests/test_verify_order.py`: with a launcher configured, a planted `conftest.py`
that executes when the check runs bare does **not** execute — the command is
handed to the launcher instead.
