### PR TITLE
Linux docker worker lane + verify-swarm kit + 2026-07-12 run evidence

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,17 @@
+# Ringer worker container — Linux write-isolation for swarm runs.
+# The macOS builds get Seatbelt via engines/opencode-sandboxed.sh; on Linux the
+# container boundary is the sandbox: repo mounted read-only, writes confined to
+# the mounted ~/.ringer volume, HOME is a tmpfs that dies with the container.
+# Build:  docker build -t ringer-worker docker/
+# Run:    docker/run.sh run <manifest.json> --identity <who>
+FROM node:22-bookworm-slim
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends python3 ca-certificates curl git \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN npm install -g opencode-ai && opencode --version
+
+# Auth is env-var only (OPENROUTER_API_KEY passed at run time). No credentials
+# are baked into this image and none may be written to it.
+ENTRYPOINT ["python3", "ringer.py"]

--- a/docker/config.toml
+++ b/docker/config.toml
@@ -1,0 +1,44 @@
+# Ringer config for the docker worker container (mounted read-only at
+# ~/.config/ringer/config.toml inside the container by docker/run.sh).
+# Container-specific deltas from the host config: opencode is on PATH from the
+# image's global npm install, and only the opencode engine exists in-container
+# (codex/claude/grok are host installs — route those tasks outside docker).
+
+state_dir = "~/.ringer"
+dashboard_port_base = 8787
+allow_full_access = false
+
+[eval]
+backend = "jsonl"
+jsonl_path = "~/.ringer/runs.jsonl"
+
+# OpenCode + OpenRouter. No OS sandbox flags here: the container IS the
+# sandbox (read-only repo mount, writes confined to the ~/.ringer volume).
+# Auth: OPENROUTER_API_KEY env var only — no auth.json exists in-container.
+# Flag note: opencode 1.17.18 dropped --dangerously-skip-permissions; --auto
+# is the auto-approve flag. Reasoning effort via per-task engine_args
+# ("--variant", "low|high|max").
+[engines.opencode]
+bin = "opencode"
+model_default = "openrouter/z-ai/glm-5.2"
+args_template = [
+  "run",
+  "-m",
+  "{model}",
+  "--auto",
+  "--format",
+  "json",
+  "{engine_args}",
+  "--dir",
+  "{taskdir}",
+  "{spec}",
+]
+sandbox_args = []
+full_access_args = []
+token_regex = '"tokens":\{"total":([0-9]+)'
+
+[artifact]
+enabled = true
+out = "~/.ringer/artifacts/{run_id}.html"
+report_out = "~/.ringer/artifacts/{run_id}-report.html"
+index_out = "~/.ringer/artifacts/index.html"

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Run ringer.py inside the worker container (Linux write-isolation lane).
+#
+# What the container can touch:
+#   - this repo, mounted READ-ONLY at its real path
+#   - ~/.ringer, the ONE writable volume (state, workdirs, artifacts, logs) —
+#     mounted at the identical path so the host Ringside reads the same files
+#   - a tmpfs HOME for opencode scratch, gone when the container exits
+# Auth: OPENROUTER_API_KEY is passed through from the caller's environment
+# (loaded by zshrc from keep/.secrets); nothing credential-shaped is on disk.
+#
+# Usage: docker/run.sh run ~/.ringer/manifests/foo.json --identity <who> [...]
+#        (any ringer.py arguments work; manifest paths must live under ~/.ringer
+#         or the repo, since those are the only mounts)
+# Extra read-only mounts (e.g. a repo the workers must READ but never write):
+#   RINGER_MOUNTS_RO="/path/one /path/two" docker/run.sh run ...
+# Each path is mounted read-only at its identical in-container path.
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+IMAGE="${RINGER_IMAGE:-ringer-worker}"
+
+: "${OPENROUTER_API_KEY:?OPENROUTER_API_KEY not set — eval \"\$(manifest age decrypt ~/repos/scottidler/keep/.secrets/openrouter-api-key.age)\"}"
+
+mkdir -p "$HOME/.ringer"
+
+EXTRA_MOUNTS=()
+for p in ${RINGER_MOUNTS_RO:-}; do
+  EXTRA_MOUNTS+=(-v "$p:$p:ro")
+done
+
+# Config rides the read-only repo mount and is passed via --config; nothing is
+# bind-mounted under the tmpfs HOME (a bind there makes docker pre-create
+# root-owned parent dirs, which breaks opencode's own ~/.config/opencode mkdir).
+exec docker run --rm \
+  -e OPENROUTER_API_KEY \
+  -e HOME="$HOME" \
+  --user "$(id -u):$(id -g)" \
+  --tmpfs "$HOME:exec,uid=$(id -u),gid=$(id -g),size=512m" \
+  -v "$REPO_DIR:$REPO_DIR:ro" \
+  -v "$HOME/.ringer:$HOME/.ringer" \
+  "${EXTRA_MOUNTS[@]}" \
+  -w "$REPO_DIR" \
+  "$IMAGE" \
+  --config "$REPO_DIR/docker/config.toml" \
+  "$@"

--- a/docs/MODEL-NOTES.md
+++ b/docs/MODEL-NOTES.md
@@ -154,6 +154,16 @@ checks and raw logs support — no vibes, no worker self-reports.
   attempt 1, ~83k tokens. First real outing; promising for review work.
   (Ran through an ad-hoc copy of the opencode engine block — the per-task
   `model` field now makes that unnecessary.)
+- 2026-07-12 — code-review (gx design-doc adversarial panel, desk.lan docker
+  lane): PASS attempt 2, 117k tokens, 324s. Strongest concurrency instincts of
+  the 3-model panel — the proposal-dir lock/TOCTOU gap and the apply-idempotency
+  gap were its finds, both orchestrator-confirmed as real design input. All 3
+  panel models needed attempt 2 (opencode warm-up pattern again — budget for it).
+- 2026-07-12 — verify (gx verify swarm, 4 tasks): 3 clean verdicts incl. killing
+  the canary, but 1 silent no-op FAIL: attempt 2 exited rc=0 with ~35 output
+  tokens and no report.md after 5.4k reasoning tokens. Same failure shape as
+  GPT-5.5's persona-review no-writes — reasoned, then never used the write tool.
+  Watch for it on small single-file-deliverable tasks.
 
 ## kimi-k2.6 (`moonshotai/kimi-k2.6`, subject-model evidence via OpenRouter)
 
@@ -311,3 +321,28 @@ checks and raw logs support — no vibes, no worker self-reports.
 
 ## opencode / z-ai glm-5.2 (via openrouter)
 - 2026-07-09 (aicred-invoice-downloads, 4 code-fix tasks + 1 follow-up, worktrees+npm ci checks): systematic attempt-1 NO-OP — all 4 parallel workers produced zero edits and no summary on first attempt, then completed cleanly on attempt 2 after retry-prompt injection (34k-69k tokens each). Follow-up single task passed attempt 1. Suspect first-invocation session warm-up in opencode-sandboxed under parallel spawn; budget for 2 attempts on parallel GLM batches. Output quality on Next.js/Stripe route+test work: solid, spec-faithful, one boss-caught design gap (used user-scoped supabase client where RLS demanded service role — spec didn't say explicitly; say it explicitly).
+- 2026-07-12 (probe, glm-lane-probe, first run on desk.lan Linux via new docker worker container): PASS attempt 1, 8.5k tokens, 45s, ~$0.004. Clean tool use (bash + read-back + file write), honest transcript separating assumptions from observed facts. The scoreboard's 2 probe FAIL rows from the same day are HARNESS errors, not GLM: docker bind-mounted a config under the tmpfs HOME, so docker pre-created a root-owned ~/.config and opencode died on mkdir EACCES before the model ever saw the task. Fixed in docker/run.sh (config now rides the read-only repo mount via --config). Discount those two rows when routing.
+- 2026-07-12 (code-review, gx design-doc adversarial panel): PASS attempt 2, 80k tokens, 529s. Most findings and sharpest citations of the panel BUT one flatly false claim: asserted src/undo.rs state_label lacked a Proposed match arm and "would not compile" (medium confidence) — the arm exists; the tree builds. GLM review output needs per-finding verification before acting; never auto-apply its P0/P1s. Good at doc-vs-code drift detection otherwise (blast-radius-skip find was real and confirmed).
+
+## deepseek-v4-pro via opencode (`openrouter/deepseek/deepseek-v4-pro`)
+
+- 2026-07-12 — code-review (gx design-doc adversarial panel, desk.lan docker
+  lane): PASS attempt 2, 188k tokens (panel's highest), 809s (slowest, needed
+  its retry after a thin attempt 1). Fewest findings (4) but deepest state-machine
+  tracing: the mark_proposed/update_overall_status stuck-InProgress gap was its
+  find, orchestrator-confirmed line by line. Also the only reviewer to catch the
+  missing Config.mcp field vs deny_unknown_fields interaction. High signal, low
+  noise; slow — give it the long-timeout lanes.
+- 2026-07-12 — verify (gx verify swarm, 4 tasks): 3 clean verdicts (incl. killing
+  the canary) but 1 double TIMEOUT at 1200s on the one finding that required
+  tracing lock usage across files. Slowest model in both rounds; verify tasks for
+  deepseek need timeout_s >= 1800, or route its slots to faster models when the
+  finding spans multiple subsystems.
+
+## qwen3-coder-next via opencode (`openrouter/qwen/qwen3-coder-next`)
+
+- 2026-07-12 — verify (gx verify swarm, first audition, 3 tasks): 3/3 checks
+  passed (2 first-try), verdicts agreed with the partner refuter on both
+  unanimous findings and took the defensible side of the one split. Cheap
+  ($0.11/$0.80 per M) and fast. Promising for the verify lane; needs volume
+  for promotion per the --explore ladder.

--- a/templates/README.md
+++ b/templates/README.md
@@ -21,6 +21,7 @@ A kit is a reusable Ringer starter: a manifest skeleton, check skeletons, and a 
 | `competitive-teardown` | Runs N scouts by competitor with verbatim-citation allowlist checks and a synthesis phase. | You need grounded competitor analysis with traceable source material. | Blueprint |
 | `data-pipeline` | Splits fetch, transform, and validate stages with executed validators and honesty rules. | You need a data workflow that proves each stage produced what it claims. | Blueprint |
 | `probe` | Provides a one-task manifest for smokes, probes, and post-mortems. | You need a visible, logged check before trusting a new engine, model, harness, or diagnosis. | Proven as a practice |
+| `verify-swarm` | Sends each finder-swarm finding to N hostile refuters (never the finding's author) and collects CONFIRMED/REFUTED verdicts with inspected evidence. | You need findings cross-examined before the orchestrator spends tokens adjudicating them. | Proven in a recorded run, 2026-07-12 (killed a seeded known-false canary) |
 
 ## Kit Anatomy
 

--- a/templates/verify-swarm/README.md
+++ b/templates/verify-swarm/README.md
@@ -1,0 +1,59 @@
+Blueprint — adapt with care
+
+# Verify Swarm
+
+## What it is
+
+A hostile-verification round that runs AFTER any finder swarm (adversarial-review, review-swarm): each finding goes to N cheap refuters whose only job is to disprove it by direct inspection of the sources. The orchestrator adjudicates only the survivors and the splits, so the expensive model reads verdicts instead of re-deriving every finding from scratch.
+
+The premise: a well-formed finding is not a true finding. Format checks catch lazy reports; only re-inspection catches fabricated ones. Minions do not trust minions.
+
+## When to use
+
+Use it between a finder swarm and the orchestrator's synthesis whenever findings will drive real work (doc changes, fix swarms, merge decisions). Use it especially when a finder model is new or has a fabrication history — the verify round is what makes a cheap, unproven finder usable at all.
+
+Skip it when the orchestrator is going to read every cited line anyway (tiny finding sets), or when findings are matters of judgment rather than checkable claims (persona feedback, style review).
+
+## Fill in
+
+| Placeholder | What goes there |
+|---|---|
+| `{{RUN_SLUG}}` | SAME run_name as the finder round — one job, one artifact, rounds accumulate. |
+| `{{WORKDIR}}` | Scratch run directory for this round, outside any repo under review. |
+| `{{FINDING_ID}}` | Stable id for the finding (f1, f2, ...). |
+| `{{FINDING_TEXT}}` | The finding VERBATIM as its author claimed it — citations, priorities, and all. Refuters test the claim, not your paraphrase. |
+| `{{REFUTER_MODEL}}` | Model slug for this refuter. NEVER the model that produced the finding. |
+| `{{SUBJECT_PATHS}}` | Read-only paths (doc, repo) every refuter inspects. |
+| `{{KIT_DIR}}` | Absolute path to `templates/verify-swarm` after copying or installing this kit. |
+
+## Checks
+
+`checks/check_verdict.py` requires a Verdict line that says exactly CONFIRMED or REFUTED (and not both), an Evidence section with at least one concrete file citation, and a Reasoning section. It fails reports that claim the verifier edited anything. It prints which requirement broke.
+
+The check validates the verdict CONTRACT; it cannot validate the verdict's truth. That is the orchestrator's adjudication seat, now narrowed to survivors and splits.
+
+## Adjudication rule (orchestrator side)
+
+- All refuters REFUTE -> finding dies; record why in the synthesis.
+- All refuters CONFIRM -> finding survives; orchestrator spot-checks at least one.
+- Split -> orchestrator reads the disagreement and decides; splits are the round's yield, spend your tokens there.
+
+## Canary rule
+
+When proving a NEW refuter panel, seed one known-false finding (a real fabrication from a past run beats an invented one) without marking it. A verify round that confirms the canary is a broken round: tighten the refuter spec or swap models before trusting any of its verdicts. A verify swarm that cannot kill a known-false finding is trusting the finders with extra steps.
+
+## Mix with
+
+Run after `adversarial-review` or `review-swarm`, before synthesis. Survivor findings feed `fix-swarm` or doc updates. Verify slots are good exploration lanes: refutation of one finding is small, checkable work — audition untested cheap models here.
+
+## Gotchas
+
+Never let a model refute its own finding; with co-authored (deduped) findings, exclude every co-author.
+
+Give refuters the finding verbatim. A paraphrase that fixes the author's overclaim makes the canary unkillable and the round worthless.
+
+Two refuters is the efficient default: unanimous kill, unanimous survive, or a split for the orchestrator. Three only when a finding gates something irreversible.
+
+Refuters inherit the finder round's read-only mounts. If the finder could read it, the refuter must be able to read it, or "could not locate evidence" produces false REFUTED verdicts.
+
+Pin the subject to a commit. A verify round judges truth-NOW, not truth-at-finding: if the code or doc moves between rounds (including fixes prompted by the findings themselves, or the findings being folded into the doc), refuters correctly refute findings that were true when found, and REFUTED stops meaning "fabricated" (2026-07-12 gx lesson: 5 commits landed between rounds; most REFUTED verdicts decoded as "already fixed", and one finding was refuted by citing the finder round's own addendum). Stamp the finder round's HEAD SHA into every finding and tell refuters to either judge at that SHA (worktree mount) or report "refuted because fixed since <sha>" as its own verdict category.

--- a/templates/verify-swarm/checks/check_verdict.py
+++ b/templates/verify-swarm/checks/check_verdict.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Validate one hostile-verifier verdict report (verify-swarm kit)."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--file", required=True, help="path to the verdict report")
+    args = parser.parse_args()
+
+    path = Path(args.file)
+    if not path.is_file():
+        print(f"FAIL: missing report: {path}")
+        return 1
+    if path.stat().st_size == 0:
+        print(f"FAIL: empty report: {path}")
+        return 1
+
+    text = path.read_text(encoding="utf-8", errors="replace")
+    lowered = text.lower()
+    failures: list[str] = []
+
+    # Verdict lines only — quoting CONFIRMED/REFUTED elsewhere is fine.
+    verdict_hits = re.findall(
+        r"(?im)^\s*(?:#+\s*)?verdict\s*:?\s*.*?\b(confirmed|refuted)\b", text
+    )
+    if not verdict_hits:
+        failures.append("no Verdict line containing CONFIRMED or REFUTED")
+    elif len({v.lower() for v in verdict_hits}) > 1:
+        failures.append("contradictory Verdict lines: both CONFIRMED and REFUTED present")
+
+    if "evidence" not in lowered:
+        failures.append("no Evidence section")
+
+    if not re.search(r"[\w./-]+\.(?:rs|py|md|toml|json|sh|yml|yaml)(?::\d+)?", text):
+        failures.append("no concrete file citation (path.ext or path.ext:line) anywhere in report")
+
+    if "reasoning" not in lowered:
+        failures.append("no Reasoning section")
+
+    if re.search(r"(?i)\bi\s+(edited|modified|patched|fixed|rewrote)\b", text):
+        failures.append("report claims the verifier modified files; verifiers are read-only")
+
+    if failures:
+        for failure in failures:
+            print(f"FAIL: {failure}")
+        return 1
+
+    print("OK: verdict report structurally valid")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/templates/verify-swarm/manifest.json
+++ b/templates/verify-swarm/manifest.json
@@ -1,0 +1,20 @@
+{
+  "run_name": "{{RUN_SLUG}}",
+  "workdir": "{{WORKDIR}}",
+  "max_parallel": 4,
+  "tasks": [
+    {
+      "key": "verify-{{FINDING_ID}}-{{REFUTER_LABEL}}",
+      "engine": "opencode",
+      "model": "{{REFUTER_MODEL}}",
+      "task_type": "verify",
+      "timeout_s": 1200,
+      "expect_files": [
+        "report.md"
+      ],
+      "spec": "You are a hostile verification worker in a verify swarm. Another AI reviewer produced the finding below. Your only job is to try to REFUTE it by direct inspection of the actual sources. You are read-only; you own only ./report.md in your current working directory; never modify the repo, the doc, or anything else.\n\nSUBJECT (read-only): {{SUBJECT_PATHS}}\n\nFINDING {{FINDING_ID}} (verbatim, as its author claimed it):\n<<<\n{{FINDING_TEXT}}\n>>>\n\nHOW TO VERIFY: open every file and line the finding cites and read the surrounding code yourself. Test each load-bearing claim independently: does the cited code exist, does it do what the finding says, and does the claimed consequence actually follow. A finding that cites lines that do not exist, misquotes code, or claims a consequence the code prevents is refuted.\n\nOUTPUT CONTRACT: write ./report.md with three sections. ## Verdict: exactly one line, 'Verdict: CONFIRMED' if every load-bearing claim held up under your own inspection, or 'Verdict: REFUTED' if any load-bearing claim failed. ## Evidence: the file:line citations YOU inspected, each with a short verbatim quote of what is actually there. ## Reasoning: which claims you tested and what you found.\n\nHARD RULES: confirm or refute only from what you actually read, never from plausibility. If you cannot locate the finding's cited evidence, the verdict is REFUTED and that failure IS your evidence. A partially-true finding whose core claim fails is REFUTED (note any salvageable part in Reasoning). No 'partially confirmed': pick one verdict. Do not edit any file.",
+      "check": "python3 '{{KIT_DIR}}/checks/check_verdict.py' --file report.md",
+      "verified": "the report contains a single CONFIRMED or REFUTED verdict backed by file:line evidence the verifier itself inspected."
+    }
+  ]
+}


### PR DESCRIPTION
## What this is

Three pieces from a real day of runs on a Linux box (desk.lan), each proven against actual swarms before landing here.

## Linux docker worker lane (`docker/`)

`engines/opencode-sandboxed.sh` is macOS Seatbelt only; the README tells Linux installs to keep manifests scoped and hope. This closes that gap: the container is the sandbox.

- repo mounted read-only at its real path; `~/.ringer` is the ONE writable volume, mounted at the identical path so the host Ringside streams the run live
- tmpfs HOME: worker scratch dies with the container
- `RINGER_MOUNTS_RO` for read-only subject repos (review targets)
- auth is env-var only (`OPENROUTER_API_KEY` passed at run time): no credential file in the image, the container, or this repo
- flag note: opencode 1.17.18 dropped `--dangerously-skip-permissions`; the lane uses `--auto`

Proven: GLM-5.2 probe (PASS attempt 1), then a 3-model review swarm and a 16-task verify swarm through the same lane.

## verify-swarm kit (`templates/verify-swarm/`)

A well-formed finding is not a true finding. The executed check catches lazy reports; only re-inspection catches fabricated ones (a reviewer in our run produced a structurally perfect finding claiming code does not compile: the cited match arm exists). This kit sends each finder finding VERBATIM to N hostile refuters (never the finding's author), who must CONFIRM or REFUTE from files they read themselves. The orchestrator adjudicates only survivors and splits.

Proven 2026-07-12: 8 findings x 2 refuters over a real design doc, including a seeded known-false canary that both refuters killed with correct evidence. Gotchas encode the day's lessons, the big one being pin-the-SHA: a verify round judges truth-now, not truth-at-finding (5 commits landed between our rounds and most REFUTED verdicts decoded as already-fixed).

## MODEL-NOTES batch

Run evidence per the post-run ritual: GLM (probe pass, harness-error discount, the fabrication flag), Kimi (review pass + a silent no-op fail shape on verify), DeepSeek (high signal, needs timeout_s >= 1800 on cross-file work), and qwen3-coder-next's first audition (3/3 verify checks).

All three commits are independent; happy to split or drop any piece if it does not fit the repo's direction.
