### PR TITLE
feat(config): per-engine allow_full_access override (claude engine unblock)

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Each task gets its own directory, its own worker, its own log, and its own verdi
 | `timeout_s` | Per-task kill timer (default 900) |
 | `engine_args` | Extra CLI flags for this task's worker, spliced in at the engine's `{engine_args}` placeholder — e.g. `["-c", "model_reasoning_effort=low"]` so the orchestrator picks reasoning depth per task |
 | `verified` | One plain-English sentence saying what the check proves — shown on the results page next to "finished & checked" |
-| `full_access` | Worker runs unsandboxed — required for workers that spawn their own sub-workers; must also be enabled in config |
+| `full_access` | Worker runs unsandboxed — required for workers that spawn their own sub-workers; also requires `allow_full_access = true` globally in config, or `allow_full_access = true` on this task's specific `[engines.<name>]` block (see [Full access is scoped, not just gated](#full-access-is-scoped-not-just-gated)) |
 | `worktrees` (run-level) | Give each task an isolated git worktree of `repo` so parallel workers can't collide |
 
 > **Worktree footgun:** on PASS the task's worktree is removed — including anything written inside it. In worktrees mode, worker logs live outside task worktrees in `workdir/logs/`; have workers write deliverables outside the worktree too, or have your `check` copy artifacts out before it exits 0.
@@ -193,6 +193,33 @@ grok login
 ```
 
 Route with per-task `"engine": "grok"` and pick the model with `"model": "grok-build"` or `"model": "grok-composer-2.5-fast"` (the shipped default — the speed pick). Grok brings its own OS sandbox on macOS (profile `workspace`: read everywhere, writes confined to the task dir, temp, and `~/.grok`), and its JSON output exposes no token counts — plan-billed workers report cost as included in plan.
+
+### Full access is scoped, not just gated
+
+The top-level `allow_full_access = false` in config is a belt-and-suspenders switch: even a task with `"full_access": true` still refuses to run unsandboxed unless this is flipped on. That's the right default when every engine in your config brings real OS-level write confinement.
+
+It stops being the right shape once one engine in the config *can't* be sandboxed at all. Claude Code is the example that forced this: it has no OS sandbox of its own, and macOS Seatbelt (`sandbox-exec`) does not reliably confine its own Bash-tool/Write-tool file writes even under a profile that correctly confines a plain `/bin/sh` (verified 2026-07-15 against Claude Code 2.1.210 — reproduced twice with a direct `sandbox-exec` invocation of the `claude` binary, bypassing any wrapper script). So a `claude` engine's `sandbox_args` has to be empty, and every real `claude` task has to request `full_access`. Flipping the global `allow_full_access` on to unblock claude would also unblock full access for every *other* engine sharing that config — codex and grok don't need that exposure just because claude does.
+
+`allow_full_access` can also be set inside an individual `[engines.<name>]` block. A task's `full_access: true` request is permitted if **either** the global switch is on **or** that task's specific engine has opted in — the global staying `false` still locks out every engine that hasn't explicitly opted in, exactly as before this existed:
+
+```toml
+# Global gate stays at its safe default — codex, grok, and any other engine
+# without their own override stay locked out of full_access.
+allow_full_access = false
+
+[engines.claude]
+bin = "/absolute/path/to/engines/claude-sandboxed.sh"
+# Claude Code has no real OS-level write confinement on this machine (see
+# above) — every claude task must run full_access, so this engine opts
+# itself in rather than requiring the global switch. Keep claude tasks
+# scoped to scratch dirs, not live repos, until Seatbelt containment is
+# re-verified against a newer Claude Code build.
+allow_full_access = true
+sandbox_args = []
+full_access_args = ["--full-access-ack"]
+```
+
+`ringer.py dry_run` (the default before a real run) prints `allowed=True`/`allowed=False` per task using this same resolution, so what you see in the preview is exactly what `_run_worker` will do.
 
 ## Ringside — mission control
 

--- a/config.sample.toml
+++ b/config.sample.toml
@@ -19,7 +19,11 @@ dashboard_port_base = 8787
 # hud_app_path = "/Applications/Ringside.app"
 
 # Belt-and-suspenders full-access gate. A task with "full_access": true will
-# still fail unless this is true.
+# still fail unless this is true — OR unless its specific engine sets its own
+# allow_full_access = true in its [engines.<name>] block below (see the
+# [engines.claude] example). The global switch staying false still locks out
+# every engine that does NOT set its own override, exactly as if per-engine
+# overrides didn't exist — this is additive scoping, not a relaxed default.
 allow_full_access = false
 
 # Optional model steering. The directory must contain profiles/ with one
@@ -115,6 +119,54 @@ model_report_regex = "(?m)^model:[ \\t]*([^ \\t\\r\\n]+)[ \\t]*\\r?$"
 # CLIs report cost as "included in plan"; regex is a harmless no-match. Its JSON
 # also does not self-report a model, so no model_report_regex is configured.
 # token_regex = "\"total_tokens\"\\s*:\\s*([0-9]+)"
+
+# Claude Code CLI (headless `claude -p`), OAuth harness. Claude Code has no OS
+# sandbox of its own, and macOS Seatbelt (sandbox-exec) does NOT reliably
+# confine its own Bash-tool/Write-tool file writes on this machine — verified
+# 2026-07-15 against Claude Code 2.1.210, reproduced twice with a direct
+# sandbox-exec invocation of the `claude` binary (bypassing any wrapper),
+# while the identical profile correctly confines a plain /bin/sh. So
+# sandbox_args is deliberately empty and every real claude task must set
+# "full_access": true in its manifest. Rather than flipping the top-level
+# allow_full_access on (which would also unblock full access for every OTHER
+# engine sharing this config), this engine opts itself in with its own
+# allow_full_access = true — see "Full access is scoped, not just gated" in
+# README.md. `bin` should point at a wrapper script that refuses to run
+# without an explicit full-access flag rather than silently running
+# unconfined and calling it sandboxed (ringer's own invariant #2). Keep
+# claude tasks scoped to scratch dirs, not live repos, until Seatbelt
+# containment is re-verified against a newer Claude Code build.
+# Uncomment and set an absolute path for `bin` to enable.
+# [engines.claude]
+# bin = "/absolute/path/to/engines/claude-sandboxed.sh"
+# model_default = "sonnet"
+# allow_full_access = true
+# args_template = [
+#   "{taskdir}",
+#   "{access_args}",
+#   "-p",
+#   "{spec}",
+#   "--setting-sources",
+#   "",
+#   "--strict-mcp-config",
+#   "--no-session-persistence",
+#   "--tools",
+#   "Bash,Edit,Read,Write",
+#   "--permission-mode",
+#   "bypassPermissions",
+#   "--output-format",
+#   "text",
+#   "--model",
+#   "{model}",
+#   "{engine_args}",
+# ]
+# sandbox_args = []
+# full_access_args = ["--full-access-ack"]
+# --output-format text prints prose, no "tokens used: N" line — harmless
+# no-match, same as the plan-billed Grok block above. Switch a task to
+# ["--output-format", "json"] via engine_args and this would need a
+# JSON-aware regex against usage.output_tokens to extract anything.
+# token_regex = "tokens\\s+used\\s*:?\\s*([0-9][0-9,]*)"
 
 # For CI, acceptance evals, and trying Ringer without an API bill.
 # [engines.mock]

--- a/docs/MODEL-NOTES.md
+++ b/docs/MODEL-NOTES.md
@@ -311,3 +311,30 @@ checks and raw logs support — no vibes, no worker self-reports.
 
 ## opencode / z-ai glm-5.2 (via openrouter)
 - 2026-07-09 (aicred-invoice-downloads, 4 code-fix tasks + 1 follow-up, worktrees+npm ci checks): systematic attempt-1 NO-OP — all 4 parallel workers produced zero edits and no summary on first attempt, then completed cleanly on attempt 2 after retry-prompt injection (34k-69k tokens each). Follow-up single task passed attempt 1. Suspect first-invocation session warm-up in opencode-sandboxed under parallel spawn; budget for 2 attempts on parallel GLM batches. Output quality on Next.js/Stripe route+test work: solid, spec-faithful, one boss-caught design gap (used user-scoped supabase client where RLS demanded service role — spec didn't say explicitly; say it explicitly).
+
+## claude — per-engine allow_full_access scoping (2026-07-15, task #43)
+- Task #43 asked, before touching ringer.py, to first check whether the whole
+  problem evaporates on a newer Claude Code build (i.e. whether Seatbelt
+  containment now holds and claude no longer needs full_access at all).
+  Checked `claude --version` (2.1.210) against npm's published latest
+  (`npm view @anthropic-ai/claude-code version` → 2.1.210) — already on
+  latest, and it's the exact build the 2026-07-15 containment finding above
+  was verified against, same day. No newer build exists to re-test against,
+  so the containment re-test was NOT re-run — re-running it would just
+  reproduce the same result on the same binary. If a newer Claude Code build
+  ships later, re-verify with the direct `sandbox-exec` reproduction
+  described above before assuming this is still needed.
+- Implemented the per-engine override anyway, per the task's own framing:
+  "it's still correct defense-in-depth" even if claude's containment gap
+  closes later. `EngineConfig.allow_full_access` (default `False`) plus a
+  shared `full_access_permitted(config, engine)` resolver, checked at both
+  enforcement sites (`RingerRunner._run_worker` and the `dry_run` preview) —
+  see README.md "Full access is scoped, not just gated" and the
+  `[engines.claude]` example in `config.sample.toml`. Resolves the exact gap
+  flagged in the "claude" section above ("FULL_ACCESS IS A CONFIG-WIDE
+  GATE, NOT PER-ENGINE"): the global switch staying `false` still locks out
+  every engine without its own opt-in — this is additive scoping, not a
+  relaxed default. 19 new tests in `tests/test_full_access_scope.py` cover
+  config parsing, the resolver function directly, and both real
+  enforcement sites (denied/allowed/no-leak-to-other-engines/global-on
+  back-compat).

--- a/ringer.py
+++ b/ringer.py
@@ -118,6 +118,12 @@ class EngineConfig:
     # its own "model" — this is what makes a harness engine (OpenCode) model
     # agnostic instead of hard-coding one model into the command line.
     model_default: str = ""
+    # Per-engine override of the global allow_full_access switch. A task's
+    # full_access=true request is permitted iff the global config.allow_full_access
+    # is true OR this engine's allow_full_access is true — see full_access_permitted().
+    # Defaults to False: an engine gets no full-access override unless its config
+    # section (or a built-in default for that engine name) opts in explicitly.
+    allow_full_access: bool = False
 
     @property
     def process_name(self) -> str:
@@ -608,6 +614,11 @@ def load_engines(raw: Any) -> dict[str, EngineConfig]:
         model_default = str(
             section.get("model_default", base.model_default if base else "")
         ).strip()
+        engine_allow_full_access = bool(
+            section.get(
+                "allow_full_access", base.allow_full_access if base else False
+            )
+        )
         engines[clean_name] = EngineConfig(
             name=clean_name,
             bin=bin_path,
@@ -617,6 +628,7 @@ def load_engines(raw: Any) -> dict[str, EngineConfig]:
             token_regex=token_regex,
             model_report_regex=model_report_regex,
             model_default=model_default,
+            allow_full_access=engine_allow_full_access,
         )
     return engines
 
@@ -7655,14 +7667,15 @@ class RingerRunner:
                 tokens=None,
                 error=f"unknown worker engine: {runtime.task.engine}",
             )
-        if runtime.task.full_access and not self.config.allow_full_access:
+        if runtime.task.full_access and not full_access_permitted(self.config, engine):
             return WorkerResult(
                 returncode=None,
                 timed_out=False,
                 tokens=None,
                 error=(
                     f"task requested full_access with engine {runtime.task.engine}, "
-                    "but config allow_full_access is false"
+                    "but config allow_full_access is false and "
+                    f"engines.{runtime.task.engine}.allow_full_access is not true"
                 ),
             )
         cmd = build_worker_command(
@@ -8137,6 +8150,21 @@ def resolved_task_model(
     )
 
 
+def full_access_permitted(config: AppConfig, engine: EngineConfig | None) -> bool:
+    """Whether a task's full_access=true request is allowed to proceed.
+
+    Permitted iff the global config.allow_full_access switch is true, OR the
+    task's specific engine has individually opted in via its own
+    allow_full_access=true. The global switch staying false must keep every
+    engine WITHOUT an explicit per-engine override locked out, exactly as
+    before this per-engine override existed — this is additive, not a relaxation
+    of the global default.
+    """
+    if config.allow_full_access:
+        return True
+    return bool(engine is not None and engine.allow_full_access)
+
+
 def build_worker_command(
     engine: EngineConfig,
     *,
@@ -8565,7 +8593,7 @@ def dry_run(
     for task in manifest.tasks:
         taskdir = (manifest.workdir / task.key).resolve()
         engine = config.engines.get(task.engine)
-        full_access_allowed = task.full_access and config.allow_full_access
+        full_access_allowed = task.full_access and full_access_permitted(config, engine)
         cmd = (
             build_worker_command(
                 engine,
@@ -8590,8 +8618,11 @@ def dry_run(
         print(f"    check: {task.check}")
         if engine is None:
             print("    command: ERROR unknown engine")
-        elif task.full_access and not config.allow_full_access:
-            print("    command: ERROR full_access requires allow_full_access=true in config")
+        elif task.full_access and not full_access_permitted(config, engine):
+            print(
+                "    command: ERROR full_access requires allow_full_access=true in "
+                f"config or engines.{task.engine}.allow_full_access=true"
+            )
         else:
             print(f"    command: {shell_command_for_display(cmd)} < /dev/null")
 

--- a/tests/test_full_access_scope.py
+++ b/tests/test_full_access_scope.py
@@ -1,0 +1,307 @@
+#!/usr/bin/env python3
+"""Per-engine allow_full_access override (task #43).
+
+Covers: config parsing of engines.<name>.allow_full_access, the
+full_access_permitted() decision function, and both real enforcement sites
+(RingerRunner._run_worker and the dry_run() preview) so the CLI-visible
+behavior and the actual spawn-gating behavior can't drift apart.
+"""
+from __future__ import annotations
+
+import contextlib
+import io
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+import ringer  # noqa: E402
+from ringer import (  # noqa: E402
+    AppConfig,
+    ArtifactConfig,
+    EngineConfig,
+    EvalConfig,
+    Manifest,
+    RingerRunner,
+    dry_run,
+    full_access_permitted,
+    load_engines,
+)
+
+
+def mock_engine(name: str = "mock", *, allow_full_access: bool = False) -> EngineConfig:
+    return EngineConfig(
+        name=name,
+        bin=sys.executable,
+        args_template=(str(ROOT / "engines" / "mock_worker.py"), "{spec}"),
+        full_access_args=(),
+        sandbox_args=(),
+        token_regex=None,
+        allow_full_access=allow_full_access,
+    )
+
+
+def make_config(root: Path, engines: dict[str, EngineConfig], *, allow_full_access: bool) -> AppConfig:
+    return AppConfig(
+        path=None,
+        identity_default=None,
+        state_dir=root / "state",
+        dashboard_port_base=8787,
+        hud_port=8700,
+        hud_app_path=None,
+        allow_full_access=allow_full_access,
+        eval=EvalConfig(backend="jsonl", jsonl_path=root / "eval.jsonl"),
+        engines=engines,
+        artifact=ArtifactConfig(
+            enabled=False,
+            out_template=str(root / "live.html"),
+            report_template=str(root / "report.html"),
+            index_out=root / "index.html",
+        ),
+    )
+
+
+class ConfigParsingTests(unittest.TestCase):
+    """engines.<name>.allow_full_access parses like every other per-engine field."""
+
+    def test_default_is_false_when_unset(self) -> None:
+        engines = load_engines(
+            {"harness": {"bin": "/usr/local/bin/harness", "args_template": ["{spec}"]}}
+        )
+        self.assertFalse(engines["harness"].allow_full_access)
+
+    def test_explicit_true_is_read(self) -> None:
+        engines = load_engines(
+            {
+                "claude": {
+                    "bin": "/usr/local/bin/claude-sandboxed.sh",
+                    "args_template": ["{taskdir}", "{access_args}", "{spec}"],
+                    "allow_full_access": True,
+                }
+            }
+        )
+        self.assertTrue(engines["claude"].allow_full_access)
+
+    def test_explicit_false_is_read(self) -> None:
+        engines = load_engines(
+            {"codex": {"bin": "/usr/local/bin/codex", "allow_full_access": False}}
+        )
+        self.assertFalse(engines["codex"].allow_full_access)
+
+    def test_built_in_codex_engine_defaults_to_false(self) -> None:
+        engines = load_engines(None)
+        self.assertFalse(engines["codex"].allow_full_access)
+
+    def test_only_the_configured_engine_is_affected(self) -> None:
+        engines = load_engines(
+            {
+                "claude": {
+                    "bin": "/usr/local/bin/claude-sandboxed.sh",
+                    "args_template": ["{taskdir}", "{access_args}", "{spec}"],
+                    "allow_full_access": True,
+                },
+                "grok": {
+                    "bin": "/usr/local/bin/grok",
+                    "args_template": ["{taskdir}", "{access_args}", "{spec}"],
+                },
+            }
+        )
+        self.assertTrue(engines["claude"].allow_full_access)
+        self.assertFalse(engines["grok"].allow_full_access)
+        self.assertFalse(engines["codex"].allow_full_access)  # untouched built-in default
+
+    def test_overriding_the_built_in_codex_engine_can_opt_it_in_too(self) -> None:
+        # "codex" is pre-seeded via built_in_codex_engine() before user config is
+        # applied (base is not None here), so this exercises the
+        # base.allow_full_access-fallback branch, not just the brand-new-engine path.
+        engines = load_engines(
+            {"codex": {"bin": "/usr/local/bin/codex", "allow_full_access": True}}
+        )
+        self.assertTrue(engines["codex"].allow_full_access)
+
+    def test_overriding_codex_bin_without_the_key_keeps_the_false_base_default(self) -> None:
+        engines = load_engines({"codex": {"bin": "/usr/local/bin/codex"}})
+        self.assertFalse(engines["codex"].allow_full_access)
+
+
+class FullAccessPermittedTests(unittest.TestCase):
+    """Unit tests for the decision function both enforcement sites call."""
+
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.root = Path(self.tmp.name)
+
+    def test_global_off_engine_off_denied(self) -> None:
+        engine = mock_engine(allow_full_access=False)
+        config = make_config(self.root, {"mock": engine}, allow_full_access=False)
+        self.assertFalse(full_access_permitted(config, engine))
+
+    def test_global_off_engine_on_allowed(self) -> None:
+        engine = mock_engine(allow_full_access=True)
+        config = make_config(self.root, {"mock": engine}, allow_full_access=False)
+        self.assertTrue(full_access_permitted(config, engine))
+
+    def test_global_off_engine_on_does_not_leak_to_a_different_engine(self) -> None:
+        claude = mock_engine("claude", allow_full_access=True)
+        codex = mock_engine("codex", allow_full_access=False)
+        config = make_config(
+            self.root, {"claude": claude, "codex": codex}, allow_full_access=False
+        )
+        self.assertTrue(full_access_permitted(config, claude))
+        self.assertFalse(full_access_permitted(config, codex))
+
+    def test_global_on_allowed_regardless_of_engine_back_compat(self) -> None:
+        engine = mock_engine(allow_full_access=False)
+        config = make_config(self.root, {"mock": engine}, allow_full_access=True)
+        self.assertTrue(full_access_permitted(config, engine))
+
+    def test_unknown_engine_is_denied_unless_global_is_on(self) -> None:
+        config = make_config(self.root, {}, allow_full_access=False)
+        self.assertFalse(full_access_permitted(config, None))
+        config_global_on = make_config(self.root, {}, allow_full_access=True)
+        self.assertTrue(full_access_permitted(config_global_on, None))
+
+
+class RingerRunnerEnforcementTests(unittest.IsolatedAsyncioTestCase):
+    """_run_worker is where a task actually gets spawned or blocked."""
+
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.root = Path(self.tmp.name)
+
+    def _runner(self, config: AppConfig, *, engine: str) -> RingerRunner:
+        manifest = Manifest.from_obj(
+            {
+                "run_name": "full-access-scope",
+                "workdir": str(self.root / "work"),
+                "tasks": [
+                    {
+                        "key": "task-a",
+                        "engine": engine,
+                        "spec": "MOCK_FILE: result.txt\nhello\nMOCK_END",
+                        "check": "true",
+                        "full_access": True,
+                    }
+                ],
+            }
+        )
+        runner = RingerRunner(manifest, config, "test", dashboard_enabled=False)
+        runner.runtimes[0].taskdir.mkdir(parents=True, exist_ok=True)
+        return runner
+
+    async def test_global_off_engine_off_task_is_denied(self) -> None:
+        engine = mock_engine(allow_full_access=False)
+        config = make_config(self.root, {"mock": engine}, allow_full_access=False)
+        runner = self._runner(config, engine="mock")
+        runtime = runner.runtimes[0]
+
+        result = await runner._run_worker(runtime, runtime.task.spec, 1)
+
+        self.assertIsNotNone(result.error)
+        assert result.error is not None
+        self.assertIn("allow_full_access is false", result.error)
+        self.assertFalse((runtime.taskdir / "result.txt").exists())
+
+    async def test_global_off_engine_on_task_runs(self) -> None:
+        engine = mock_engine(allow_full_access=True)
+        config = make_config(self.root, {"mock": engine}, allow_full_access=False)
+        runner = self._runner(config, engine="mock")
+        runtime = runner.runtimes[0]
+
+        result = await runner._run_worker(runtime, runtime.task.spec, 1)
+
+        self.assertIsNone(result.error)
+        self.assertEqual(0, result.returncode)
+        self.assertTrue((runtime.taskdir / "result.txt").exists())
+
+    async def test_global_off_engine_on_does_not_unblock_a_different_engine(self) -> None:
+        # The whole point of task #43: opting claude in must not also unblock
+        # codex/grok/whatever else shares the same config.
+        claude = mock_engine("claude", allow_full_access=True)
+        other = mock_engine("other", allow_full_access=False)
+        config = make_config(
+            self.root, {"claude": claude, "other": other}, allow_full_access=False
+        )
+        runner = self._runner(config, engine="other")
+        runtime = runner.runtimes[0]
+
+        result = await runner._run_worker(runtime, runtime.task.spec, 1)
+
+        self.assertIsNotNone(result.error)
+        assert result.error is not None
+        self.assertIn("allow_full_access is false", result.error)
+
+    async def test_global_on_task_runs_back_compat(self) -> None:
+        engine = mock_engine(allow_full_access=False)
+        config = make_config(self.root, {"mock": engine}, allow_full_access=True)
+        runner = self._runner(config, engine="mock")
+        runtime = runner.runtimes[0]
+
+        result = await runner._run_worker(runtime, runtime.task.spec, 1)
+
+        self.assertIsNone(result.error)
+        self.assertEqual(0, result.returncode)
+        self.assertTrue((runtime.taskdir / "result.txt").exists())
+
+
+class DryRunPreviewTests(unittest.TestCase):
+    """dry_run() is what a human reads before trusting the gate; it must agree
+    with what _run_worker will actually do."""
+
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.root = Path(self.tmp.name)
+
+    def _manifest(self, engine: str) -> Manifest:
+        return Manifest.from_obj(
+            {
+                "run_name": "dry-run-scope",
+                "workdir": str(self.root / "work"),
+                "tasks": [
+                    {
+                        "key": "task-a",
+                        "engine": engine,
+                        "spec": "hello",
+                        "check": "true",
+                        "full_access": True,
+                    }
+                ],
+            }
+        )
+
+    def _render(self, config: AppConfig, engine: str) -> str:
+        out = io.StringIO()
+        with contextlib.redirect_stdout(out):
+            dry_run(self._manifest(engine), config, "test", False, False)
+        return out.getvalue()
+
+    def test_global_off_engine_off_shows_denied(self) -> None:
+        engine = mock_engine(allow_full_access=False)
+        config = make_config(self.root, {"mock": engine}, allow_full_access=False)
+        output = self._render(config, "mock")
+        self.assertIn("full_access: true allowed=False", output)
+        self.assertIn("command: ERROR full_access requires", output)
+
+    def test_global_off_engine_on_shows_allowed(self) -> None:
+        engine = mock_engine(allow_full_access=True)
+        config = make_config(self.root, {"mock": engine}, allow_full_access=False)
+        output = self._render(config, "mock")
+        self.assertIn("full_access: true allowed=True", output)
+        self.assertNotIn("command: ERROR", output)
+
+    def test_global_on_shows_allowed(self) -> None:
+        engine = mock_engine(allow_full_access=False)
+        config = make_config(self.root, {"mock": engine}, allow_full_access=True)
+        output = self._render(config, "mock")
+        self.assertIn("full_access: true allowed=True", output)
+        self.assertNotIn("command: ERROR", output)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- The global `allow_full_access` switch was one flat boolean, so unblocking the `claude` engine (no OS sandbox of its own — Seatbelt does not confine its Bash/Write-tool writes on this machine, verified 2026-07-15 against Claude Code 2.1.210) meant disabling the safety check for **every** engine, not just claude.
- Adds `EngineConfig.allow_full_access` (default `False`) and a shared `full_access_permitted(config, engine)` resolver, checked at both real enforcement sites (`RingerRunner._run_worker` and the `dry_run` preview): a task's `full_access` request is now permitted iff the global switch is on **or** its specific engine has opted in. The global staying `False` still locks out every engine without its own override — this is additive scoping, not a relaxed default.
- Checked the "does this evaporate on a newer build" alternative first: `claude --version` (2.1.210) already matches npm's published latest, and that's the exact build the containment finding was verified against same-day — no re-test was run (documented in `docs/MODEL-NOTES.md`).
- Docs: README gets a new "Full access is scoped, not just gated" section + an updated manifest-fields row; `config.sample.toml` gets an inline explanation on the global gate plus a commented `[engines.claude]` example.

## Test plan
- [x] `python3 -m pytest tests/test_full_access_scope.py -v` — 19/19 new tests pass (config parsing, the resolver function directly, and both enforcement sites: denied / allowed / no-leak-to-other-engines / global-on back-compat)
- [x] `python3 -m pytest tests/ -q` — 196 passed, 3 pre-existing failures unrelated to this change (hardcoded `"Generated July 6, 2026"` date-string assertions in `test_design_reference.py`/`test_scoreboard_page.py`, confirmed failing identically on unmodified `main` via `git stash`)
- [x] `python3 ringer.py lint templates/review-swarm/manifest.json` → `lint: clean (1 tasks)`
- [x] `python3 -c "import ast; ast.parse(open('ringer.py').read())"` — syntax OK
- [x] `config.sample.toml` re-parses cleanly with `tomllib` after the new `[engines.claude]` block

## Config Jared should add to enable claude narrowly
Once this merges, `~/.config/ringer/config.toml`'s `[engines.claude]` block just needs one added line — the global `allow_full_access` can stay `false`:
```toml
[engines.claude]
allow_full_access = true
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)