### PR TITLE
Circuit-break an engine after its first spawn failure

### DIFF
--- a/ringer.py
+++ b/ringer.py
@@ -7485,6 +7485,17 @@ class RingerRunner:
                         runtime.ended_at_monotonic = time.monotonic()
                     await self._cleanup_worktree_on_pass(runtime)
                     return
+                if verdict == "INFRA":
+                    # A retry cannot install a missing binary — skip it and
+                    # tell the operator exactly what to fix.
+                    with contextlib.suppress(Exception):
+                        append_text(
+                            runtime.log_path,
+                            "[ringer.py] engine spawn failure "
+                            f"(rc={worker.returncode}, no tokens): the worker "
+                            "binary never ran. Not retrying — fix the engine "
+                            "'bin'/PATH in the ringer config and re-run.\n",
+                        )
                 if attempt < max_attempts and verdict in {"FAIL", "TIMEOUT"}:
                     failure_context = build_failure_context(runtime.log_path, verify.raw_output_excerpt)
                     current_spec = (
@@ -7812,6 +7823,19 @@ class RingerRunner:
         verdict: str,
         duration_ms: int,
     ) -> None:
+        if worker_never_ran(worker):
+            # No model was invoked, so there is no model evidence to log.
+            # The task record (run JSON) still carries the full attempt state;
+            # only the per-model scoreboard is protected here.
+            with contextlib.suppress(Exception):
+                append_text(
+                    runtime.log_path,
+                    "[ringer.py] no model evidence for this attempt "
+                    f"(rc={worker.returncode}, tokens={worker.tokens}, "
+                    f"error={worker.error or 'none'}) — the worker never ran, "
+                    "so no model-log row is written.\n",
+                )
+            return
         engine = self.config.engines.get(runtime.task.engine)
         resolved_model = resolved_task_model(
             runtime.task,
@@ -7992,9 +8016,32 @@ class AsyncFileCloser:
         self.fh.close()
 
 
+def worker_never_ran(worker: WorkerResult) -> bool:
+    """True when no model evidence exists for this attempt.
+
+    Two signatures, both meaning the model was never invoked: the engine
+    process failed before exec (error set, no exit code, no timeout), or the
+    engine command/wrapper exited with the shell's command-not-found (127) /
+    not-executable (126) codes without emitting any token usage. Attempts like
+    these are infrastructure evidence, not model evidence — they must not
+    reach the per-model log, where a `verdict != PASS` row silently drags the
+    model's pass rate down for a failure it had no part in.
+    """
+    if worker.tokens:
+        return False
+    if worker.error is not None and worker.returncode is None and not worker.timed_out:
+        return True
+    return worker.returncode in (126, 127)
+
+
 def verdict_for(worker: WorkerResult, verify: VerifyResult) -> str:
     if worker.error:
         return "ERROR"
+    if worker_never_ran(worker):
+        # Deliberately checked before verify.ok: even if a check passes (for
+        # example against artifacts left by an earlier run), a PASS must not
+        # be credited to a model that never ran.
+        return "INFRA"
     if worker.timed_out or verify.check_timed_out:
         return "TIMEOUT"
     if verify.ok:
@@ -8614,6 +8661,14 @@ def print_summary(run_id: str, runtimes: list[TaskRuntime]) -> None:
             f"{runtime.task.key:<24} {runtime.status:<8} "
             f"{(runtime.final_verdict or ''):<8} {runtime.attempts:>8} "
             f"{tokens:>10} {runtime.elapsed_s(now):>10.1f}"
+        )
+    infra = [r for r in runtimes if r.final_verdict == "INFRA"]
+    if infra:
+        print(
+            f"\n{len(infra)} task(s) hit engine spawn failures (INFRA): the "
+            "worker binary never ran, so no model-log rows were written and "
+            "no retries were spent. Check the engine 'bin' and PATH in your "
+            "ringer config, then re-run."
         )
 
 

--- a/ringer.py
+++ b/ringer.py
@@ -7397,6 +7397,14 @@ class RingerRunner:
         self.verifier = Verifier()
         self.semaphore = asyncio.Semaphore(manifest.max_parallel)
         self.active_processes: dict[int, asyncio.subprocess.Process] = {}
+        # Engines that already produced a spawn failure this run. A missing
+        # binary fails identically for every task, so after the first INFRA
+        # verdict the remaining tasks on that engine are failed without
+        # spawning — one broken engine should cost one attempt, not
+        # tasks × attempts. (The startup preflight can't catch every case:
+        # wrapper-script engines resolve fine and then exit 127 when the
+        # binary INSIDE the wrapper is missing.)
+        self.infra_failed_engines: set[str] = set()
 
     async def run(self) -> int:
         self.manifest.workdir.mkdir(parents=True, exist_ok=True)
@@ -7451,6 +7459,24 @@ class RingerRunner:
         async with self.semaphore:
             with self.lock:
                 runtime.started_at_monotonic = time.monotonic()
+                engine_broken = runtime.task.engine in self.infra_failed_engines
+            if engine_broken:
+                # The engine already failed to spawn this run; every further
+                # task on it is doomed the same way. Fail fast, spawn nothing,
+                # log no model row (there is no model evidence).
+                with self.lock:
+                    runtime.status = "fail"
+                    runtime.final_verdict = "INFRA"
+                    runtime.ended_at_monotonic = time.monotonic()
+                with contextlib.suppress(Exception):
+                    append_text(
+                        runtime.log_path,
+                        f"[ringer.py] engine '{runtime.task.engine}' already "
+                        "hit a spawn failure this run — not spawning this "
+                        "task. Fix the engine 'bin'/PATH in the ringer "
+                        "config and re-run.\n",
+                    )
+                return
             prepared, prepare_error = await self._prepare_taskdir(runtime)
             if not prepared:
                 await self._record_prepare_error(runtime, prepare_error or "taskdir preparation failed")
@@ -7486,8 +7512,12 @@ class RingerRunner:
                     await self._cleanup_worktree_on_pass(runtime)
                     return
                 if verdict == "INFRA":
-                    # A retry cannot install a missing binary — skip it and
-                    # tell the operator exactly what to fix.
+                    # A retry cannot install a missing binary — skip it, trip
+                    # the per-engine circuit breaker so queued tasks on this
+                    # engine fail fast instead of spawning, and tell the
+                    # operator exactly what to fix.
+                    with self.lock:
+                        self.infra_failed_engines.add(runtime.task.engine)
                     with contextlib.suppress(Exception):
                         append_text(
                             runtime.log_path,

--- a/tests/test_infra_circuit_breaker.py
+++ b/tests/test_infra_circuit_breaker.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""One broken engine should cost one attempt, not tasks x attempts.
+
+The startup preflight (preflight_engine_bins) cannot catch every spawn
+failure: wrapper-script engines resolve and execute fine, then exit 127
+because the binary INSIDE the wrapper is missing. Observed in the field
+(2026-07-14): a 16-task run burned 32 doomed spawns that way before
+summarizing.
+
+This pins the circuit breaker: after the first INFRA verdict on an engine,
+the remaining tasks on that engine fail fast — verdict INFRA, zero attempts,
+no worker spawned, no model-log rows, and a worker-log breadcrumb naming the
+fix.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def toml_string(value: object) -> str:
+    return json.dumps(str(value))
+
+
+class InfraCircuitBreakerTests(unittest.TestCase):
+    def test_first_spawn_failure_trips_breaker_for_remaining_tasks(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_root:
+            root = Path(temp_root)
+            home = root / "home"
+            ringer_home = root / "ringer-home"
+            state_dir = root / "state"
+            workdir = root / "work"
+            config_path = root / "config.toml"
+            manifest_path = root / "manifest.json"
+            model_log = root / "runs.jsonl"
+
+            home.mkdir()
+            ringer_home.mkdir()
+
+            # A wrapper that exists and is executable (so the startup
+            # preflight passes) but whose inner binary is "missing" — the
+            # exact field failure shape.
+            config_path.write_text(
+                "\n".join(
+                    [
+                        f"state_dir = {toml_string(state_dir)}",
+                        "",
+                        "[eval]",
+                        'backend = "jsonl"',
+                        f"jsonl_path = {toml_string(model_log)}",
+                        "",
+                        "[artifact]",
+                        "enabled = false",
+                        "",
+                        "[engines.broken]",
+                        'bin = "/bin/sh"',
+                        "args_template = [",
+                        '  "-c",',
+                        '  "echo wrapper: engine not found on PATH; exit 127",',
+                        '  "wrapper",',
+                        '  "{spec}",',
+                        "]",
+                        "sandbox_args = []",
+                        "full_access_args = []",
+                        "",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            def task(key: str) -> dict[str, object]:
+                return {
+                    "key": key,
+                    "engine": "broken",
+                    "spec": (
+                        f"Task {key}: the engine wrapper exits 127 before any "
+                        "model is invoked; this spec exists so the manifest "
+                        "is well-formed."
+                    ),
+                    "check": (
+                        "test -f never-created.txt || "
+                        "{ echo FAIL: worker never ran; exit 1; }"
+                    ),
+                    "expect_files": ["never-created.txt"],
+                }
+
+            manifest_path.write_text(
+                json.dumps(
+                    {
+                        "run_name": "circuit-breaker-test",
+                        "workdir": str(workdir),
+                        # Serialized so the breaker deterministically trips
+                        # before the queued tasks reach the semaphore.
+                        "max_parallel": 1,
+                        "worktrees": False,
+                        "tasks": [task("spawn-1"), task("spawn-2"), task("spawn-3")],
+                    },
+                    indent=2,
+                ),
+                encoding="utf-8",
+            )
+
+            env = os.environ.copy()
+            env["HOME"] = str(home)
+            env["RINGER_HOME"] = str(ringer_home)
+            env["XDG_CONFIG_HOME"] = str(root / "xdg-config")
+
+            proc = subprocess.run(
+                [
+                    sys.executable,
+                    "ringer.py",
+                    "run",
+                    str(manifest_path),
+                    "--config",
+                    str(config_path),
+                    "--no-dashboard",
+                    "--identity",
+                    "circuit-breaker-test",
+                ],
+                cwd=ROOT,
+                env=env,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=False,
+                timeout=30,
+            )
+
+            combined_output = proc.stdout + proc.stderr
+
+            # The first task spawned once and was classified INFRA.
+            self.assertRegex(
+                combined_output,
+                re.compile(r"^spawn-1\s+fail\s+INFRA\s+1\s+", re.MULTILINE),
+                combined_output,
+            )
+            # The queued tasks never spawned at all: zero attempts.
+            for key in ("spawn-2", "spawn-3"):
+                self.assertRegex(
+                    combined_output,
+                    re.compile(rf"^{key}\s+fail\s+INFRA\s+0\s+", re.MULTILINE),
+                    combined_output,
+                )
+
+            # No model-log rows for any of them.
+            if model_log.exists():
+                rows = [
+                    json.loads(line)
+                    for line in model_log.read_text(encoding="utf-8").splitlines()
+                    if line.strip()
+                ]
+                self.assertEqual([], rows, rows)
+
+            # The first task's log names the spawn failure; the skipped tasks'
+            # logs name the breaker and the fix.
+            first_log = (workdir / "spawn-1" / "worker.log").read_text(
+                encoding="utf-8"
+            )
+            self.assertIn("engine spawn failure", first_log)
+            for key in ("spawn-2", "spawn-3"):
+                skipped_log = (workdir / key / "worker.log").read_text(
+                    encoding="utf-8"
+                )
+                self.assertIn("already hit a spawn failure this run", skipped_log)
+                self.assertNotIn("attempt 1 exited", skipped_log)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_infra_spawn_failures.py
+++ b/tests/test_infra_spawn_failures.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""Engine spawn failures are infrastructure evidence, not model evidence.
+
+Observed in the field (2026-07-14): an engine wrapper script exited 127
+("command not found") on every task because the underlying binary was not on
+ringer's PATH. Each attempt wrote a FAIL row to the per-model log — 36 rows —
+silently dragging an innocent model's pass rate from 1.00 to 0.40, and every
+task burned its retry on a failure a retry cannot fix.
+
+These tests pin the fix:
+  * verdict is INFRA, not FAIL, when the worker never ran
+  * no model-log row is written for such attempts
+  * the retry is skipped (attempts == 1)
+  * the run summary names the failure class and the fix
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from ringer import (  # noqa: E402
+    VerifyResult,
+    WorkerResult,
+    verdict_for,
+    worker_never_ran,
+)
+
+
+def toml_string(value: object) -> str:
+    return json.dumps(str(value))
+
+
+FAILING_VERIFY = VerifyResult(
+    ok=False, check_returncode=1, check_timed_out=False, raw_output_excerpt=""
+)
+PASSING_VERIFY = VerifyResult(
+    ok=True, check_returncode=0, check_timed_out=False, raw_output_excerpt=""
+)
+
+
+class WorkerNeverRanTests(unittest.TestCase):
+    def test_command_not_found_without_tokens_is_infra(self) -> None:
+        worker = WorkerResult(returncode=127, timed_out=False, tokens=None)
+        self.assertTrue(worker_never_ran(worker))
+        self.assertEqual("INFRA", verdict_for(worker, FAILING_VERIFY))
+
+    def test_not_executable_without_tokens_is_infra(self) -> None:
+        worker = WorkerResult(returncode=126, timed_out=False, tokens=None)
+        self.assertTrue(worker_never_ran(worker))
+        self.assertEqual("INFRA", verdict_for(worker, FAILING_VERIFY))
+
+    def test_infra_wins_over_a_passing_check(self) -> None:
+        # A check may pass against artifacts left by an earlier run; a model
+        # that never ran must not be credited with that PASS.
+        worker = WorkerResult(returncode=127, timed_out=False, tokens=None)
+        self.assertEqual("INFRA", verdict_for(worker, PASSING_VERIFY))
+
+    def test_exit_127_with_token_usage_is_model_evidence(self) -> None:
+        # If the engine reported token usage, a model ran — a late 127 from a
+        # wrapper's cleanup must still count as a model FAIL, not INFRA.
+        worker = WorkerResult(returncode=127, timed_out=False, tokens=512)
+        self.assertFalse(worker_never_ran(worker))
+        self.assertEqual("FAIL", verdict_for(worker, FAILING_VERIFY))
+
+    def test_ordinary_failure_without_tokens_is_not_infra(self) -> None:
+        # Plenty of engines crash with rc=1 and no parseable token line; that
+        # is still model evidence and must keep reaching the log.
+        worker = WorkerResult(returncode=1, timed_out=False, tokens=None)
+        self.assertFalse(worker_never_ran(worker))
+        self.assertEqual("FAIL", verdict_for(worker, FAILING_VERIFY))
+
+    def test_spawn_exception_before_exec_never_ran(self) -> None:
+        worker = WorkerResult(
+            returncode=None, timed_out=False, tokens=None, error="spawn failed"
+        )
+        self.assertTrue(worker_never_ran(worker))
+        # verdict stays ERROR (the error branch wins); the shared
+        # worker_never_ran gate is what keeps it out of the model log.
+        self.assertEqual("ERROR", verdict_for(worker, FAILING_VERIFY))
+
+    def test_timeout_is_model_evidence(self) -> None:
+        worker = WorkerResult(returncode=None, timed_out=True, tokens=None)
+        self.assertFalse(worker_never_ran(worker))
+        self.assertEqual("TIMEOUT", verdict_for(worker, FAILING_VERIFY))
+
+
+class SpawnFailureEndToEndTests(unittest.TestCase):
+    def test_spawn_failure_skips_model_log_and_retry(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_root:
+            root = Path(temp_root)
+            home = root / "home"
+            ringer_home = root / "ringer-home"
+            state_dir = root / "state"
+            workdir = root / "work"
+            config_path = root / "config.toml"
+            manifest_path = root / "manifest.json"
+            model_log = root / "runs.jsonl"
+
+            home.mkdir()
+            ringer_home.mkdir()
+
+            # The engine is a wrapper that cannot find its real binary — the
+            # exact shape of the field failure (opencode-sandboxed.sh: 127).
+            config_path.write_text(
+                "\n".join(
+                    [
+                        f"state_dir = {toml_string(state_dir)}",
+                        "",
+                        "[eval]",
+                        'backend = "jsonl"',
+                        f"jsonl_path = {toml_string(model_log)}",
+                        "",
+                        "[artifact]",
+                        "enabled = false",
+                        "",
+                        "[engines.broken]",
+                        'bin = "/bin/sh"',
+                        "args_template = [",
+                        '  "-c",',
+                        '  "echo wrapper: engine not found on PATH; exit 127",',
+                        '  "wrapper",',
+                        '  "{spec}",',
+                        "]",
+                        "sandbox_args = []",
+                        "full_access_args = []",
+                        "",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            manifest_path.write_text(
+                json.dumps(
+                    {
+                        "run_name": "spawn-failure-test",
+                        "workdir": str(workdir),
+                        "max_parallel": 1,
+                        "worktrees": False,
+                        "tasks": [
+                            {
+                                "key": "spawn-task",
+                                "engine": "broken",
+                                "spec": (
+                                    "You will never run: the engine wrapper exits 127 "
+                                    "before any model is invoked. This spec exists so "
+                                    "the manifest is well-formed."
+                                ),
+                                "check": (
+                                    "test -f never-created.txt || "
+                                    "{ echo FAIL: worker never ran; exit 1; }"
+                                ),
+                                "expect_files": ["never-created.txt"],
+                            }
+                        ],
+                    },
+                    indent=2,
+                ),
+                encoding="utf-8",
+            )
+
+            env = os.environ.copy()
+            env["HOME"] = str(home)
+            env["RINGER_HOME"] = str(ringer_home)
+            env["XDG_CONFIG_HOME"] = str(root / "xdg-config")
+
+            proc = subprocess.run(
+                [
+                    sys.executable,
+                    "ringer.py",
+                    "run",
+                    str(manifest_path),
+                    "--config",
+                    str(config_path),
+                    "--no-dashboard",
+                    "--identity",
+                    "spawn-failure-test",
+                ],
+                cwd=ROOT,
+                env=env,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=False,
+                timeout=30,
+            )
+
+            combined_output = proc.stdout + proc.stderr
+
+            # Verdict INFRA, exactly one attempt — the retry was not spent.
+            self.assertRegex(
+                combined_output,
+                re.compile(r"^spawn-task\s+fail\s+INFRA\s+1\s+", re.MULTILINE),
+                combined_output,
+            )
+
+            # The summary names the failure class and points at the fix.
+            self.assertIn("engine spawn failures (INFRA)", combined_output)
+
+            # No model-log row was written for an attempt with no model.
+            if model_log.exists():
+                rows = [
+                    json.loads(line)
+                    for line in model_log.read_text(encoding="utf-8").splitlines()
+                    if line.strip()
+                ]
+                offending = [r for r in rows if r.get("task_key") == "spawn-task"]
+                self.assertEqual([], offending, rows)
+
+            # The worker log says why nothing was logged and why no retry ran.
+            worker_log = (workdir / "spawn-task" / "worker.log").read_text(
+                encoding="utf-8"
+            )
+            self.assertIn("no model evidence for this attempt", worker_log)
+            self.assertIn("Not retrying", worker_log)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
**Stacked on #35** — review the last commit only (`f18e906`); the first commit is #35's INFRA classification, which this builds on.

## Problem

`preflight_engine_bins` cannot catch every spawn failure by construction: wrapper-script engines (e.g. `engines/opencode-sandboxed.sh`) resolve and execute fine, then exit 127 because the binary *inside* the wrapper is missing. In the field (2026-07-14), a 16-task run burned **32 doomed spawns** — every task, both attempts — before the summary printed.

## Fix

A missing binary fails identically for every task on that engine, so the first INFRA verdict trips a per-engine circuit breaker:

- remaining tasks on that engine **fail fast**: verdict `INFRA`, **zero attempts**, no worker spawned, no taskdir prepared, no model-log row
- each skipped task's worker log gets a breadcrumb naming the engine and the fix (`bin`/PATH in config)
- #35's summary hint counts breaker-skipped tasks automatically

One broken engine costs one attempt, not tasks × attempts. Engines unaffected by the failure keep running normally — the breaker is per-engine, taken under the runner lock.

## Test

End-to-end (`tests/test_infra_circuit_breaker.py`): three tasks on a wrapper engine that exits 127, `max_parallel: 1` for determinism. Asserts `spawn-1 fail INFRA 1`, `spawn-2/3 fail INFRA 0` with breaker breadcrumbs and no `attempt 1 exited` line in their logs, and an empty model log. Full suite: no new failures (the pre-existing `test_design_reference`/`test_scoreboard_page` failures on main reproduce with this change stashed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)