### PR TITLE
Add per-engine spawn_stagger_s to serialize shared-state engine cold starts

### DIFF
--- a/config.sample.toml
+++ b/config.sample.toml
@@ -145,7 +145,10 @@ model_report_regex = "(?m)^model:[ \\t]*([^ \\t\\r\\n]+)[ \\t]*\\r?$"
 # ringer's simultaneous retries reproduce the collision. A minimum gap between
 # spawns of this engine lets each cold start claim the DB before the next
 # begins. Applies per attempt (retries stagger too); 0 disables. Engines
-# without shared state (codex) don't need it.
+# without shared state (codex) don't need it. Staggered workers still hold
+# max_parallel slots while they wait for their spawn slot, so a wide batch on a
+# staggered engine can starve other engines' workers during the stagger window —
+# size max_parallel or split the run accordingly.
 # Uncomment and set an absolute path for `bin` to enable.
 # [engines.opencode]
 # bin = "/absolute/path/to/ringer/engines/opencode-sandboxed.sh"

--- a/config.sample.toml
+++ b/config.sample.toml
@@ -138,10 +138,19 @@ model_report_regex = "(?m)^model:[ \\t]*([^ \\t\\r\\n]+)[ \\t]*\\r?$"
 # ~/.local/share/opencode/auth.json ({"openrouter": {"type": "api", "key": "..."}});
 # confirm the path with your installed CLI.
 # Per-task engine_args can set reasoning effort ("--variant", "low|high|max").
+# spawn_stagger_s: every OpenCode process shares one SQLite state DB
+# (~/.local/share/opencode/opencode.db), and parallel cold starts collide on
+# it — one worker wins the lock, the rest die in ~2s with "database is locked"
+# (or a generic "Unexpected server error") before spending a single token, and
+# ringer's simultaneous retries reproduce the collision. A minimum gap between
+# spawns of this engine lets each cold start claim the DB before the next
+# begins. Applies per attempt (retries stagger too); 0 disables. Engines
+# without shared state (codex) don't need it.
 # Uncomment and set an absolute path for `bin` to enable.
 # [engines.opencode]
 # bin = "/absolute/path/to/ringer/engines/opencode-sandboxed.sh"
 # model_default = "openrouter/z-ai/glm-5.2"
+# spawn_stagger_s = 2.0
 # args_template = [
 #   "{taskdir}",
 #   "{access_args}",

--- a/ringer.py
+++ b/ringer.py
@@ -6,6 +6,7 @@ import asyncio
 import base64
 import contextlib
 import json
+import math
 import mimetypes
 import os
 import re
@@ -625,6 +626,10 @@ def load_engines(raw: Any) -> dict[str, EngineConfig]:
                 f"engines.{clean_name}.spawn_stagger_s must be a number of seconds"
             )
         spawn_stagger_s = float(stagger_raw)
+        if not math.isfinite(spawn_stagger_s):
+            raise ValueError(
+                f"engines.{clean_name}.spawn_stagger_s must be a finite number of seconds"
+            )
         if spawn_stagger_s < 0:
             raise ValueError(
                 f"engines.{clean_name}.spawn_stagger_s must not be negative"
@@ -1091,6 +1096,7 @@ class WorkerResult:
     tokens: int | None
     error: str | None = None
     reported_model: str | None = None
+    spawn_wait_ms: int = 0
 
 
 @dataclass(frozen=True)
@@ -7532,7 +7538,11 @@ class RingerRunner:
                     runtime.last_check_returncode = verify.check_returncode
                     runtime.last_check_timed_out = verify.check_timed_out
                     runtime.last_check_output = verify.raw_output_excerpt
-                duration_ms = int((time.monotonic() - attempt_started) * 1000)
+                duration_ms = max(
+                    0,
+                    int((time.monotonic() - attempt_started) * 1000)
+                    - worker.spawn_wait_ms,
+                )
                 self._log_attempt(runtime, current_spec, retrying, worker, verify, verdict, duration_ms)
                 if verdict == "PASS":
                     self._harvest_deliverables_on_pass(runtime)
@@ -7722,14 +7732,6 @@ class RingerRunner:
                     "but config allow_full_access is false"
                 ),
             )
-        waited = await self.spawn_gate.wait_turn(engine.name, engine.spawn_stagger_s)
-        if waited > 0:
-            with contextlib.suppress(Exception):
-                append_text(
-                    log_path,
-                    f"[ringer.py] spawn stagger: waited {waited:.1f}s "
-                    f"(engines.{engine.name}.spawn_stagger_s = {engine.spawn_stagger_s:g})\n",
-                )
         cmd = build_worker_command(
             engine,
             taskdir=runtime.taskdir,
@@ -7784,6 +7786,15 @@ class RingerRunner:
                 append_text(log_path, steering_line)
         with self.lock:
             runtime.last_worker_command = list(cmd)
+        waited = await self.spawn_gate.wait_turn(engine.name, engine.spawn_stagger_s)
+        spawn_wait_ms = int(waited * 1000)
+        if waited > 0:
+            with contextlib.suppress(Exception):
+                append_text(
+                    log_path,
+                    f"[ringer.py] spawn stagger: waited {waited:.1f}s "
+                    f"(engines.{engine.name}.spawn_stagger_s = {engine.spawn_stagger_s:g})\n",
+                )
         append_text(
             log_path,
             "\n"
@@ -7795,7 +7806,13 @@ class RingerRunner:
         try:
             log_fh = log_path.open("ab")
         except OSError as exc:
-            return WorkerResult(returncode=None, timed_out=False, tokens=None, error=str(exc))
+            return WorkerResult(
+                returncode=None,
+                timed_out=False,
+                tokens=None,
+                error=str(exc),
+                spawn_wait_ms=spawn_wait_ms,
+            )
         async with AsyncFileCloser(log_fh):
             try:
                 proc = await asyncio.create_subprocess_exec(
@@ -7810,7 +7827,13 @@ class RingerRunner:
                 message = f"[ringer.py] worker spawn failed: {exc}\n"
                 log_fh.write(message.encode("utf-8", errors="replace"))
                 log_fh.flush()
-                return WorkerResult(returncode=None, timed_out=False, tokens=None, error=str(exc))
+                return WorkerResult(
+                    returncode=None,
+                    timed_out=False,
+                    tokens=None,
+                    error=str(exc),
+                    spawn_wait_ms=spawn_wait_ms,
+                )
             with self.lock:
                 runtime.worker_pid = proc.pid
             self.active_processes[proc.pid] = proc
@@ -7844,6 +7867,7 @@ class RingerRunner:
             timed_out=timed_out,
             tokens=tokens,
             reported_model=reported_model,
+            spawn_wait_ms=spawn_wait_ms,
         )
 
     async def _tee_stream(
@@ -7930,6 +7954,7 @@ class RingerRunner:
                 "verify_method": VERIFY_METHOD,
                 "verdict": verdict,
                 "duration_ms": duration_ms,
+                "spawn_wait_ms": worker.spawn_wait_ms,
                 "worker_tokens": worker.tokens,
                 "notes": "\n".join(notes_parts),
                 "orchestrator": self.identity,

--- a/ringer.py
+++ b/ringer.py
@@ -40,6 +40,7 @@ from html import escape as html_escape
 from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
+from collections.abc import Awaitable, Callable
 from typing import Any, Iterable
 
 
@@ -118,6 +119,14 @@ class EngineConfig:
     # its own "model" — this is what makes a harness engine (OpenCode) model
     # agnostic instead of hard-coding one model into the command line.
     model_default: str = ""
+    # Minimum seconds between consecutive worker spawns of THIS engine.
+    # Engines whose instances share local state (OpenCode: one SQLite state
+    # DB for every process) fail their cold start when several workers launch
+    # in the same instant — one wins the lock, the rest die in seconds with
+    # "database is locked" before spending a single token, and simultaneous
+    # retries reproduce the collision. 0 (the default) preserves the current
+    # spawn-all-at-once behavior.
+    spawn_stagger_s: float = 0.0
 
     @property
     def process_name(self) -> str:
@@ -608,6 +617,18 @@ def load_engines(raw: Any) -> dict[str, EngineConfig]:
         model_default = str(
             section.get("model_default", base.model_default if base else "")
         ).strip()
+        stagger_raw = section.get(
+            "spawn_stagger_s", base.spawn_stagger_s if base else 0.0
+        )
+        if isinstance(stagger_raw, bool) or not isinstance(stagger_raw, (int, float)):
+            raise ValueError(
+                f"engines.{clean_name}.spawn_stagger_s must be a number of seconds"
+            )
+        spawn_stagger_s = float(stagger_raw)
+        if spawn_stagger_s < 0:
+            raise ValueError(
+                f"engines.{clean_name}.spawn_stagger_s must not be negative"
+            )
         engines[clean_name] = EngineConfig(
             name=clean_name,
             bin=bin_path,
@@ -617,6 +638,7 @@ def load_engines(raw: Any) -> dict[str, EngineConfig]:
             token_regex=token_regex,
             model_report_regex=model_report_regex,
             model_default=model_default,
+            spawn_stagger_s=spawn_stagger_s,
         )
     return engines
 
@@ -7354,6 +7376,40 @@ class Verifier:
         return proc.returncode, timed_out, output
 
 
+class SpawnGate:
+    """Spaces worker spawns of the same engine at least stagger_s apart.
+
+    Slot reservation: each caller claims the next free slot for its engine and
+    sleeps until then, so concurrent waiters spawn stagger_s apart in claim
+    order instead of colliding on shared engine state. Engines with
+    spawn_stagger_s = 0 pass through untouched. The bookkeeping between
+    reading and writing _next_free has no await points, so it is atomic on
+    the event loop — keep it that way.
+
+    now/sleep are injectable for deterministic tests.
+    """
+
+    def __init__(
+        self,
+        now: Callable[[], float] = time.monotonic,
+        sleep: Callable[[float], Awaitable[None]] = asyncio.sleep,
+    ) -> None:
+        self._now = now
+        self._sleep = sleep
+        self._next_free: dict[str, float] = {}
+
+    async def wait_turn(self, engine_name: str, stagger_s: float) -> float:
+        if stagger_s <= 0:
+            return 0.0
+        now = self._now()
+        slot = max(now, self._next_free.get(engine_name, now))
+        self._next_free[engine_name] = slot + stagger_s
+        wait = slot - now
+        if wait > 0:
+            await self._sleep(wait)
+        return wait
+
+
 class RingerRunner:
     def __init__(
         self,
@@ -7396,6 +7452,7 @@ class RingerRunner:
         self.logger = EvalLogger(config.eval)
         self.verifier = Verifier()
         self.semaphore = asyncio.Semaphore(manifest.max_parallel)
+        self.spawn_gate = SpawnGate()
         self.active_processes: dict[int, asyncio.subprocess.Process] = {}
 
     async def run(self) -> int:
@@ -7665,6 +7722,14 @@ class RingerRunner:
                     "but config allow_full_access is false"
                 ),
             )
+        waited = await self.spawn_gate.wait_turn(engine.name, engine.spawn_stagger_s)
+        if waited > 0:
+            with contextlib.suppress(Exception):
+                append_text(
+                    log_path,
+                    f"[ringer.py] spawn stagger: waited {waited:.1f}s "
+                    f"(engines.{engine.name}.spawn_stagger_s = {engine.spawn_stagger_s:g})\n",
+                )
         cmd = build_worker_command(
             engine,
             taskdir=runtime.taskdir,

--- a/tests/test_spawn_stagger.py
+++ b/tests/test_spawn_stagger.py
@@ -63,6 +63,14 @@ class SpawnStaggerConfigTests(unittest.TestCase):
         with self.assertRaises(ValueError):
             load_engines({"opencode": engine_section(spawn_stagger_s=-1)})
 
+    def test_inf_rejected(self) -> None:
+        with self.assertRaisesRegex(ValueError, "finite"):
+            load_engines({"opencode": engine_section(spawn_stagger_s=float("inf"))})
+
+    def test_nan_rejected(self) -> None:
+        with self.assertRaisesRegex(ValueError, "finite"):
+            load_engines({"opencode": engine_section(spawn_stagger_s=float("nan"))})
+
     def test_string_rejected(self) -> None:
         with self.assertRaises(ValueError):
             load_engines({"opencode": engine_section(spawn_stagger_s="2")})
@@ -264,6 +272,18 @@ class SpawnStaggerEndToEndTests(unittest.TestCase):
             for earlier, later in zip(spawn_times, spawn_times[1:]):
                 gap_s = (later - earlier).total_seconds()
                 self.assertGreaterEqual(gap_s, stagger_s * 0.75, spawn_times)
+
+            rows = [
+                json.loads(line)
+                for line in (root / "runs.jsonl").read_text(encoding="utf-8").splitlines()
+            ]
+            self.assertEqual(3, len(rows))
+            self.assertEqual(1, sum(row["spawn_wait_ms"] == 0 for row in rows))
+            self.assertEqual(2, sum(row["spawn_wait_ms"] >= 450 for row in rows))
+            # The third task waits about 1200 ms; if that leaked into
+            # duration_ms, this bound fails loudly, while a fast mock attempt
+            # stays far under it.
+            self.assertTrue(all(row["duration_ms"] < 1080 for row in rows), rows)
 
 
 if __name__ == "__main__":

--- a/tests/test_spawn_stagger.py
+++ b/tests/test_spawn_stagger.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python3
+"""Per-engine spawn stagger: config parsing, SpawnGate slot math, end-to-end spacing.
+
+Engines whose instances share local state (OpenCode: one SQLite state DB per
+machine) fail their cold start when several workers spawn in the same instant.
+spawn_stagger_s spaces spawns of the same engine apart; 0 preserves the old
+spawn-all-at-once behavior.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+import unittest
+from datetime import datetime
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from ringer import SpawnGate, load_engines  # noqa: E402
+
+
+def toml_string(value: object) -> str:
+    return json.dumps(str(value))
+
+
+def engine_section(**overrides: object) -> dict[str, object]:
+    section: dict[str, object] = {
+        "bin": "worker-bin",
+        "args_template": ["{spec}"],
+        "sandbox_args": [],
+        "full_access_args": [],
+    }
+    section.update(overrides)
+    return section
+
+
+class SpawnStaggerConfigTests(unittest.TestCase):
+    def test_defaults_to_zero(self) -> None:
+        engines = load_engines({"opencode": engine_section()})
+        self.assertEqual(0.0, engines["opencode"].spawn_stagger_s)
+
+    def test_builtin_codex_defaults_to_zero(self) -> None:
+        engines = load_engines(None)
+        self.assertEqual(0.0, engines["codex"].spawn_stagger_s)
+
+    def test_parses_float_and_int(self) -> None:
+        engines = load_engines(
+            {
+                "opencode": engine_section(spawn_stagger_s=2.5),
+                "other": engine_section(spawn_stagger_s=3),
+            }
+        )
+        self.assertEqual(2.5, engines["opencode"].spawn_stagger_s)
+        self.assertEqual(3.0, engines["other"].spawn_stagger_s)
+
+    def test_negative_rejected(self) -> None:
+        with self.assertRaises(ValueError):
+            load_engines({"opencode": engine_section(spawn_stagger_s=-1)})
+
+    def test_string_rejected(self) -> None:
+        with self.assertRaises(ValueError):
+            load_engines({"opencode": engine_section(spawn_stagger_s="2")})
+
+    def test_bool_rejected(self) -> None:
+        with self.assertRaises(ValueError):
+            load_engines({"opencode": engine_section(spawn_stagger_s=True)})
+
+
+class SpawnGateTests(unittest.TestCase):
+    def make_gate(self, clock: dict[str, float], sleeps: list[float]) -> SpawnGate:
+        async def fake_sleep(seconds: float) -> None:
+            sleeps.append(seconds)
+            clock["t"] += seconds
+
+        return SpawnGate(now=lambda: clock["t"], sleep=fake_sleep)
+
+    def test_zero_stagger_never_sleeps(self) -> None:
+        clock = {"t": 100.0}
+        sleeps: list[float] = []
+        gate = self.make_gate(clock, sleeps)
+        waited = asyncio.run(gate.wait_turn("opencode", 0.0))
+        self.assertEqual(0.0, waited)
+        self.assertEqual([], sleeps)
+
+    def test_concurrent_claims_space_out(self) -> None:
+        clock = {"t": 100.0}
+        sleeps: list[float] = []
+        gate = self.make_gate(clock, sleeps)
+        spawn_times: list[float] = []
+
+        async def claim() -> None:
+            await gate.wait_turn("opencode", 2.0)
+            spawn_times.append(clock["t"])
+
+        async def claim_three() -> None:
+            # Fire all claims in one loop pass, the way asyncio.gather fires
+            # every _run_task at once. The contract is the spawn TIMES: each
+            # exactly one stagger after the previous, regardless of when the
+            # individual waits were computed.
+            await asyncio.gather(claim(), claim(), claim())
+
+        asyncio.run(claim_three())
+        self.assertEqual([100.0, 102.0, 104.0], sorted(spawn_times))
+
+    def test_engines_do_not_block_each_other(self) -> None:
+        clock = {"t": 100.0}
+        sleeps: list[float] = []
+        gate = self.make_gate(clock, sleeps)
+
+        async def claim_pairs() -> tuple[float, float]:
+            await gate.wait_turn("opencode", 2.0)
+            return await gate.wait_turn("codex", 2.0), await gate.wait_turn(
+                "opencode", 2.0
+            )
+
+        codex_wait, opencode_wait = asyncio.run(claim_pairs())
+        self.assertEqual(0.0, codex_wait)
+        self.assertGreater(opencode_wait, 0.0)
+
+    def test_no_wait_once_gap_has_elapsed(self) -> None:
+        clock = {"t": 100.0}
+        sleeps: list[float] = []
+        gate = self.make_gate(clock, sleeps)
+
+        async def claim_then_wait_out_the_gap() -> float:
+            await gate.wait_turn("opencode", 2.0)
+            clock["t"] += 10.0
+            return await gate.wait_turn("opencode", 2.0)
+
+        self.assertEqual(0.0, asyncio.run(claim_then_wait_out_the_gap()))
+
+
+class SpawnStaggerEndToEndTests(unittest.TestCase):
+    def test_parallel_mock_workers_spawn_spaced_apart(self) -> None:
+        stagger_s = 0.6
+        with tempfile.TemporaryDirectory() as temp_root:
+            root = Path(temp_root)
+            home = root / "home"
+            ringer_home = root / "ringer-home"
+            state_dir = root / "state"
+            workdir = root / "work"
+            config_path = root / "config.toml"
+            manifest_path = root / "manifest.json"
+
+            home.mkdir()
+            ringer_home.mkdir()
+
+            config_path.write_text(
+                "\n".join(
+                    [
+                        f"state_dir = {toml_string(state_dir)}",
+                        "",
+                        "[eval]",
+                        'backend = "jsonl"',
+                        f"jsonl_path = {toml_string(root / 'runs.jsonl')}",
+                        "",
+                        "[artifact]",
+                        "enabled = false",
+                        "",
+                        "[engines.mock]",
+                        f"bin = {toml_string(sys.executable)}",
+                        "args_template = [",
+                        f"  {toml_string(ROOT / 'engines' / 'mock_worker.py')},",
+                        '  "{spec}",',
+                        "]",
+                        "sandbox_args = []",
+                        "full_access_args = []",
+                        f"spawn_stagger_s = {stagger_s}",
+                        "",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            def mock_task(index: int) -> dict[str, object]:
+                return {
+                    "key": f"stagger-task-{index}",
+                    "engine": "mock",
+                    "spec": (
+                        "You are the deterministic mock worker. Write only the "
+                        "file described in this MOCK_FILE block so the executed "
+                        "check can verify the spawn-stagger path.\n"
+                        f"MOCK_FILE: out-{index}.txt\n"
+                        f"stagger {index}\n"
+                        "MOCK_END"
+                    ),
+                    "check": (
+                        f"grep -q stagger out-{index}.txt || "
+                        f"{{ echo FAIL: out-{index}.txt missing marker; exit 1; }}"
+                    ),
+                    "expect_files": [f"out-{index}.txt"],
+                }
+
+            manifest_path.write_text(
+                json.dumps(
+                    {
+                        "run_name": "spawn-stagger-test",
+                        "workdir": str(workdir),
+                        "max_parallel": 3,
+                        "worktrees": False,
+                        "tasks": [mock_task(index) for index in range(1, 4)],
+                    },
+                    indent=2,
+                ),
+                encoding="utf-8",
+            )
+
+            env = os.environ.copy()
+            env["HOME"] = str(home)
+            env["RINGER_HOME"] = str(ringer_home)
+            env["XDG_CONFIG_HOME"] = str(root / "xdg-config")
+
+            proc = subprocess.run(
+                [
+                    sys.executable,
+                    "ringer.py",
+                    "run",
+                    str(manifest_path),
+                    "--config",
+                    str(config_path),
+                    "--no-dashboard",
+                    "--identity",
+                    "stagger-test",
+                ],
+                cwd=ROOT,
+                env=env,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=False,
+                timeout=60,
+            )
+
+            combined_output = proc.stdout + proc.stderr
+            self.assertEqual(0, proc.returncode, combined_output)
+
+            spawn_times: list[datetime] = []
+            stagger_lines = 0
+            for index in range(1, 4):
+                log_text = (
+                    workdir / f"stagger-task-{index}" / "worker.log"
+                ).read_text(encoding="utf-8")
+                match = re.search(
+                    r"^\[ringer\.py\] attempt 1 started (\S+)$",
+                    log_text,
+                    flags=re.MULTILINE,
+                )
+                self.assertIsNotNone(match, log_text)
+                spawn_times.append(datetime.fromisoformat(match.group(1)))
+                stagger_lines += len(
+                    re.findall(r"spawn stagger: waited [0-9.]+s", log_text)
+                )
+
+            # Three simultaneous claims: the first spawns immediately, the
+            # other two wait one and two stagger slots.
+            self.assertEqual(2, stagger_lines)
+            spawn_times.sort()
+            for earlier, later in zip(spawn_times, spawn_times[1:]):
+                gap_s = (later - earlier).total_seconds()
+                self.assertGreaterEqual(gap_s, stagger_s * 0.75, spawn_times)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Problem

Engines whose instances share local state fail their cold start when several workers spawn in the same instant. OpenCode is the motivating case: every process opens one SQLite state DB (`~/.local/share/opencode/opencode.db`), so a 4-wide spawn wave has exactly one winner — the rest die in ~2s with `database is locked` (or a generic "Unexpected server error") before spending a single token. Ringer then retries all losers simultaneously, which reproduces the collision: one more winner, and the remaining tasks burn both attempts on harness failures that pollute the model scoreboard with FAIL rows the model never earned.

Observed in the field (2026-07-12, four-model bakeoff): two spawn waves, exactly one survivor each; the two twice-dead tasks passed first-try when rerun serially.

## Change

`engines.<name>.spawn_stagger_s` (float seconds, default `0`) sets a minimum gap between consecutive spawns of that engine:

- A `SpawnGate` on the runner reserves spawn slots per engine in claim order — no barrier, workers of other engines are unaffected, and concurrent waiters sleep toward their own slots.
- Applies to **every attempt**, so retries stagger too (the second collision wave above was simultaneous retries).
- Logs `[ringer.py] spawn stagger: waited N.Ns` to the worker log whenever a spawn actually waited, so post-mortems can see the gate at work.
- Default `0` = spawn-all-at-once, zero behavior change for every existing config.
- Documented on the sample config's opencode block with the collision rationale.

## Validation

1. **Unit tests** (`tests/test_spawn_stagger.py`): config parsing (defaults, float/int, rejects negative/string/bool) and the gate's slot math via injectable clock/sleep — three simultaneous claims spawn at t+0/+2/+4, engines don't block each other, no wait once the gap has already elapsed.
2. **End-to-end** (same file): a real `ringer.py run` over three mock-engine tasks at `max_parallel 3` with `spawn_stagger_s = 0.6`, asserting spawn spacing from the `attempt 1 started` timestamps in the worker logs and exactly two stagger log lines.
3. **Live probe**: three OpenCode workers (GLM-5.2) fired at `max_parallel 3` with a 2s stagger — spawns at +0s/+2.002s/+4.001s, 3/3 first-try passes, zero lock errors. Same shape that lost 3 of 4 workers to the collision the same morning.

Full suite: 190 tests, failure set identical to the pre-change baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)