### PR TITLE
Steering profiles: per-model rule injection + observation collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,10 @@ The promotion ladder is the point. A model enters as **untested**. You spend a s
 
 The per-user philosophy, stated plainly: every user's workload is different, so the scoreboard learns what works for *your* tasks on *your* machine. A model that's proven in someone else's log is untested in yours until you've run it. The numbers are not portable between users, and the routing recommendations get personal as the log grows — which is exactly why the catalog and the change log stay local and the explore tiers are computed from your own `runs.jsonl`, not from anyone's aggregate.
 
+## Steering profiles
+
+Ringer can optionally load per-model steering profiles, prepend applicable worker rules to both first-attempt and retry prompts, print driver guidance for the orchestrator, and collect one local observation row per attempt. The feature is fail-open: missing or malformed steering data never blocks a run. Setup, the profile contract, and the observation schema are documented in [`docs/STEERING.md`](docs/STEERING.md).
+
 ## Hard-won invariants
 
 Four rules are baked into every worker invocation. They all cost us real debugging hours; you get them for free:

--- a/config.sample.toml
+++ b/config.sample.toml
@@ -22,6 +22,13 @@ dashboard_port_base = 8787
 # still fail unless this is true.
 allow_full_access = false
 
+# Optional model steering. The directory must contain profiles/ with one
+# Markdown profile per model. Ringer creates observations/ringer/ beneath this
+# directory automatically as attempts finish.
+# [steering]
+# dir = "~/.ringer/steering"
+# inject_candidates = true
+
 [eval]
 # Safe public default: write one JSON object per attempt to a local JSONL file.
 # Use "postgres" only when [eval.postgres] is configured.

--- a/docs/STEERING.md
+++ b/docs/STEERING.md
@@ -1,0 +1,236 @@
+# Steering profiles
+
+Steering profiles let a Ringer install keep model-specific operating knowledge beside the orchestrator. Ringer injects qualifying worker rules at the code path that builds each worker prompt, so attempt 1 and the retry use the same deterministic contract. It surfaces driver rules to the orchestrator before a run and appends one observation row after every attempt as a side effect.
+
+Steering is optional and local. It does not replace the manifest, the executed check, or the normal eval log.
+
+## Enable steering
+
+Create a steering directory with a `profiles/` subdirectory, then set it in `config.toml`:
+
+```toml
+[steering]
+dir = "~/.ringer/steering"
+inject_candidates = true
+```
+
+`RINGER_STEERING_DIR` overrides `steering.dir` when set. Paths expand `~`. `inject_candidates` defaults to `true`; set it to `false` to omit candidate rules from worker prompts while still injecting confirmed and stale-pending-reverify worker rules.
+
+The configured directory has this shape:
+
+```text
+~/.ringer/steering/
+├── profiles/
+│   ├── gpt-5.6-sol.md
+│   └── openrouter-z-ai-glm-5.2.md
+└── observations/
+    └── ringer/
+        └── 2026-07-10.jsonl
+```
+
+Ringer creates `observations/ringer/` when it has an observation to write.
+
+## Install and upgrade
+
+Every agent or Ringer install must create and own its own steering directory. Do not point one install at another person's directory or at a shared mutable profile tree. A sane default is:
+
+```bash
+mkdir -p ~/.ringer/steering/profiles
+```
+
+Then copy or author the profiles that this install should use and configure `dir = "~/.ringer/steering"`. On upgrade, keep that directory in place; it is install data, not part of the Ringer clone. Review profile format changes before replacing local profiles, and preserve the local observations unless you intentionally want a new evidence history.
+
+## Profile resolution
+
+Ringer resolves a task's model in the same order used by its attempt log:
+
+1. The task's `model` field.
+2. The engine's `model_default`.
+3. A `-m`, `--model`, or `--model=...` value in the composed worker command.
+
+For `openrouter/z-ai/glm-5.2`, it checks these files in order:
+
+1. `profiles/openrouter-z-ai-glm-5.2.md`
+2. `profiles/glm-5.2.md`
+
+The first existing path wins. Profile filenames and matching are lowercase.
+
+## Profile file format v1
+
+There is one Markdown file per model: `profiles/<model-slug>.md`. The slug is canonical: it is the filename and the prefix for fully qualified rule IDs such as `gpt-5.6-sol/spec-as-file`.
+
+A profile contains:
+
+1. YAML-like frontmatter with profile metadata.
+2. One `## R<n> · <rule-id>` section per rule.
+3. Optional `## Environment notes` and `## Changelog` sections.
+
+Ringer uses a tolerant stdlib-only line parser, not a general YAML parser. It reads `model` and `profile_version` from frontmatter. From each rule's first fenced `yaml` block it reads the simple top-level `id`, `status`, and `audience` values. It reads the paragraph beginning with `**Inject:**` through the first blank line. A rule it cannot parse is skipped.
+
+### Frontmatter
+
+```yaml
+---
+kind: steering-profile
+format: 1
+model: gpt-5.6-sol
+model_names: ["GPT-5.6 Sol (high reasoning)"]
+surfaces: ["codex-cli 0.144"]
+profile_version: 0.1.0
+updated: 2026-07-10
+verified_against: gpt-5.6-sol
+---
+```
+
+`kind` is the constant `steering-profile`. `format` is this format's major version. `model` is the canonical slug. `profile_version` follows semantic versioning:
+
+- MAJOR: a format-breaking change.
+- MINOR: a rule addition or rule-status change.
+- PATCH: wording, metadata, or evidence-link changes without a status change.
+
+Seed profiles start at `0.1.0`; the first ablation pass that grades the rules promotes the profile to `1.0.0`.
+
+### Rule sections
+
+The heading is `## R<n> · <rule-id>`. A rule number is assigned once, never renumbered, and never reused. Refuted rules remain in the profile because a failed hypothesis is evidence.
+
+````markdown
+## R1 · spec-as-file
+
+```yaml
+id: spec-as-file
+status: candidate
+audience: driver
+domains: [cad-3d]
+first_observed: 2026-07-10
+last_verified: 2026-07-10
+verified_on: gpt-5.6-sol
+steer_gain: null
+evidence:
+  - kind: observation
+    ref: observations/2026-07-10-example.md
+    date: 2026-07-10
+```
+
+**Inject:** Put every hard constraint in a spec file the model must read.
+
+**Detail:** Explain how the rule works and the failure mode it prevents.
+
+**Evidence notes:** Add optional context beyond the evidence links.
+````
+
+`Inject` is one prompt-ready sentence or short paragraph. It must be self-contained, written as an instruction to the agent that receives it, and must not depend on access to the profile repository.
+
+### Audience
+
+Every rule targets one audience:
+
+- `driver`: guidance for the orchestrator steering the model—how to structure a spec, present references, or phrase feedback. Ringer prints these before running tasks, including during `--dry-run`. Driver rules are never pasted into a worker prompt. If `audience` is absent, Ringer defaults it to `driver`.
+- `worker`: text written for the model itself. Ringer may prepend it to the worker spec according to the rule status.
+
+The distinction keeps "how to prompt this model" separate from "what to tell this model."
+
+### Status lifecycle
+
+```text
+candidate --ablation--> confirmed --model version bump--> stale-pending-reverify
+    |                       ^                                  |
+    +------ablation------> refuted        re-verification -----+
+```
+
+- `candidate`: a hypothesis awaiting an ablation.
+- `confirmed`: a validated rule.
+- `refuted`: a tested rule that did not help; it remains in the profile but is never injected.
+- `stale-pending-reverify`: a formerly confirmed rule awaiting validation on a newer model version.
+
+Only the validation gate—the steering-foundry or a manually run ablation—changes a rule's status. A model-version bump changes confirmed rules to stale-pending-reverify. Agents append observations; they never edit profiles or promote, refute, or reverify rules. An N=1 observation may become an evidence link later, but it cannot change status.
+
+### Environment notes and changelog
+
+An optional `## Environment notes` section records stamped, verifiable tooling or surface facts that steering agents need but that are not steering hypotheses. Examples include CLI flags, sandbox behavior, or version-specific limitations. Each bullet ends with `— <surface>, <date>`. These facts do not graduate through rule statuses; they are simply current or outdated. Renderers may append them when the target surface matches, but Ringer's worker injector does not currently emit them.
+
+An optional `## Changelog` records profile-version changes. Keep status changes, additions, staleness updates, and wording/evidence edits aligned with the semantic-version rules above.
+
+### Injection contract
+
+Worker rules are emitted in profile order:
+
+- `confirmed`: `- <inject text>`
+- `candidate`: `- (candidate) <inject text>`, unless `inject_candidates = false`
+- `stale-pending-reverify`: `- (unverified on current model version) <inject text>`
+- `refuted`: never injected
+
+The complete worker block is:
+
+```text
+[Steering profile <model> v<profile_version> — auto-injected by ringer.py]
+- <confirmed inject text>
+- (candidate) <candidate inject text>
+- (unverified on current model version) <stale inject text>
+[End steering profile]
+
+<original task spec>
+```
+
+If no worker rules qualify, Ringer does not add an empty block.
+
+Driver rules with status `confirmed`, `candidate`, or `stale-pending-reverify` are printed once per distinct resolved model:
+
+```text
+Steering notes for <model> (v<profile_version>) — apply when writing specs/feedback:
+- (<status>) <inject text>
+```
+
+## Observation JSONL
+
+After each attempt's verdict is known, Ringer appends one JSON object to:
+
+```text
+<steering-dir>/observations/ringer/<YYYY-MM-DD>.jsonl
+```
+
+The filename uses the UTC date. Each row contains:
+
+| Field | Type | Meaning |
+|---|---|---|
+| `ts` | string | UTC ISO timestamp |
+| `source` | string | Always `ringer.py` |
+| `run_id` | string | Ringer run ID |
+| `run_name` | string | Manifest run name |
+| `task_key` | string | Manifest task key |
+| `task_type` | string | Optional task classification |
+| `engine` | string | Configured worker engine |
+| `model` | string | Resolved model |
+| `profile` | string or null | Matched profile filename slug |
+| `profile_version` | string or null | Matched profile version |
+| `rules_injected` | array of strings | Worker rule IDs injected for this attempt |
+| `attempt` | integer | Attempt number, starting at 1 |
+| `retry` | boolean | Whether this was the retry |
+| `verdict` | string | `PASS`, `FAIL`, `TIMEOUT`, or `ERROR` |
+| `duration_ms` | integer | Attempt duration in milliseconds |
+| `worker_tokens` | integer or null | Tokens reported for this attempt |
+| `check_excerpt` | string | First 500 characters of raw check output |
+
+Observation rows are evidence inputs only. Writing one never changes a profile.
+
+## Fail-open guarantee
+
+The entire steering feature is fail-open. With steering unconfigured, Ringer follows its original prompt, log, and state paths without a steering branch. A missing directory, missing profile, unreadable file, malformed or empty profile, rule parse error, directory-creation failure, observation write failure, or any other steering exception never fails, blocks, delays, retries, or otherwise changes the run. The only allowed effect is that no steering is injected or no observation is recorded. Observation-write failures are noted in the task worker log with the `[ringer.py] steering:` prefix when that log remains writable.
+
+The worker's stdin remains closed, sandbox selection remains explicit, verification still executes the artifact, and raw worker output remains in the worker log.
+
+## Verification recipe
+
+Status: tested by the repo steering test suite.
+
+Safe actions: all tests use temporary homes, configs, profiles, work directories, and the offline mock engine. They do not call a model API.
+
+Run from the Ringer repository root:
+
+```bash
+python3 -m unittest tests.test_steering -v
+python3 -m unittest discover -s tests
+python3 -c "import ast; ast.parse(open('ringer.py').read())"
+```
+
+No cleanup is required; temporary test directories are removed by `unittest`.

--- a/ringer.py
+++ b/ringer.py
@@ -149,6 +149,216 @@ class ArtifactConfig:
         return Path(format_artifact_template(self.report_template, run_id, run_name))
 
 
+@dataclass(frozen=True)
+class SteeringConfig:
+    dir: Path | None = None
+    inject_candidates: bool = True
+
+
+@dataclass(frozen=True)
+class SteeringRule:
+    id: str
+    status: str
+    audience: str
+    inject: str
+
+
+@dataclass(frozen=True)
+class SteeringProfile:
+    model: str
+    profile_version: str
+    slug: str
+    rules: tuple[SteeringRule, ...]
+
+
+STEERING_STATUSES = {"candidate", "confirmed", "refuted", "stale-pending-reverify"}
+STEERING_AUDIENCES = {"driver", "worker"}
+STEERING_RULE_HEADING_RE = re.compile(r"^## R\d+ · ([^\n]+?)\s*$", re.MULTILINE)
+
+
+def load_steering_config(raw: Any) -> SteeringConfig:
+    """Load optional steering settings without allowing them to break config load."""
+    try:
+        section = raw if isinstance(raw, dict) else {}
+        env_dir = os.environ.get(f"{ENV_VAR_PREFIX}_STEERING_DIR")
+        directory = optional_path(env_dir) if env_dir and env_dir.strip() else optional_path(
+            section.get("dir")
+        )
+        return SteeringConfig(
+            dir=directory,
+            inject_candidates=bool(section.get("inject_candidates", True)),
+        )
+    except Exception:
+        return SteeringConfig()
+
+
+def _steering_yaml_values(text: str) -> dict[str, str]:
+    values: dict[str, str] = {}
+    for line in text.splitlines():
+        if line != line.lstrip():
+            continue
+        match = re.match(r"^([A-Za-z_][A-Za-z0-9_-]*):\s*(.*?)\s*$", line)
+        if not match:
+            continue
+        value = match.group(2).strip()
+        value = re.split(r"\s+#", value, maxsplit=1)[0].rstrip()
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in {'"', "'"}:
+            value = value[1:-1]
+        values[match.group(1)] = value
+    return values
+
+
+def parse_steering_profile(text: str, *, slug: str | None = None) -> SteeringProfile | None:
+    """Parse the small, documented subset of steering profile markdown. Never raise."""
+    try:
+        lines = text.splitlines()
+        if not lines or lines[0].strip() != "---":
+            return None
+        frontmatter_end = next(
+            index for index in range(1, len(lines)) if lines[index].strip() == "---"
+        )
+        frontmatter = _steering_yaml_values("\n".join(lines[1:frontmatter_end]))
+        model = frontmatter.get("model", "").strip()
+        profile_version = frontmatter.get("profile_version", "").strip()
+        if not model or not profile_version:
+            return None
+
+        body = "\n".join(lines[frontmatter_end + 1 :])
+        headings = list(STEERING_RULE_HEADING_RE.finditer(body))
+        rules: list[SteeringRule] = []
+        for heading in headings:
+            next_section = re.search(r"^## ", body[heading.end() :], re.MULTILINE)
+            section_end = (
+                heading.end() + next_section.start() if next_section is not None else len(body)
+            )
+            section = body[heading.end() : section_end]
+            yaml_match = re.search(r"```yaml[ \t]*\n(.*?)^```[ \t]*$", section, re.MULTILINE | re.DOTALL)
+            if yaml_match is None:
+                continue
+            metadata = _steering_yaml_values(yaml_match.group(1))
+            rule_id = metadata.get("id", "").strip()
+            status = metadata.get("status", "").strip().lower()
+            audience = metadata.get("audience", "driver").strip().lower() or "driver"
+            if not rule_id or status not in STEERING_STATUSES or audience not in STEERING_AUDIENCES:
+                continue
+
+            inject_parts: list[str] = []
+            found_inject = False
+            for line in section.splitlines():
+                stripped = line.strip()
+                if not found_inject:
+                    if stripped.startswith("**Inject:**"):
+                        found_inject = True
+                        first = stripped.removeprefix("**Inject:**").strip()
+                        if first:
+                            inject_parts.append(first)
+                    continue
+                if not stripped:
+                    break
+                inject_parts.append(stripped)
+            inject_text = " ".join(inject_parts).strip()
+            if not inject_text:
+                continue
+            rules.append(
+                SteeringRule(
+                    id=rule_id,
+                    status=status,
+                    audience=audience,
+                    inject=inject_text,
+                )
+            )
+        if not rules:
+            return None
+        return SteeringProfile(
+            model=model,
+            profile_version=profile_version,
+            slug=(slug or model).strip(),
+            rules=tuple(rules),
+        )
+    except Exception:
+        return None
+
+
+def load_steering_profile(path: Path) -> SteeringProfile | None:
+    try:
+        return parse_steering_profile(
+            path.read_text(encoding="utf-8", errors="replace"),
+            slug=path.stem,
+        )
+    except Exception:
+        return None
+
+
+def steering_profile_candidates(steering_dir: Path, resolved_model: str) -> tuple[Path, ...]:
+    model = resolved_model.strip().lower()
+    if not model:
+        return ()
+    slugs = [model.replace("/", "-"), model.rsplit("/", 1)[-1]]
+    unique_slugs = tuple(dict.fromkeys(slugs))
+    return tuple(steering_dir / "profiles" / f"{slug}.md" for slug in unique_slugs)
+
+
+def resolve_steering_profile(
+    steering_dir: Path | None, resolved_model: str
+) -> SteeringProfile | None:
+    """Return the first matching profile path, even when that file is malformed."""
+    try:
+        if steering_dir is None:
+            return None
+        for candidate in steering_profile_candidates(steering_dir, resolved_model):
+            if candidate.is_file():
+                return load_steering_profile(candidate)
+    except Exception:
+        return None
+    return None
+
+
+def steering_worker_rules(
+    profile: SteeringProfile, *, inject_candidates: bool = True
+) -> tuple[SteeringRule, ...]:
+    try:
+        return tuple(
+            rule
+            for rule in profile.rules
+            if rule.audience == "worker"
+            and (
+                rule.status in {"confirmed", "stale-pending-reverify"}
+                or (rule.status == "candidate" and inject_candidates)
+            )
+        )
+    except Exception:
+        return ()
+
+
+def inject_steering_spec(
+    spec: str,
+    profile: SteeringProfile | None,
+    *,
+    inject_candidates: bool = True,
+) -> tuple[str, tuple[str, ...]]:
+    """Prepend qualifying worker rules, returning the original spec on any error."""
+    try:
+        if profile is None:
+            return spec, ()
+        rules = steering_worker_rules(profile, inject_candidates=inject_candidates)
+        if not rules:
+            return spec, ()
+        lines = [
+            f"[Steering profile {profile.model} v{profile.profile_version} — auto-injected by ringer.py]"
+        ]
+        for rule in rules:
+            prefix = ""
+            if rule.status == "candidate":
+                prefix = "(candidate) "
+            elif rule.status == "stale-pending-reverify":
+                prefix = "(unverified on current model version) "
+            lines.append(f"- {prefix}{rule.inject}")
+        lines.append("[End steering profile]")
+        return "\n".join(lines) + "\n\n" + spec, tuple(rule.id for rule in rules)
+    except Exception:
+        return spec, ()
+
+
 def format_artifact_template(template: str, run_id: str, run_name: str) -> str:
     text = template.replace("{run_id}", run_id).replace("{run_name}", run_name)
     return str(Path(text).expanduser())
@@ -184,6 +394,7 @@ class AppConfig:
     eval: EvalConfig
     engines: dict[str, EngineConfig]
     artifact: ArtifactConfig
+    steering: SteeringConfig = field(default_factory=SteeringConfig)
 
     @classmethod
     def load(cls, path: Path | None = None) -> "AppConfig":
@@ -210,6 +421,12 @@ class AppConfig:
         eval_config = load_eval_config(data.get("eval"), state_dir)
         engines = load_engines(data.get("engines"))
         artifact_config = load_artifact_config(data.get("artifact"), state_dir)
+        try:
+            steering_config = load_steering_config(data.get("steering"))
+        except Exception:
+            # Steering is optional and must never make the base config unusable,
+            # including when its loader itself is replaced or extended later.
+            steering_config = SteeringConfig()
         return cls(
             path=config_path if config_path.exists() else None,
             identity_default=identity_default,
@@ -221,6 +438,7 @@ class AppConfig:
             eval=eval_config,
             engines=engines,
             artifact=artifact_config,
+            steering=steering_config,
         )
 
 
@@ -813,6 +1031,7 @@ class TaskRuntime:
     last_check_timed_out: bool = False
     last_check_output: str = ""
     last_worker_command: list[str] = field(default_factory=list)
+    steering: dict[str, Any] | None = None
 
     def elapsed_s(self, now: float) -> float:
         if self.started_at_monotonic is None:
@@ -986,43 +1205,44 @@ class StateWriter:
                 log_tail_full = tail_lines(runtime.log_path, line_count=40)
                 engine = self.engines.get(runtime.task.engine)
                 process_name = engine.process_name if engine else runtime.task.engine
-                tasks.append(
-                    {
-                        "key": runtime.task.key,
-                        "status": runtime.status,
-                        "verdict": runtime.final_verdict,
-                        "engine": runtime.task.engine,
-                        "model": (
-                            runtime.task.model
-                            or (engine.model_default if engine else "")
-                            or effective_model_from_command(runtime.last_worker_command)
-                        ),
-                        "spec": runtime.task.spec,
-                        "spec_short": runtime.spec_short,
-                        "verified": runtime.task.verified,
-                        "check": runtime.task.check,
-                        "check_returncode": runtime.last_check_returncode,
-                        "check_timed_out": runtime.last_check_timed_out,
-                        "check_output_tail": shorten(runtime.last_check_output, 4000),
-                        "timeout_s": runtime.task.timeout_s,
-                        "taskdir": str(runtime.taskdir),
-                        "log_path": str(runtime.log_path),
-                        "report_paths": {
-                            name: str(path) for name, path in runtime.report_paths.items()
-                        },
-                        "deliverables": [dict(item) for item in runtime.deliverables],
-                        "deliverable_notes": list(runtime.deliverable_notes),
-                        "activity": worker_activity(runtime.log_path, log_tail),
-                        "elapsed_s": round(runtime.elapsed_s(now), 1),
-                        "tokens": runtime.tokens,
-                        "attempts": runtime.attempts,
-                        "children": ProcessTree.count_named_descendants(
-                            runtime.worker_pid, children, commands, process_name
-                        ),
-                        "log_tail": log_tail,
-                        "log_tail_full": log_tail_full,
-                    }
-                )
+                task_state = {
+                    "key": runtime.task.key,
+                    "status": runtime.status,
+                    "verdict": runtime.final_verdict,
+                    "engine": runtime.task.engine,
+                    "model": (
+                        runtime.task.model
+                        or (engine.model_default if engine else "")
+                        or effective_model_from_command(runtime.last_worker_command)
+                    ),
+                    "spec": runtime.task.spec,
+                    "spec_short": runtime.spec_short,
+                    "verified": runtime.task.verified,
+                    "check": runtime.task.check,
+                    "check_returncode": runtime.last_check_returncode,
+                    "check_timed_out": runtime.last_check_timed_out,
+                    "check_output_tail": shorten(runtime.last_check_output, 4000),
+                    "timeout_s": runtime.task.timeout_s,
+                    "taskdir": str(runtime.taskdir),
+                    "log_path": str(runtime.log_path),
+                    "report_paths": {
+                        name: str(path) for name, path in runtime.report_paths.items()
+                    },
+                    "deliverables": [dict(item) for item in runtime.deliverables],
+                    "deliverable_notes": list(runtime.deliverable_notes),
+                    "activity": worker_activity(runtime.log_path, log_tail),
+                    "elapsed_s": round(runtime.elapsed_s(now), 1),
+                    "tokens": runtime.tokens,
+                    "attempts": runtime.attempts,
+                    "children": ProcessTree.count_named_descendants(
+                        runtime.worker_pid, children, commands, process_name
+                    ),
+                    "log_tail": log_tail,
+                    "log_tail_full": log_tail_full,
+                }
+                if runtime.steering is not None:
+                    task_state["steering"] = dict(runtime.steering)
+                tasks.append(task_state)
             pass_count = sum(1 for item in tasks if item["status"] == "pass")
             fail_count = sum(1 for item in tasks if item["status"] == "fail")
             running_count = sum(
@@ -7109,6 +7329,50 @@ class RingerRunner:
             engine_args=runtime.task.engine_args,
             model=runtime.task.model,
         )
+        if self.config.steering.dir is not None:
+            original_cmd = cmd
+            steering_state: dict[str, Any] = {
+                "profile": None,
+                "version": None,
+                "rule_ids": [],
+            }
+            steering_line = "[ringer.py] steering: no profile matched\n"
+            try:
+                resolved_model = resolved_task_model(runtime.task, engine, cmd)
+                profile = resolve_steering_profile(self.config.steering.dir, resolved_model)
+                injected_spec, rule_ids = inject_steering_spec(
+                    spec,
+                    profile,
+                    inject_candidates=self.config.steering.inject_candidates,
+                )
+                if profile is not None:
+                    steering_state = {
+                        "profile": profile.slug,
+                        "version": profile.profile_version,
+                        "rule_ids": list(rule_ids),
+                    }
+                    shown_rules = ", ".join(rule_ids) if rule_ids else "(none)"
+                    steering_line = (
+                        f"[ringer.py] steering: profile={profile.slug} "
+                        f"version={profile.profile_version} rule_ids={shown_rules}\n"
+                    )
+                if injected_spec != spec:
+                    cmd = build_worker_command(
+                        engine,
+                        taskdir=runtime.taskdir,
+                        spec=injected_spec,
+                        full_access=runtime.task.full_access,
+                        engine_args=runtime.task.engine_args,
+                        model=runtime.task.model,
+                    )
+            except Exception:
+                cmd = original_cmd
+                steering_state = {"profile": None, "version": None, "rule_ids": []}
+                steering_line = "[ringer.py] steering: no profile matched\n"
+            with self.lock:
+                runtime.steering = steering_state
+            with contextlib.suppress(Exception):
+                append_text(log_path, steering_line)
         with self.lock:
             runtime.last_worker_command = list(cmd)
         append_text(
@@ -7216,6 +7480,16 @@ class RingerRunner:
             notes_parts.append(f"missing_expect_files={json.dumps(list(verify.missing_files))}")
         notes_parts.append("raw_check_output_first_2000_chars:")
         notes_parts.append(verify.raw_output_excerpt)
+        with contextlib.suppress(Exception):
+            self._write_steering_observation(
+                runtime,
+                resolved_model=resolved_model,
+                retrying=retrying,
+                worker=worker,
+                verify=verify,
+                verdict=verdict,
+                duration_ms=duration_ms,
+            )
         self.logger.log_attempt(
             {
                 "run_id": self.run_id,
@@ -7235,6 +7509,65 @@ class RingerRunner:
                 "retry": retrying,
             }
         )
+
+    def _write_steering_observation(
+        self,
+        runtime: TaskRuntime,
+        *,
+        resolved_model: str,
+        retrying: bool,
+        worker: WorkerResult,
+        verify: VerifyResult,
+        verdict: str,
+        duration_ms: int,
+    ) -> None:
+        steering_dir = self.config.steering.dir
+        if steering_dir is None:
+            return
+        try:
+            steering_state = runtime.steering
+            if steering_state is None:
+                profile = resolve_steering_profile(steering_dir, resolved_model)
+                steering_state = {
+                    "profile": profile.slug if profile else None,
+                    "version": profile.profile_version if profile else None,
+                    "rule_ids": [],
+                }
+                with self.lock:
+                    runtime.steering = steering_state
+            now = datetime.now(timezone.utc)
+            row = {
+                "ts": now.isoformat(),
+                "source": "ringer.py",
+                "run_id": self.run_id,
+                "run_name": self.manifest.run_name,
+                "task_key": runtime.task.key,
+                "task_type": runtime.task.task_type,
+                "engine": runtime.task.engine,
+                "model": resolved_model,
+                "profile": steering_state.get("profile"),
+                "profile_version": steering_state.get("version"),
+                "rules_injected": list(steering_state.get("rule_ids", [])),
+                "attempt": runtime.attempts,
+                "retry": retrying,
+                "verdict": verdict,
+                "duration_ms": duration_ms,
+                "worker_tokens": worker.tokens,
+                "check_excerpt": verify.raw_output_excerpt[:500],
+            }
+            path = (
+                steering_dir
+                / "observations"
+                / "ringer"
+                / f"{now.strftime('%Y-%m-%d')}.jsonl"
+            )
+            append_text(path, json.dumps(row, sort_keys=True) + "\n")
+        except Exception as exc:
+            with contextlib.suppress(Exception):
+                append_text(
+                    runtime.log_path,
+                    f"[ringer.py] steering: observation write failed {exc}\n",
+                )
 
     def _task_runtime(self, task: TaskSpec) -> TaskRuntime:
         taskdir = self._taskdir(task)
@@ -7402,6 +7735,18 @@ def effective_model_from_command(command: list[str]) -> str:
     return ""
 
 
+def resolved_task_model(
+    task: TaskSpec,
+    engine: EngineConfig | None,
+    command: list[str] | None = None,
+) -> str:
+    return (
+        task.model
+        or (engine.model_default if engine else "")
+        or effective_model_from_command(command or [])
+    )
+
+
 def build_worker_command(
     engine: EngineConfig,
     *,
@@ -7437,6 +7782,52 @@ def build_worker_command(
             .replace("{model}", resolved_model)
         )
     return command
+
+
+def print_steering_notes(manifest: Manifest, config: AppConfig) -> None:
+    """Surface driver-audience guidance once per resolved model. Never raise."""
+    try:
+        if config.steering.dir is None:
+            return
+        seen_models: set[str] = set()
+        for task in manifest.tasks:
+            try:
+                engine = config.engines.get(task.engine)
+                command: list[str] = []
+                if engine is not None:
+                    command = build_worker_command(
+                        engine,
+                        taskdir=(manifest.workdir / task.key).resolve(),
+                        spec=task.spec,
+                        full_access=task.full_access,
+                        engine_args=task.engine_args,
+                        model=task.model,
+                    )
+                model = resolved_task_model(task, engine, command)
+                if not model or model in seen_models:
+                    continue
+                seen_models.add(model)
+                profile = resolve_steering_profile(config.steering.dir, model)
+                if profile is None:
+                    continue
+                rules = tuple(
+                    rule
+                    for rule in profile.rules
+                    if rule.audience == "driver"
+                    and rule.status in {"confirmed", "candidate", "stale-pending-reverify"}
+                )
+                if not rules:
+                    continue
+                print(
+                    f"Steering notes for {model} (v{profile.profile_version}) "
+                    "— apply when writing specs/feedback:"
+                )
+                for rule in rules:
+                    print(f"- ({rule.status}) {rule.inject}")
+            except Exception:
+                continue
+    except Exception:
+        return
 
 
 ENGINE_INSTALL_HINTS = {
@@ -8292,6 +8683,8 @@ def main(argv: list[str] | None = None) -> int:
         else:
             manifest_path = args.manifest
         manifest = Manifest.from_path(manifest_path).with_max_parallel(args.max_parallel)
+        with contextlib.suppress(Exception):
+            print_steering_notes(manifest, config)
         print_lint_findings(lint_manifest(manifest, include_model_log_nudges=True))
         validate_manifest_engines(manifest, config)
         identity_start_paths = [manifest.workdir]

--- a/tests/test_steering.py
+++ b/tests/test_steering.py
@@ -1,0 +1,818 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest import mock
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+import ringer  # noqa: E402
+
+from ringer import (  # noqa: E402
+    AppConfig,
+    ArtifactConfig,
+    EngineConfig,
+    EvalConfig,
+    Manifest,
+    RingerRunner,
+    SteeringConfig,
+    SteeringProfile,
+    SteeringRule,
+    TaskSpec,
+    VerifyResult,
+    WorkerResult,
+    inject_steering_spec,
+    load_steering_config,
+    parse_steering_profile,
+    print_steering_notes,
+    resolve_steering_profile,
+    steering_profile_candidates,
+)
+
+
+FIXTURE_PROFILE = """---
+kind: steering-profile
+format: 1
+model: openrouter/z-ai/glm-5.2
+profile_version: 1.2.3
+---
+
+# Steering profile
+
+## R1 · keep-checks-executable
+
+```yaml
+id: keep-checks-executable
+status: confirmed
+audience: worker
+```
+
+**Inject:** Keep verification executable and run it before reporting completion.
+
+**Detail:** This is supporting prose.
+
+## R2 · inspect-first
+
+```yaml
+id: inspect-first
+status: candidate
+audience: worker
+```
+
+**Inject:** Inspect the existing implementation before editing, then follow its
+local patterns.
+
+## R3 · reverify-version
+
+```yaml
+id: reverify-version
+status: stale-pending-reverify
+audience: worker
+```
+
+**Inject:** Recheck version-sensitive behavior against the installed tool.
+
+## R4 · discarded-rule
+
+```yaml
+id: discarded-rule
+status: refuted
+audience: worker
+```
+
+**Inject:** Apply the discarded approach.
+
+## R5 · driver-brief
+
+```yaml
+id: driver-brief
+status: confirmed
+```
+
+**Inject:** Put the acceptance criteria in the task brief.
+
+## R6 · malformed-rule
+
+```yaml
+id: malformed-rule
+status: unknown
+audience: worker
+```
+
+**Inject:** This rule should be skipped.
+"""
+
+
+def toml_string(value: object) -> str:
+    return json.dumps(str(value))
+
+
+def write_profile(path: Path, *, model: str, version: str = "1.0.0") -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        FIXTURE_PROFILE.replace("openrouter/z-ai/glm-5.2", model).replace(
+            "profile_version: 1.2.3", f"profile_version: {version}"
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_engine(model_default: str = "openrouter/z-ai/glm-5.2") -> EngineConfig:
+    return EngineConfig(
+        name="mock",
+        bin=sys.executable,
+        args_template=(str(ROOT / "engines" / "mock_worker.py"), "{spec}"),
+        full_access_args=(),
+        sandbox_args=(),
+        token_regex=None,
+        model_default=model_default,
+    )
+
+
+def make_config(root: Path, steering_dir: Path) -> AppConfig:
+    return AppConfig(
+        path=None,
+        identity_default=None,
+        state_dir=root / "state",
+        dashboard_port_base=8787,
+        hud_port=8700,
+        hud_app_path=None,
+        allow_full_access=False,
+        eval=EvalConfig(backend="jsonl", jsonl_path=root / "eval.jsonl"),
+        engines={"mock": test_engine()},
+        artifact=ArtifactConfig(
+            enabled=False,
+            out_template=str(root / "live.html"),
+            report_template=str(root / "report.html"),
+            index_out=root / "index.html",
+        ),
+        steering=SteeringConfig(dir=steering_dir),
+    )
+
+
+class SteeringProfileParserTests(unittest.TestCase):
+    def test_parser_reads_frontmatter_rules_statuses_audiences_and_inject_paragraphs(self) -> None:
+        profile = parse_steering_profile(FIXTURE_PROFILE, slug="glm-5.2")
+
+        self.assertIsNotNone(profile)
+        assert profile is not None
+        self.assertEqual("openrouter/z-ai/glm-5.2", profile.model)
+        self.assertEqual("1.2.3", profile.profile_version)
+        self.assertEqual("glm-5.2", profile.slug)
+        self.assertEqual(
+            [
+                "keep-checks-executable",
+                "inspect-first",
+                "reverify-version",
+                "discarded-rule",
+                "driver-brief",
+            ],
+            [rule.id for rule in profile.rules],
+        )
+        self.assertEqual(
+            {"confirmed", "candidate", "stale-pending-reverify", "refuted"},
+            {rule.status for rule in profile.rules},
+        )
+        self.assertEqual({"driver", "worker"}, {rule.audience for rule in profile.rules})
+        self.assertEqual("driver", profile.rules[-1].audience)
+        self.assertEqual(
+            "Inspect the existing implementation before editing, then follow its local patterns.",
+            profile.rules[1].inject,
+        )
+
+    def test_malformed_or_empty_profile_returns_none(self) -> None:
+        self.assertIsNone(parse_steering_profile(""))
+        self.assertIsNone(parse_steering_profile("---\nmodel: x\n---\n"))
+        self.assertIsNone(
+            parse_steering_profile(
+                "---\nmodel: x\nprofile_version: 1.0.0\n---\n\n# No rules\n"
+            )
+        )
+        self.assertIsNone(parse_steering_profile("not frontmatter"))
+
+
+class SteeringResolutionTests(unittest.TestCase):
+    def test_candidates_try_fully_qualified_slug_before_basename(self) -> None:
+        root = Path("/tmp/steering")
+        self.assertEqual(
+            (
+                root / "profiles" / "openrouter-z-ai-glm-5.2.md",
+                root / "profiles" / "glm-5.2.md",
+            ),
+            steering_profile_candidates(root, "openrouter/z-ai/glm-5.2"),
+        )
+
+        with tempfile.TemporaryDirectory() as temp_root:
+            steering_dir = Path(temp_root)
+            full = steering_dir / "profiles" / "openrouter-z-ai-glm-5.2.md"
+            basename = steering_dir / "profiles" / "glm-5.2.md"
+            write_profile(full, model="full-match", version="2.0.0")
+            write_profile(basename, model="basename-match", version="3.0.0")
+
+            profile = resolve_steering_profile(steering_dir, "openrouter/z-ai/glm-5.2")
+            self.assertIsNotNone(profile)
+            assert profile is not None
+            self.assertEqual("full-match", profile.model)
+
+            full.unlink()
+            profile = resolve_steering_profile(steering_dir, "openrouter/z-ai/glm-5.2")
+            self.assertIsNotNone(profile)
+            assert profile is not None
+            self.assertEqual("basename-match", profile.model)
+
+    def test_first_existing_malformed_file_wins_without_falling_through(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_root:
+            steering_dir = Path(temp_root)
+            full = steering_dir / "profiles" / "openrouter-z-ai-glm-5.2.md"
+            basename = steering_dir / "profiles" / "glm-5.2.md"
+            full.parent.mkdir(parents=True)
+            full.write_text("malformed", encoding="utf-8")
+            write_profile(basename, model="should-not-load")
+            self.assertIsNone(
+                resolve_steering_profile(steering_dir, "openrouter/z-ai/glm-5.2")
+            )
+
+
+class SteeringInjectionTests(unittest.TestCase):
+    def setUp(self) -> None:
+        parsed = parse_steering_profile(FIXTURE_PROFILE, slug="glm-5.2")
+        assert parsed is not None
+        self.profile = parsed
+
+    def test_worker_injection_contract(self) -> None:
+        original = "Build the requested artifact."
+        injected, rule_ids = inject_steering_spec(original, self.profile)
+
+        self.assertTrue(
+            injected.startswith(
+                "[Steering profile openrouter/z-ai/glm-5.2 v1.2.3 — auto-injected by ringer.py]\n"
+            )
+        )
+        self.assertIn("- Keep verification executable", injected)
+        self.assertIn("- (candidate) Inspect the existing implementation", injected)
+        self.assertIn(
+            "- (unverified on current model version) Recheck version-sensitive behavior",
+            injected,
+        )
+        self.assertNotIn("Apply the discarded approach", injected)
+        self.assertNotIn("Put the acceptance criteria", injected)
+        self.assertTrue(injected.endswith("[End steering profile]\n\n" + original))
+        self.assertEqual(
+            ("keep-checks-executable", "inspect-first", "reverify-version"),
+            rule_ids,
+        )
+
+    def test_candidates_can_be_disabled(self) -> None:
+        injected, rule_ids = inject_steering_spec(
+            "Original", self.profile, inject_candidates=False
+        )
+        self.assertNotIn("(candidate)", injected)
+        self.assertEqual(("keep-checks-executable", "reverify-version"), rule_ids)
+
+    def test_only_driver_rules_produces_no_block(self) -> None:
+        driver_profile = SteeringProfile(
+            model="x",
+            profile_version="1",
+            slug="x",
+            rules=(SteeringRule("driver", "confirmed", "driver", "Guide the driver."),),
+        )
+        self.assertEqual(("Original", ()), inject_steering_spec("Original", driver_profile))
+
+    def test_fail_open_inputs_leave_spec_unchanged(self) -> None:
+        original = "Original spec bytes\n"
+        self.assertEqual((original, ()), inject_steering_spec(original, None))
+        self.assertIsNone(resolve_steering_profile(None, "model"))
+        with tempfile.TemporaryDirectory() as temp_root:
+            root = Path(temp_root)
+            self.assertIsNone(resolve_steering_profile(root / "missing", "model"))
+            malformed = root / "profiles" / "model.md"
+            malformed.parent.mkdir()
+            malformed.write_text("---\nprofile_version: nope\n---", encoding="utf-8")
+            profile = resolve_steering_profile(root, "model")
+            self.assertIsNone(profile)
+            self.assertEqual((original, ()), inject_steering_spec(original, profile))
+
+
+class SteeringConfigAndDriverTests(unittest.TestCase):
+    def test_env_directory_overrides_config_and_expands_home(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_root:
+            home = Path(temp_root)
+            with mock.patch.dict(
+                os.environ,
+                {"HOME": str(home), "RINGER_STEERING_DIR": "~/env-steering"},
+                clear=True,
+            ):
+                config = load_steering_config(
+                    {"dir": str(home / "config-steering"), "inject_candidates": False}
+                )
+        self.assertEqual((home / "env-steering").resolve(), config.dir)
+        self.assertFalse(config.inject_candidates)
+
+    def test_config_load_is_fail_open_if_steering_loader_raises(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_root:
+            root = Path(temp_root)
+            config_path = root / "config.toml"
+            config_path.write_text(
+                f"state_dir = {toml_string(root / 'state')}\n",
+                encoding="utf-8",
+            )
+            with mock.patch.object(
+                ringer,
+                "load_steering_config",
+                side_effect=RuntimeError("broken steering loader"),
+            ):
+                config = AppConfig.load(config_path)
+
+        self.assertEqual(SteeringConfig(), config.steering)
+
+    def test_driver_rules_print_once_per_model(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_root:
+            root = Path(temp_root)
+            steering_dir = root / "steering"
+            write_profile(
+                steering_dir / "profiles" / "openrouter-z-ai-glm-5.2.md",
+                model="openrouter/z-ai/glm-5.2",
+            )
+            manifest = Manifest.from_obj(
+                {
+                    "run_name": "driver-notes",
+                    "workdir": str(root / "work"),
+                    "tasks": [
+                        {"key": "one", "engine": "mock", "spec": "one", "check": "true"},
+                        {"key": "two", "engine": "mock", "spec": "two", "check": "true"},
+                    ],
+                }
+            )
+            config = make_config(root, steering_dir)
+            output = io.StringIO()
+            with contextlib.redirect_stdout(output):
+                print_steering_notes(manifest, config)
+            text = output.getvalue()
+            self.assertEqual(1, text.count("Steering notes for openrouter/z-ai/glm-5.2"))
+            self.assertIn("- (confirmed) Put the acceptance criteria", text)
+            self.assertNotIn("Keep verification executable", text)
+
+    def test_driver_notes_use_explicit_model_without_a_known_engine(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_root:
+            root = Path(temp_root)
+            steering_dir = root / "steering"
+            write_profile(
+                steering_dir / "profiles" / "explicit-model.md",
+                model="explicit/model",
+            )
+            manifest = Manifest.from_obj(
+                {
+                    "run_name": "driver-notes-explicit-model",
+                    "workdir": str(root / "work"),
+                    "tasks": [
+                        {
+                            "key": "one",
+                            "engine": "not-configured",
+                            "model": "explicit/model",
+                            "spec": "one",
+                            "check": "true",
+                        }
+                    ],
+                }
+            )
+            config = make_config(root, steering_dir)
+            output = io.StringIO()
+            with contextlib.redirect_stdout(output):
+                print_steering_notes(manifest, config)
+
+        self.assertIn("Steering notes for explicit/model", output.getvalue())
+
+class SteeringObservationTests(unittest.TestCase):
+    def test_observation_row_schema_and_path(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_root:
+            root = Path(temp_root)
+            steering_dir = root / "steering"
+            manifest = Manifest.from_obj(
+                {
+                    "run_name": "observation-test",
+                    "workdir": str(root / "work"),
+                    "tasks": [
+                        {
+                            "key": "task-a",
+                            "engine": "mock",
+                            "task_type": "code-feature",
+                            "spec": "Do the work",
+                            "check": "true",
+                        }
+                    ],
+                }
+            )
+            config = make_config(root, steering_dir)
+            runner = RingerRunner(manifest, config, "test", dashboard_enabled=False)
+            runtime = runner.runtimes[0]
+            runtime.attempts = 2
+            runtime.steering = {
+                "profile": "glm-5.2",
+                "version": "1.2.3",
+                "rule_ids": ["keep-checks-executable"],
+            }
+
+            runner._write_steering_observation(
+                runtime,
+                resolved_model="openrouter/z-ai/glm-5.2",
+                retrying=True,
+                worker=WorkerResult(returncode=0, timed_out=False, tokens=42),
+                verify=VerifyResult(
+                    ok=True,
+                    check_returncode=0,
+                    check_timed_out=False,
+                    raw_output_excerpt="x" * 700,
+                ),
+                verdict="PASS",
+                duration_ms=123,
+            )
+
+            date = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+            path = steering_dir / "observations" / "ringer" / f"{date}.jsonl"
+            row = json.loads(path.read_text(encoding="utf-8"))
+            self.assertEqual(
+                {
+                    "ts",
+                    "source",
+                    "run_id",
+                    "run_name",
+                    "task_key",
+                    "task_type",
+                    "engine",
+                    "model",
+                    "profile",
+                    "profile_version",
+                    "rules_injected",
+                    "attempt",
+                    "retry",
+                    "verdict",
+                    "duration_ms",
+                    "worker_tokens",
+                    "check_excerpt",
+                },
+                set(row),
+            )
+            self.assertEqual("ringer.py", row["source"])
+            self.assertEqual("observation-test", row["run_name"])
+            self.assertEqual(["keep-checks-executable"], row["rules_injected"])
+            self.assertEqual(2, row["attempt"])
+            self.assertTrue(row["retry"])
+            self.assertEqual(500, len(row["check_excerpt"]))
+
+    def test_observation_write_failure_is_logged_and_does_not_raise(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_root:
+            root = Path(temp_root)
+            blocked = root / "not-a-directory"
+            blocked.write_text("blocked", encoding="utf-8")
+            manifest = Manifest.from_obj(
+                {
+                    "run_name": "write-failure",
+                    "workdir": str(root / "work"),
+                    "tasks": [
+                        {"key": "task-a", "engine": "mock", "spec": "Do it", "check": "true"}
+                    ],
+                }
+            )
+            config = make_config(root, blocked)
+            runner = RingerRunner(manifest, config, "test", dashboard_enabled=False)
+            runtime = runner.runtimes[0]
+            runtime.log_path.parent.mkdir(parents=True)
+            runner._write_steering_observation(
+                runtime,
+                resolved_model="openrouter/z-ai/glm-5.2",
+                retrying=False,
+                worker=WorkerResult(returncode=0, timed_out=False, tokens=None),
+                verify=VerifyResult(True, 0, False, "ok"),
+                verdict="PASS",
+                duration_ms=1,
+            )
+            self.assertIn(
+                "[ringer.py] steering: observation write failed",
+                runtime.log_path.read_text(encoding="utf-8"),
+            )
+
+
+class SteeringIntegrationFailOpenTests(unittest.IsolatedAsyncioTestCase):
+    async def test_retry_reinjects_profile_and_writes_a_second_observation(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_root:
+            root = Path(temp_root)
+            steering_dir = root / "steering"
+            write_profile(
+                steering_dir / "profiles" / "openrouter-z-ai-glm-5.2.md",
+                model="openrouter/z-ai/glm-5.2",
+            )
+            manifest = Manifest.from_obj(
+                {
+                    "run_name": "steering-retry",
+                    "workdir": str(root / "work"),
+                    "tasks": [
+                        {
+                            "key": "task-a",
+                            "engine": "mock",
+                            "spec": "MOCK_FAIL",
+                            "check": "false",
+                        }
+                    ],
+                }
+            )
+            runner = RingerRunner(
+                manifest,
+                make_config(root, steering_dir),
+                "test",
+                dashboard_enabled=False,
+            )
+            runtime = runner.runtimes[0]
+            injected_specs: list[str] = []
+            original_build_worker_command = ringer.build_worker_command
+
+            def recording_build_worker_command(*args: object, **kwargs: object) -> list[str]:
+                spec = kwargs.get("spec")
+                if isinstance(spec, str) and spec.startswith("[Steering profile "):
+                    injected_specs.append(spec)
+                return original_build_worker_command(*args, **kwargs)  # type: ignore[arg-type]
+
+            with mock.patch.object(
+                ringer,
+                "build_worker_command",
+                side_effect=recording_build_worker_command,
+            ):
+                await runner._run_task(runtime)
+
+            self.assertEqual(2, len(injected_specs))
+            self.assertTrue(
+                all(
+                    spec.startswith("[Steering profile openrouter/z-ai/glm-5.2")
+                    for spec in injected_specs
+                )
+            )
+            date = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+            observation_path = (
+                steering_dir / "observations" / "ringer" / f"{date}.jsonl"
+            )
+            rows = [
+                json.loads(line)
+                for line in observation_path.read_text(encoding="utf-8").splitlines()
+            ]
+            self.assertEqual([1, 2], [row["attempt"] for row in rows])
+            self.assertEqual([False, True], [row["retry"] for row in rows])
+            self.assertEqual(
+                [
+                    "keep-checks-executable",
+                    "inspect-first",
+                    "reverify-version",
+                ],
+                rows[1]["rules_injected"],
+            )
+
+    async def test_worker_resolution_exception_runs_original_spec(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_root:
+            root = Path(temp_root)
+            manifest = Manifest.from_obj(
+                {
+                    "run_name": "fail-open-worker",
+                    "workdir": str(root / "work"),
+                    "tasks": [
+                        {
+                            "key": "task-a",
+                            "engine": "mock",
+                            "spec": "MOCK_FILE: result.txt\noriginal spec\nMOCK_END",
+                            "check": "true",
+                        }
+                    ],
+                }
+            )
+            runner = RingerRunner(
+                manifest,
+                make_config(root, root / "steering"),
+                "test",
+                dashboard_enabled=False,
+            )
+            runtime = runner.runtimes[0]
+            runtime.taskdir.mkdir(parents=True)
+
+            with mock.patch.object(
+                ringer,
+                "resolve_steering_profile",
+                side_effect=RuntimeError("steering exploded"),
+            ):
+                result = await runner._run_worker(runtime, runtime.task.spec, 1)
+
+            self.assertEqual(0, result.returncode)
+            self.assertEqual(
+                "original spec\n",
+                (runtime.taskdir / "result.txt").read_text(encoding="utf-8"),
+            )
+            log = runtime.log_path.read_text(encoding="utf-8")
+            self.assertNotIn("[Steering profile", log)
+            self.assertIn("[ringer.py] steering: no profile matched", log)
+            self.assertEqual(
+                {"profile": None, "version": None, "rule_ids": []},
+                runtime.steering,
+            )
+
+    async def test_observation_hook_exception_does_not_escape_attempt_logging(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_root:
+            root = Path(temp_root)
+            manifest = Manifest.from_obj(
+                {
+                    "run_name": "fail-open-observation-hook",
+                    "workdir": str(root / "work"),
+                    "tasks": [
+                        {
+                            "key": "task-a",
+                            "engine": "mock",
+                            "spec": "Do it",
+                            "check": "true",
+                        }
+                    ],
+                }
+            )
+            runner = RingerRunner(
+                manifest,
+                make_config(root, root / "steering"),
+                "test",
+                dashboard_enabled=False,
+            )
+            runtime = runner.runtimes[0]
+            runtime.attempts = 1
+            runtime.last_worker_command = ["mock", "--model=mock/model"]
+
+            with mock.patch.object(
+                runner,
+                "_write_steering_observation",
+                side_effect=RuntimeError("observation hook exploded"),
+            ):
+                runner._log_attempt(
+                    runtime,
+                    runtime.task.spec,
+                    False,
+                    WorkerResult(returncode=0, timed_out=False, tokens=None),
+                    VerifyResult(True, 0, False, "ok"),
+                    "PASS",
+                    1,
+                )
+
+            rows = [
+                json.loads(line)
+                for line in (root / "eval.jsonl").read_text(encoding="utf-8").splitlines()
+            ]
+            self.assertEqual(1, len(rows))
+            self.assertEqual("PASS", rows[0]["verdict"])
+
+
+class SteeringMockEngineFunctionalTests(unittest.TestCase):
+    def test_mock_worker_receives_injected_spec_and_observation_is_written(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_root:
+            root = Path(temp_root)
+            home = root / "home"
+            ringer_home = root / "ringer-home"
+            state_dir = root / "state"
+            steering_dir = root / "steering"
+            workdir = root / "work"
+            config_path = root / "config.toml"
+            manifest_path = root / "manifest.json"
+            home.mkdir()
+            ringer_home.mkdir()
+            write_profile(
+                steering_dir / "profiles" / "mock-model.md",
+                model="mock/model",
+                version="4.5.6",
+            )
+
+            config_path.write_text(
+                "\n".join(
+                    [
+                        f"state_dir = {toml_string(state_dir)}",
+                        "",
+                        "[steering]",
+                        f"dir = {toml_string(steering_dir)}",
+                        "inject_candidates = true",
+                        "",
+                        "[eval]",
+                        'backend = "jsonl"',
+                        f"jsonl_path = {toml_string(root / 'runs.jsonl')}",
+                        "",
+                        "[artifact]",
+                        "enabled = false",
+                        "",
+                        "[engines.mock]",
+                        f"bin = {toml_string(sys.executable)}",
+                        'model_default = "mock/model"',
+                        "args_template = [",
+                        f"  {toml_string(ROOT / 'engines' / 'mock_worker.py')},",
+                        '  "{spec}",',
+                        "]",
+                        "sandbox_args = []",
+                        "full_access_args = []",
+                        "",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+            manifest_path.write_text(
+                json.dumps(
+                    {
+                        "run_name": "steering-functional",
+                        "workdir": str(workdir),
+                        "tasks": [
+                            {
+                                "key": "steered-task",
+                                "engine": "mock",
+                                "task_type": "code-feature",
+                                "spec": "MOCK_FILE: result.txt\nsteered run\nMOCK_END",
+                                "check": "test \"$(cat result.txt)\" = \"steered run\"",
+                                "expect_files": ["result.txt"],
+                            }
+                        ],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            env = os.environ.copy()
+            env.update(
+                {
+                    "HOME": str(home),
+                    "RINGER_HOME": str(ringer_home),
+                    "XDG_CONFIG_HOME": str(root / "xdg-config"),
+                }
+            )
+            env.pop("RINGER_STEERING_DIR", None)
+
+            proc = subprocess.run(
+                [
+                    sys.executable,
+                    "ringer.py",
+                    "run",
+                    str(manifest_path),
+                    "--config",
+                    str(config_path),
+                    "--no-dashboard",
+                    "--identity",
+                    "steering-test",
+                ],
+                cwd=ROOT,
+                env=env,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=False,
+                timeout=30,
+            )
+
+            combined = proc.stdout + proc.stderr
+            self.assertEqual(0, proc.returncode, combined)
+            log = (workdir / "steered-task" / "worker.log").read_text(encoding="utf-8")
+            self.assertIn(
+                "[Steering profile mock/model v4.5.6 — auto-injected by ringer.py]",
+                log,
+            )
+            self.assertIn(
+                "[ringer.py] steering: profile=mock-model version=4.5.6",
+                log,
+            )
+
+            state_path = next((state_dir / "runs").glob("*.json"))
+            state = json.loads(state_path.read_text(encoding="utf-8"))
+            self.assertEqual(
+                {
+                    "profile": "mock-model",
+                    "version": "4.5.6",
+                    "rule_ids": [
+                        "keep-checks-executable",
+                        "inspect-first",
+                        "reverify-version",
+                    ],
+                },
+                state["tasks"][0]["steering"],
+            )
+
+            date = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+            observation_path = (
+                steering_dir / "observations" / "ringer" / f"{date}.jsonl"
+            )
+            rows = [
+                json.loads(line)
+                for line in observation_path.read_text(encoding="utf-8").splitlines()
+            ]
+            self.assertEqual(1, len(rows))
+            self.assertEqual("PASS", rows[0]["verdict"])
+            self.assertEqual("mock/model", rows[0]["model"])
+            self.assertEqual(
+                ["keep-checks-executable", "inspect-first", "reverify-version"],
+                rows[0]["rules_injected"],
+            )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## What

Adds an optional **steering profiles** feature: point Ringer at a per-install steering directory and it will

- **Inject** worker-audience steering rules from the resolved model's profile into every worker prompt (attempt 1 and retry), deterministically, per a documented status contract (confirmed always; candidates behind `inject_candidates`; stale with a warning prefix; refuted never).
- **Surface** driver-audience rules (spec/feedback-writing guidance) to the orchestrator at run start.
- **Collect** one structured observation JSONL row per attempt under `<steering-dir>/observations/ringer/` — including `profile: null` rows when no profile matched, so rule-on/rule-off evidence accrues from normal work.

## Enable

```toml
[steering]
dir = "~/.ringer/steering"   # must contain profiles/; observations/ is auto-created
inject_candidates = true
```

Each install creates and owns its **own** steering directory — see `docs/STEERING.md` for the profile format v1 contract (statuses, audiences, `**Inject:**` payloads) and the observation schema.

## Safety

- **Entirely fail-open**: unset config, missing dir, malformed/empty profile, unwritable observations dir, or any exception in steering code never blocks or alters a run beyond the absence of injection. With `[steering]` unset, behavior is identical to main.
- Stdlib-only parser, no new dependencies.
- The four baked-in worker invariants are untouched.

## Verification

- 18 new tests (`tests/test_steering.py`): parser, resolution order, injection contract, fail-open paths, observation schema, retry re-injection, and a functional mock-engine test proving the worker receives the injected spec and an observation row lands.
- Full suite on this branch has a failure set identical to main (the 3 pre-existing design-reference/scoreboard failures); all 165 tests otherwise green.

Implemented by GPT-5.6 Sol via Ringer run `ringer-steering-profiles` (repo-feature manifest, executed checks); reviewed and integrated by Claude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)