### PR TITLE
Make Ringer and no-mistakes explicit opt-in modes

### DIFF
--- a/.claude/skills/ringer/SKILL.md
+++ b/.claude/skills/ringer/SKILL.md
@@ -21,7 +21,7 @@ description: >-
 
 # Ringer orchestrator playbook
 
-## Read this first — the four rules that actually get broken
+## Read this first: the five rules that actually get broken
 
 1. **You review; workers type.** Your lane: specs, checks, pattern choice,
    reading results. If you are typing implementation, running probes, or
@@ -47,13 +47,18 @@ description: >-
    your one-liner, not wondering if anything is happening. Never pass
    `--no-dashboard` except in automated tests or when the user explicitly
    asks.
+5. **Two strikes, then the human.**
+   When the same task or task family has failed two rounds, including a no-mistakes review round, a third identical attempt is forbidden.
+   Run `./ringer.py status`, then change the plan or escalate with the evidence.
+   Every stranded escalation from `status` must be resumed, re-planned, or reported before a new run starts.
 
 Ringer runs manifest tasks in parallel across cheap CLI workers (Codex,
 OpenCode/GLM, others via config) and verifies every task by **executing a
-check command** — exit 0 is the only PASS. Failed tasks are retried once
-with the check's actual failure output injected into the retry prompt. You —
-the orchestrating model — pay tokens only for specs, orchestration, and
-review.
+check command**; exit 0 is the only PASS.
+Eligible `FAIL` and `TIMEOUT` outcomes run once more with the check's actual failure output injected into the retry prompt.
+A `FAIL` whose worker exits nonzero in less than 10,000 ms by default is a launch-class failure and stops without an identical retry; worker spawn errors are also launch class.
+The threshold measures worker time only; `RINGER_LAUNCH_CLASS_THRESHOLD_MS` tunes it in integer milliseconds, values below `0` clamp to `0`, and non-integers use the default.
+You, the orchestrating model, pay tokens only for specs, orchestration, and review.
 
 ```bash
 ./ringer.py lint manifest.json            # always lint before running
@@ -195,21 +200,12 @@ the mix isn't working. This is per-user by design: the scoreboard learns
 THIS user's workload — never import another machine's conclusions or
 recommend from a different user's numbers.
 
-**Explore or the scoreboard fossilizes.** Always recommending the proven
-pick means never learning a new one. In any run of 3+ tasks that has a
-low-stakes lane (docs sweeps, mechanical edits, persona reviews — strong
-executed check, retry to absorb failure), assign roughly ONE task to an
-exploration candidate from `./ringer.py models --explore --task-type <type>`
-(untested + cheap or free, text-capable, decent context). Free promos from
-`catalog --changes` jump the queue — a temporarily-free model is a zero-cost
-experiment. Never explore on time-critical work, never with more than a
-small slice of a batch, and name the experiment when presenting the engine
-ask so the human can veto it. Promotion ladder (computed by --explore):
-untested → probation (some evidence) → proven for a task_type (3+ tasks,
-first-try ≥ 0.67). Proven models earn bigger lanes in that type and an
-audition one rung up in adjacent types; repeated first-attempt failures end
-the audition — record the demotion in MODEL-NOTES so the next orchestrator
-doesn't re-run the experiment.
+**Explore or the scoreboard fossilizes.** Always recommending the proven pick means never learning a new one.
+In any run of 3+ tasks that has a low-stakes lane, such as docs sweeps, mechanical edits, or persona reviews, assign roughly ONE task to an untested, cheap or free, text-capable candidate with a decent context window from `./ringer.py models --explore --task-type <type>` when the executed check is strong and an eligible retry can absorb a check failure.
+Free promos from `catalog --changes` jump the queue because a temporarily-free model is a zero-cost experiment.
+Never explore on time-critical work or with more than a small slice of a batch, and name the experiment when presenting the engine ask so the human can veto it.
+The promotion ladder computed by `--explore` is untested, then probation with some evidence, then proven for a `task_type` at 3+ tasks and `first_try_pass_rate >= 0.67`.
+Proven models earn bigger lanes in that type and an audition one rung up in adjacent types; repeated first-attempt failures end the audition, so record the demotion in MODEL-NOTES and do not rerun the experiment.
 
 **OpenCode is the harness; the model is a manifest field.** Unless a model
 ships its own first-class harness (Codex does), it runs through the
@@ -282,7 +278,15 @@ someone's untracked scratch files.
 
 ## Post-run review ritual
 
-1. Read the run JSON in `~/.ringer/runs/` — statuses, retries, durations.
+0. Run `./ringer.py status`.
+   Exit 0 means no stranded work remains.
+   Exit 2 means escalations or dead runs awaiting matching-state recovery remain; active runs alone are informational.
+   Exit 1 means recovery, review snapshot, or clear persistence failed.
+   Resume, re-plan, or report every escalation before acknowledgement.
+   Run plain `status` before `status --clear-escalations`; clearing refuses an unreviewed ledger and acknowledges only the latest displayed snapshot, so later escalations remain stranded.
+   For a custom state directory, use the matching config with `./ringer.py --config /path/to/config.toml status`.
+   A `launch` class means the engine, environment, or spec must change; `prepare`, `cancelled`, and `orchestrator` identify setup or runner failures, while `work` is an ordinary terminal task failure.
+1. Read the run JSON in `~/.ringer/runs/`: statuses, retries, durations, and `failure_class`.
 2. For any retried or failed task, read the raw worker log in
    `<workdir>/logs/` before deciding anything. Retries that passed on
    attempt 2 often reveal a spec ambiguity worth fixing in your next

--- a/.claude/skills/ringer/SKILL.md
+++ b/.claude/skills/ringer/SKILL.md
@@ -1,327 +1,63 @@
 ---
 name: ringer
 description: >-
-  Orchestrator playbook and routing rules for Ringer, the verified-swarm
-  delegation tool. Load before any model-calling script or conversational
-  harness; edit-test-edit loop or batch edit; quick check that launches a
-  model or CLI agent; failed worker diagnosis; manifest authoring or review;
-  swarm-pattern, engine, model, task-type, or effort selection; or Ringer run
-  debugging. A single task is a one-task manifest. Skip only for file reads
-  and searches, Git-only operations, one one-file few-line edit, prose or
-  documentation authored from current context, or pure conversation.
+  Operate Ringer, the verified-swarm delegation tool, only when the user
+  explicitly asks to use Ringer, invokes $ringer, selects the full harness,
+  requests a Ringer manifest or verified Ringer swarm, or when the closest
+  repository instructions explicitly require Ringer for the authorized task.
+  Also use this skill to inspect, resume, or debug an existing Ringer run.
+  Do not trigger Ringer from ordinary implementation, testing, validation,
+  edit loops, file counts, model use, commits, pushes, or pull-request work.
+  If Ringer might help but was not selected, recommend it once without
+  launching it and continue directly.
 ---
 
-# Ringer orchestrator playbook
+# Ringer
 
-## Read this first — the four rules that actually get broken
+Treat Ringer as an opt-in execution mode, not the default path for substantive work.
+Standing authorization removes a second permission prompt after Ringer is selected.
+It does not select Ringer or make it mandatory.
 
-1. **You review; workers type.** Your lane: specs, checks, pattern choice,
-   reading results. If you are typing implementation, running probes, or
-   babysitting a retry loop yourself, you have left your lane.
-2. **A single task is a one-task manifest.** Same verification, zero
-   ceremony. "Too small for Ringer" is how drift starts — the smoke test,
-   the probe script, the three-edit fix are all one-task manifests.
-3. **Beware the tiny-edit death spiral.** The named anti-pattern: each step
-   is individually small enough to justify inline, and two hours later the
-   exception has become the workflow and nothing was verified or visible.
-   The one-shot exception is ONE file, a few lines, ONCE. The second pass on
-   the same problem is a loop, and loops are manifests.
-4. **Runs are watched, not hidden — and the screen comes up FIRST.** The
-   moment this skill loads for real work, before you write a single spec,
-   put Ringside on the human's screen: `./ringer.py hud` (idempotent — if
-   one is already up it says so and opens the page; runs also auto-start
-   it). Ringside is the PAGE at http://127.0.0.1:8700 — NEVER launch the
-   Ringside.app application (`open -a Ringside`); it is a parked prototype
-   with a stale frontend. And never go dark: if your prep (research,
-   check-writing, manifest drafting) will take more than ~30 seconds,
-   tell the human in one sentence what you're doing and roughly how long
-   before you start — they should be watching the empty arena and reading
-   your one-liner, not wondering if anything is happening. Never pass
-   `--no-dashboard` except in automated tests or when the user explicitly
-   asks.
+## Activation contract
 
-Ringer runs manifest tasks in parallel across cheap CLI workers (Codex,
-OpenCode/GLM, others via config) and verifies every task by **executing a
-check command** — exit 0 is the only PASS. Failed tasks are retried once
-with the check's actual failure output injected into the retry prompt. You —
-the orchestrating model — pay tokens only for specs, orchestration, and
-review.
+- Launch Ringer only after explicit user selection or an explicit closest-repository requirement.
+- Continue directly when the task merely involves several files, an edit-test loop, local validation, or a model-calling command.
+- Recommend Ringer at most once when the work has at least two genuinely independent lanes, needs isolated perspectives, or benefits from a verified model comparison.
+- Treat a user choice of `direct` as suppression of Ringer for the current job unless the scope materially changes.
+- Do not hand work to no-mistakes automatically.
+- Use no-mistakes after Ringer only when the user separately selected it, selected the full harness, or the closest repository requires it and publication is already authorized.
+
+## Start an explicitly selected job
+
+1. Announce that the Ringer skill caused the orchestration step.
+2. Run `/Users/mattskinner/.local/bin/ringer status` and resolve or report stranded escalations before starting another run.
+3. Open Ringside with `/Users/mattskinner/.local/bin/ringer hud` before preparing work that will take more than about 30 seconds.
+4. Keep one human job under one stable `run_name` across all rounds.
+5. Choose the required references below and read each selected reference completely before acting.
+6. Lint every manifest before running it.
+7. Review the run artifacts, executed checks, retries, and raw logs before accepting the result.
+
+## Load only the required references
+
+- Read [manifest-design.md](references/manifest-design.md) before authoring or reviewing a manifest, choosing a swarm pattern, designing task ownership, or writing checks.
+- Read [model-routing.md](references/model-routing.md) before choosing engines, models, effort, exploration lanes, or interpreting the model scoreboard.
+- Read [run-operations.md](references/run-operations.md) before launching a run, using worktrees, integrating results, handling failures, or completing post-run review.
+
+## Core invariants after activation
+
+- You review and orchestrate; Ringer workers type and execute task checks.
+- A selected Ringer job may use a one-task manifest, but task size alone never selects Ringer.
+- Make worker file ownership disjoint across concurrent lanes.
+- Make checks executable, content-aware, and informative on failure.
+- Never run no-mistakes or another worker scheduler inside a Ringer manifest.
+- Stop after two failed rounds in the same task family, inspect status and evidence, then change the plan or return to the user.
+- Preserve stdin closure, explicit sandbox mode, executed artifact verification, and raw-only worker logs in any Ringer implementation change.
+
+## Commands
 
 ```bash
-./ringer.py lint manifest.json            # always lint before running
-./ringer.py run manifest.json --identity <who-you-are>
-./ringer.py demo                          # 3-worker smoke test
-./ringer.py run manifest.json --dry-run   # print the plan, spawn nothing
+/Users/mattskinner/.local/bin/ringer lint manifest.json
+/Users/mattskinner/.local/bin/ringer run manifest.json --identity <who-you-are>
+/Users/mattskinner/.local/bin/ringer run manifest.json --dry-run
+/Users/mattskinner/.local/bin/ringer status
 ```
-
-Runs land in `~/.ringer/runs/`. Raw worker logs land in `<workdir>/logs/`.
-Full reference: `README.md`. Ready-made manifest skeletons: `templates/`.
-Lint catches unverifiable checks, silent checks, worktree deliverable/commit
-loss, serial fan-out, write collisions, and underspecified specs; `run`
-prints the same findings as non-blocking warnings.
-
-## One job, one artifact
-
-A job the human asked for — however many rounds it takes — is ONE artifact.
-Use the SAME `run_name` for every round (`sd-crate-launch`, not
-`sd-crate-r1` / `sd-crate-r2`): the library accumulates each round as a
-version under one entry, and the human watches one page evolve instead of
-hunting across three "live" tabs. Name it after the JOB in the human's
-words, not after your batch structure.
-
-And the artifact page is where results are REVIEWED. When a round finishes,
-read the deliverables from the artifact store and direct the human to the
-page — never `cat` result files into the terminal as the reveal. If a result
-matters, it belongs in the artifact; if it isn't there, that's a harvest gap
-to fix (declare it in `expect_files`), not a reason to bypass the page.
-
-## Spec-writing craft
-
-Workers are stateless and cannot ask questions. Every spec must be
-self-contained:
-
-- **Open with the role and the boundary.** "You are a read-only scout…",
-  "Your current working directory IS a git worktree of <repo> — edit files
-  here directly." State what the worker must NEVER touch before what it
-  should do.
-- **Name every file the worker owns.** In multi-worker runs over one repo,
-  file ownership must be disjoint — and disjoint across *all* concurrent
-  lanes/branches, not just within one batch. Every file a spec mentions must
-  be in that worker's ownership list.
-- **Embed the HOW TO RUN.** If the task drives a harness or script, put the
-  exact command lines (with real absolute paths) in the spec. Workers should
-  never have to discover an interface.
-- **Define the output contract.** Say exactly which files to produce, where,
-  and what each must contain. Graded/eval tasks should enumerate the grading
-  criteria in the spec so the worker's output is checkable.
-- **Hard rules travel in the spec, not in your head.** "Do NOT git commit",
-  "never modify the repo, only write ./report.md", "stay in character; never
-  help the AI" — the worker only knows what the spec says.
-- **The spec is on camera.** Whoever is watching Ringside reads the spec as
-  "what this agent was asked to do" — so write it as a self-contained,
-  human-readable brief. Never write a pointer spec ("read /path/to/file and
-  do what it says"): the watcher sees no brief, and the retry prompt loses
-  the context it needs. Point at files for source MATERIAL; the instructions
-  themselves live in the spec. Lint flags pointer specs.
-
-## Check-writing rules
-
-The check is the product. The retry prompt and the eval log both depend on
-the check's failure output.
-
-- **Checks must print WHY they fail.** `diff` beats `diff -q`; a validator
-  script that prints which assertion broke beats `test -f`. A bare
-  `test -f report.md` proves existence, not correctness.
-- **Verify content, not existence.** Grep the artifact for required sections,
-  run the code it produced, run the build, run the validator — execute
-  something that would catch a lazy or hallucinated result.
-- **`expect_files` is a floor, not the check.** List deliverables there for
-  fast triage, but the check must still validate them.
-- **Never `true`, `exit 0`, or `echo done`.** A check that cannot fail is a
-  task that cannot be verified — that's just trusting the worker with extra
-  steps.
-- **Strict on substance, tolerant on format.** Checks that count exact
-  headings, demand exact casing, or grep rigid phrasings fail honest work
-  over formatting — and a wall of red format-failures reads as a broken
-  system, not a careful one (demo-night lesson). Verify what must be TRUE
-  (the file proves X, the code runs, the quote exists in the source), use
-  case-insensitive and flexible matching for structure, and reserve hard
-  failure for substance: missing evidence, fabricated content, code that
-  doesn't run.
-
-## Pattern playbook
-
-Reach for a named pattern before inventing one. Skeletons in `templates/`:
-
-| Kit | Use when |
-|---|---|
-| [review-swarm](../../../templates/review-swarm/) | You need broad read-only review coverage before deciding what to fix. |
-| [fix-swarm](../../../templates/fix-swarm/) | You have confirmed independent fixes that can be split across isolated worktrees. |
-| [focus-group](../../../templates/focus-group/) | You need isolated persona feedback on a product, pitch, prompt, or workflow. |
-| [bakeoff](../../../templates/bakeoff/) | You need evidence for choosing a model, prompt, or configuration across shared scenarios. |
-| [research-with-proof](../../../templates/research-with-proof/) | You need research backed by a proof task whose check executes the claim. |
-| [launch-kit](../../../templates/launch-kit/) | You need a go-to-market package built across research, persona review, and final assembly rounds. |
-| [asset-swarm](../../../templates/asset-swarm/) | You need media assets produced in parallel with executable checks for renders, batches, diagrams, or captures. |
-| [adversarial-review](../../../templates/adversarial-review/) | You want several models to review the same artifact before the orchestrator synthesizes findings. |
-| [repo-feature](../../../templates/repo-feature/) | You know what to build and need sandboxed workers to edit a real repo with build and git checks. |
-| [migration-swarm](../../../templates/migration-swarm/) | You have mechanical codebase transforms that can be partitioned across worktrees. |
-| [doc-swarm](../../../templates/doc-swarm/) | You need module docs with executed examples and checks against invented APIs. |
-| [test-hardening](../../../templates/test-hardening/) | You need stronger tests by module while keeping production source edits off-limits. |
-| [competitive-teardown](../../../templates/competitive-teardown/) | You need competitor research with citation allowlists and a synthesis phase. |
-| [data-pipeline](../../../templates/data-pipeline/) | You need fetch, transform, and validate stages with executed validators and honesty rules. |
-| [probe](../../../templates/probe/) | You need a one-task manifest for a smoke, probe, or post-mortem. |
-
-Pattern-selection judgment:
-
-- **Browse the catalog first.** Before writing any manifest, browse
-  `templates/README.md`: choose a kit, mix pieces from several, or write
-  your own having seen the prior art.
-- **Review before fix.** Run a read-only review swarm, read the reports
-  yourself, then compile the confirmed findings into a fix-swarm manifest.
-  Don't let the same worker find and fix.
-- **Personas must be separate workers.** Parallel personas in one context
-  bleed into each other. One persona per task, one session dir per task.
-- **Iterating on a prompt/product? Re-run the same panel.** A fixed persona
-  panel across rounds tells you whether a change fixed what the panel
-  actually complained about.
-- **Probes, smokes, and diagnosis loops are manifests too.** A model-calling
-  smoke test is a one-task manifest with the transcript as `expect_files`
-  and a validator as the check. Diagnosing a failed worker's output is a
-  read-only scout task. If it calls a model, it runs under Ringer — that is
-  what makes it visible, verified, and logged.
-
-## Engine selection
-
-**The engine choice belongs to the human — but the recommendation comes
-from THEIR evidence.** Before the FIRST run of a job: read what's wired up
-(`[engines.<name>]` blocks in `~/.config/ringer/config.toml`), run
-`./ringer.py models --task-type <this job's type>` for the local scoreboard,
-and glance at `./ringer.py catalog --changes` for anything newly free or
-newly cheap. Then ask the user which model should do the typing — top 2–3
-options with the NUMBERS in the pitch and a recommendation, e.g.: *"GLM is
-6/6 first-try on persona work here at ~2¢/task — recommended. Codex is also
-100% but ~8x the tokens. And kimi went free on OpenRouter yesterday — want
-it auditioning one of the small tasks?"* Honor their pick via the per-task
-`engine`/`model` fields; don't re-ask every round of the same job unless
-the mix isn't working. This is per-user by design: the scoreboard learns
-THIS user's workload — never import another machine's conclusions or
-recommend from a different user's numbers.
-
-**Explore or the scoreboard fossilizes.** Always recommending the proven
-pick means never learning a new one. In any run of 3+ tasks that has a
-low-stakes lane (docs sweeps, mechanical edits, persona reviews — strong
-executed check, retry to absorb failure), assign roughly ONE task to an
-exploration candidate from `./ringer.py models --explore --task-type <type>`
-(untested + cheap or free, text-capable, decent context). Free promos from
-`catalog --changes` jump the queue — a temporarily-free model is a zero-cost
-experiment. Never explore on time-critical work, never with more than a
-small slice of a batch, and name the experiment when presenting the engine
-ask so the human can veto it. Promotion ladder (computed by --explore):
-untested → probation (some evidence) → proven for a task_type (3+ tasks,
-first-try ≥ 0.67). Proven models earn bigger lanes in that type and an
-audition one rung up in adjacent types; repeated first-attempt failures end
-the audition — record the demotion in MODEL-NOTES so the next orchestrator
-doesn't re-run the experiment.
-
-**OpenCode is the harness; the model is a manifest field.** Unless a model
-ships its own first-class harness (Codex does), it runs through the
-`opencode` engine with the task's `"model"` field set to the OpenRouter
-slug — e.g. `"engine": "opencode", "model": "openrouter/moonshotai/kimi-k2.7-code"`.
-This holds even when someone — including the user, in the heat of a run —
-says to "call kimi directly" or reach for the model's own CLI: the harness
-is what provides the sandbox, raw logs, token counts, and executed
-verification, so routing around it silently drops all four. Never clone an
-engine block or splice `-m` through `engine_args` to change models; that's
-what the `model` field is for, and a bakeoff is only real when the MANIFEST
-names each competitor (2026-07-06 lesson: an engine block with a hard-coded
-model ran one model under three competitors' names).
-
-Engines are config blocks (`[engines.<name>]` in config.toml), selectable
-per task via the manifest `engine` field. Defaults are deliberate:
-
-- **codex** (default): strongest general worker. Use per-task `engine_args`
-  to set reasoning effort — spend it on hard tasks, not boilerplate.
-- **opencode**: the universal lane — any OpenRouter model via the `model`
-  field (engine `model_default` is GLM-5.2, the cheap-intelligence pick).
-  Validate a model new to you with a trivial one-task manifest before
-  trusting it with a batch.
-- Small/flash-class models are the first to choke on long conversational or
-  multi-turn harness tasks — watch their retry counts before scaling them.
-- Match `timeout_s` to the task: conversational harness tasks and
-  build-and-test checks need far more than file edits.
-- **Check the evidence before assigning models to tasks.** Run
-  `./ringer.py models` (optionally `--task-type <type>`) — the local
-  scoreboard aggregating every executed-check outcome per (model,
-  task_type): first_try_pass_rate is the routing signal; pass_rate includes
-  retry rescues. Then read `docs/MODEL-NOTES.md` (in the ringer repo) for
-  the judgment the numbers can't carry. Routing is grounded in performance,
-  not vibes (Jon directive 2026-07-06).
-- **Use the Sol/Terra/Luna lane aliases explicitly — when your local
-  config defines them.** Sol, Terra, and Luna are optional
-  operator-defined aliases: local names an operator maps to their own
-  frontier, workhorse, and cheap model tiers in their engine/model
-  configuration. They are not shipped model IDs — never guess what they
-  resolve to; if your config doesn't define them, skip this bullet and
-  apply the same tier split with explicit `engine`/`model` values. Put the
-  model in the manifest `model` field and put reasoning effort in
-  `engine_args`. Use Sol (frontier tier) for decomposition, architecture,
-  check design, synthesis, and an explicit rescue after a cheaper lane
-  fails. Use Terra (workhorse tier) by default for implementation,
-  debugging, integration, and invariant-heavy review. Use Luna (cheap
-  tier) only for bounded mechanical edits, renderer work, tests, and
-  verification with an exact check. If Luna appears to need high effort,
-  move the task to Terra instead. Recommended defaults are Sol xhigh, Terra
-  high, and Luna medium; lower effort only when the task and check make the
-  reduced risk explicit.
-- **"Show me the scoreboard" is one command.** When the human asks to see
-  the model scoreboard, rankings, model costs, or "which models work best,"
-  run `./ringer.py models --open` — it renders the full scoreboard (tiers,
-  first-try rates, est. $/task, usage, MODEL-NOTES excerpts, free-promo
-  watchlist) as a zero-LLM HTML page in the artifact library and opens it
-  in their browser. Costs no tokens; never hand-summarize the numbers when
-  the page can show them.
-- **Give every task a `task_type`** (canonical vocabulary in the README —
-  code-feature, code-fix, code-review, research, persona-review, site-build,
-  image-gen, docs, probe, bakeoff, ...). Untyped tasks bucket as (untyped)
-  and teach the scoreboard nothing; lint nudges you when it's missing.
-
-## Harness ownership and handoff
-
-- Use a Codex Goal as an optional outer completion contract, never as a
-  worker scheduler or substitute for executed checks.
-- Let Ringer exclusively own delegated work, worker worktrees, retries, and
-  worker verification while a run is active. Never invoke firstmate or
-  no-mistakes inside a Ringer manifest.
-- After the orchestrator integrates the verified output and the canonical
-  repository check passes, hand the committed feature branch to
-  no-mistakes exactly once for review, PR creation, and CI monitoring.
-- If no-mistakes surfaces a non-mechanical design decision, stop at its gate
-  and return the decision to the human. Do not start a competing repair loop.
-
-## Worktrees-mode footguns (learned the hard way)
-
-Run-level `"worktrees": true` gives each task an isolated git worktree of
-`repo`, detached at HEAD. Three consequences:
-
-1. **Passing tasks get their worktree DELETED.** Deliverables must land
-   outside the task worktree, or the check must export them first.
-2. **Worker commits die with the worktree.** Pattern that works: the worker
-   leaves changes uncommitted; the check runs
-   `git add -A && git diff --cached > <path-outside-worktree>.patch` and
-   validates the patch. You apply and commit on your branch after review.
-3. **Logs survive** (they go to `<workdir>/logs/`), so post-mortems work
-   even on deleted worktrees.
-4. **Gitignored outputs silently vanish from patch exports.** `git add -A`
-   cannot stage ignored files (build dirs like `dist/`), so a worker's edits
-   there pass its checks, export an incomplete patch, and die with the
-   worktree. If a task touches any gitignored path, the check must `cp`
-   those files to a path outside the worktree explicitly — verify the patch
-   AND the copies before trusting the run.
-
-And on your own side of the fence: when integrating patches into the real
-repo, stage specific paths — never `git add -A` in a checkout that may hold
-someone's untracked scratch files.
-
-## Post-run review ritual
-
-1. Read the run JSON in `~/.ringer/runs/` — statuses, retries, durations.
-2. For any retried or failed task, read the raw worker log in
-   `<workdir>/logs/` before deciding anything. Retries that passed on
-   attempt 2 often reveal a spec ambiguity worth fixing in your next
-   manifest.
-3. Spot-check at least one PASSING task's artifact per run. The check
-   catches most laziness; you catch the rest.
-4. Failures with useless error messages mean your CHECK needs work, not
-   (only) the worker.
-5. **Update `docs/MODEL-NOTES.md`** (in the ringer repo) when a run taught
-   you something about a model: one dated line under the model — task type,
-   what happened (attempts, tokens, failure mode), what you'd do
-   differently. Only what the executed checks and raw logs support. The raw
-   numbers took care of themselves — every attempt already landed in the
-   local model log (`./ringer.py models` to see the updated scoreboard).
-
-## Baked-in invariants (preserve in any change to ringer.py)
-
-Stdin closed (`< /dev/null`); sandbox mode explicit; verification executes
-the artifact; logs carry raw worker output only. These are load-bearing —
-engine and invocation changes must keep all four.

--- a/.claude/skills/ringer/SKILL.md
+++ b/.claude/skills/ringer/SKILL.md
@@ -2,21 +2,13 @@
 name: ringer
 description: >-
   Orchestrator playbook and routing rules for Ringer, the verified-swarm
-  delegation tool (ringer.py). TRIGGER — load BEFORE acting, not after —
-  whenever: you are about to run ANY script or command that calls a model or
-  drives a conversational/eval harness (probe, smoke test, simulation,
-  grader, persona conversation) outside a live Ringer run; you are about to
-  start an edit→test→edit loop or a batch of similar edits across files; you
-  are about to do a "quick check" that spawns a model or a CLI agent; you are
-  reviewing or diagnosing failed worker or model output; you catch yourself
-  thinking a task is "small enough to just do myself" — that thought IS the
-  trigger (a single task is a one-task manifest); or you are writing or
-  reviewing a manifest, choosing a swarm pattern (review swarm, fix swarm,
-  focus group, bakeoff, research-with-proof), picking a worker engine, or
-  debugging a failed run. SKIP only for: reading or searching files, git
-  operations, a one-file few-line ONE-SHOT edit (once — if you are back for a
-  second pass, that is a loop: TRIGGER), authoring prose/specs/docs straight
-  from your own context, or pure conversation.
+  delegation tool. Load before any model-calling script or conversational
+  harness; edit-test-edit loop or batch edit; quick check that launches a
+  model or CLI agent; failed worker diagnosis; manifest authoring or review;
+  swarm-pattern, engine, model, task-type, or effort selection; or Ringer run
+  debugging. A single task is a one-task manifest. Skip only for file reads
+  and searches, Git-only operations, one one-file few-line edit, prose or
+  documentation authored from current context, or pure conversation.
 ---
 
 # Ringer orchestrator playbook
@@ -244,6 +236,16 @@ per task via the manifest `engine` field. Defaults are deliberate:
   retry rescues. Then read `docs/MODEL-NOTES.md` (in the ringer repo) for
   the judgment the numbers can't carry. Routing is grounded in performance,
   not vibes (Jon directive 2026-07-06).
+- **Use the local Sol/Terra/Luna lanes explicitly.** Put the model in the
+  manifest `model` field and put reasoning effort in `engine_args`.
+  Use Sol for decomposition, architecture, check design, synthesis, and an
+  explicit rescue after a cheaper lane fails. Use Terra by default for
+  implementation, debugging, integration, and invariant-heavy review. Use
+  Luna only for bounded mechanical edits, renderer work, tests, and
+  verification with an exact check. If Luna appears to need high effort,
+  move the task to Terra instead. Recommended defaults are Sol xhigh, Terra
+  high, and Luna medium; lower effort only when the task and check make the
+  reduced risk explicit.
 - **"Show me the scoreboard" is one command.** When the human asks to see
   the model scoreboard, rankings, model costs, or "which models work best,"
   run `./ringer.py models --open` — it renders the full scoreboard (tiers,
@@ -255,6 +257,19 @@ per task via the manifest `engine` field. Defaults are deliberate:
   code-feature, code-fix, code-review, research, persona-review, site-build,
   image-gen, docs, probe, bakeoff, ...). Untyped tasks bucket as (untyped)
   and teach the scoreboard nothing; lint nudges you when it's missing.
+
+## Harness ownership and handoff
+
+- Use a Codex Goal as an optional outer completion contract, never as a
+  worker scheduler or substitute for executed checks.
+- Let Ringer exclusively own delegated work, worker worktrees, retries, and
+  worker verification while a run is active. Never invoke firstmate or
+  no-mistakes inside a Ringer manifest.
+- After the orchestrator integrates the verified output and the canonical
+  repository check passes, hand the committed feature branch to
+  no-mistakes exactly once for review, PR creation, and CI monitoring.
+- If no-mistakes surfaces a non-mechanical design decision, stop at its gate
+  and return the decision to the human. Do not start a competing repair loop.
 
 ## Worktrees-mode footguns (learned the hard way)
 

--- a/.claude/skills/ringer/SKILL.md
+++ b/.claude/skills/ringer/SKILL.md
@@ -236,12 +236,19 @@ per task via the manifest `engine` field. Defaults are deliberate:
   retry rescues. Then read `docs/MODEL-NOTES.md` (in the ringer repo) for
   the judgment the numbers can't carry. Routing is grounded in performance,
   not vibes (Jon directive 2026-07-06).
-- **Use the local Sol/Terra/Luna lanes explicitly.** Put the model in the
-  manifest `model` field and put reasoning effort in `engine_args`.
-  Use Sol for decomposition, architecture, check design, synthesis, and an
-  explicit rescue after a cheaper lane fails. Use Terra by default for
-  implementation, debugging, integration, and invariant-heavy review. Use
-  Luna only for bounded mechanical edits, renderer work, tests, and
+- **Use the Sol/Terra/Luna lane aliases explicitly — when your local
+  config defines them.** Sol, Terra, and Luna are optional
+  operator-defined aliases: local names an operator maps to their own
+  frontier, workhorse, and cheap model tiers in their engine/model
+  configuration. They are not shipped model IDs — never guess what they
+  resolve to; if your config doesn't define them, skip this bullet and
+  apply the same tier split with explicit `engine`/`model` values. Put the
+  model in the manifest `model` field and put reasoning effort in
+  `engine_args`. Use Sol (frontier tier) for decomposition, architecture,
+  check design, synthesis, and an explicit rescue after a cheaper lane
+  fails. Use Terra (workhorse tier) by default for implementation,
+  debugging, integration, and invariant-heavy review. Use Luna (cheap
+  tier) only for bounded mechanical edits, renderer work, tests, and
   verification with an exact check. If Luna appears to need high effort,
   move the task to Terra instead. Recommended defaults are Sol xhigh, Terra
   high, and Luna medium; lower effort only when the task and check make the

--- a/.claude/skills/ringer/references/manifest-design.md
+++ b/.claude/skills/ringer/references/manifest-design.md
@@ -1,0 +1,95 @@
+# Manifest design
+
+Use this reference after Ringer has been explicitly selected.
+
+## Contents
+
+- One job, one artifact
+- Spec-writing rules
+- Check-writing rules
+- Pattern selection
+- Follow-up rounds
+
+## One job, one artifact
+
+Treat the human's requested job as one artifact even when it takes several rounds.
+Use the same `run_name` for every round.
+Name it after the job in the human's words, not after the internal batch structure.
+
+Review results from the artifact page.
+Do not reveal important results by dumping result files into a terminal.
+Declare every important output in `expect_files` so the artifact store captures it.
+Treat a missing artifact as a harvest gap to fix, not as a reason to bypass the artifact page.
+
+## Spec-writing rules
+
+Workers are stateless and cannot ask questions.
+Make every spec self-contained.
+
+- Open with the role and boundary.
+- State what the worker must never touch before stating what it should do.
+- Name every file the worker owns.
+- Keep ownership disjoint across all concurrent lanes and branches.
+- Include exact commands for every script or harness the worker must use.
+- Define the output contract, including file paths and required contents.
+- Include grading criteria for evaluated work.
+- Put hard rules in the spec, including Git, privacy, runtime, and mutation boundaries.
+- Write the instructions themselves in the spec.
+- Point to files only as source material, not as a substitute for the brief.
+
+## Check-writing rules
+
+Treat the check as part of the product.
+Its failure output becomes retry and evaluation evidence.
+
+- Print why the check failed.
+- Prefer a useful `diff` or validator message over a bare exit status.
+- Verify content and behavior, not mere file existence.
+- Execute generated code, builds, renderers, or validators when applicable.
+- Use `expect_files` as an artifact floor, not as the substantive check.
+- Never use `true`, unconditional `exit 0`, or `echo done` as verification.
+- Be strict about substance and tolerant about formatting.
+- Avoid exact heading counts, exact casing, and brittle phrase matching unless the format itself is the contract.
+
+## Pattern selection
+
+Browse `templates/README.md` before inventing a new pattern.
+Choose the smallest pattern that fits the selected Ringer job.
+
+| Pattern | Use when |
+|---|---|
+| `review-swarm` | Broad read-only coverage is needed before deciding what to fix. |
+| `fix-swarm` | Confirmed independent fixes can use isolated worktrees. |
+| `focus-group` | Isolated persona feedback is needed for a product, pitch, prompt, or workflow. |
+| `bakeoff` | Models, prompts, or configurations need comparison across shared scenarios. |
+| `research-with-proof` | Research claims need an executable proof task. |
+| `launch-kit` | Research, persona review, and final assembly need separate rounds. |
+| `asset-swarm` | Media assets need parallel production and executable render checks. |
+| `adversarial-review` | Several models should review the same artifact before synthesis. |
+| `repo-feature` | A known feature needs sandboxed workers, builds, and Git checks. |
+| `migration-swarm` | A mechanical transform can be partitioned across worktrees. |
+| `doc-swarm` | Module documentation needs executed examples and API checks. |
+| `test-hardening` | Tests can be strengthened by module while production files stay off-limits. |
+| `competitive-teardown` | Competitor research needs citation allowlists and synthesis. |
+| `data-pipeline` | Fetch, transform, and validation stages need separate proof. |
+| `probe` | An explicitly selected one-task smoke, probe, or post-mortem needs durable evidence. |
+
+## Pattern rules
+
+- Review before fixing when the findings are not already confirmed.
+- Do not make one worker find and fix the same uncertain issue.
+- Split an objective projected to touch more than about 25 files or two subsystems into landable slices.
+- Give each slice its own branch and pull request when independent landing is possible.
+- Keep each persona in a separate worker to prevent context bleed.
+- Reuse the same persona panel across product or prompt iterations.
+- Put a model-calling smoke or probe under Ringer only when the user selected Ringer for that job.
+
+## Follow-up rounds
+
+Resume from the existing exported patch, branch, or commits.
+Do not silently reimplement prior rounds.
+Keep the same `run_name` so the artifact page accumulates versions under one job.
+
+When a check failure reveals an ambiguous spec, fix the spec or split the task before retrying.
+When the same task family has failed two rounds, do not launch an identical third round.
+Inspect status and raw evidence, then change the task, tier, environment, or plan.

--- a/.claude/skills/ringer/references/model-routing.md
+++ b/.claude/skills/ringer/references/model-routing.md
@@ -1,0 +1,81 @@
+# Model routing
+
+Use this reference after Ringer has been explicitly selected and a worker model decision is required.
+
+## Contents
+
+- Evidence before selection
+- Engine and model fields
+- Sol, Terra, and Luna
+- Exploration
+- Task typing and scoreboard use
+
+## Evidence before selection
+
+Inspect the configured `[engines.<name>]` blocks before the first run of a job.
+Run `ringer models --task-type <type>` for local performance evidence.
+Check `ringer catalog --changes` for newly free or newly cheap models.
+
+Recommend two or three grounded options with first-try pass rate, cost, and task-type evidence.
+Ask the human to choose the worker model for the first run of the job.
+Do not ask again on every round unless the selected mix is failing.
+Never import another machine's routing conclusions.
+
+## Engine and model fields
+
+Put the engine in the manifest `engine` field.
+Put the model in the manifest `model` field.
+Put reasoning effort in `engine_args`.
+Do not clone engine blocks or splice model selection through generic engine arguments.
+
+Use Codex as the strongest general worker when its cost and task evidence justify it.
+Use OpenCode as the universal harness for OpenRouter models.
+Keep the OpenRouter slug in the task's `model` field.
+Do not call an OpenRouter model through an ad hoc CLI because that loses sandboxing, raw logs, token counts, and executed verification.
+
+Validate an unfamiliar model with a bounded task before scaling it.
+Give conversational harnesses and build checks enough timeout.
+Watch first-attempt failure and retry rates before assigning more work to a small or flash-class model.
+
+## Sol, Terra, and Luna
+
+Treat Sol, Terra, and Luna as optional operator-defined aliases.
+Never guess what they resolve to.
+Skip the aliases when local configuration does not define them.
+
+- Use Sol for decomposition, architecture, check design, synthesis, and explicit rescue after a cheaper lane fails.
+- Use Terra for normal implementation, debugging, integration, and invariant-heavy review.
+- Use Luna for bounded mechanical edits, renderer work, tests, and verification with an exact check.
+- Move a Luna task to Terra if it appears to require high reasoning effort.
+
+Use Sol at xhigh, Terra at high, and Luna at medium as the normal starting points when those aliases exist.
+Lower effort only when the task and check make the reduced risk explicit.
+Do not assign every lane in a multi-task manifest to the frontier tier.
+
+## Exploration
+
+Prevent the scoreboard from fossilizing around the current winner.
+In a selected run with at least three tasks and a low-risk lane, consider assigning about one task to an exploration candidate.
+Use `ringer models --explore --task-type <type>` to find candidates.
+Give temporary free promotions priority when the task is safe and the check is strong.
+
+Do not explore on time-critical work.
+Do not explore with more than a small slice of a batch.
+Name the experiment when presenting the model choice so the human can veto it.
+
+Treat an untested model as an audition.
+Promote it after at least three relevant tasks with a first-try pass rate of at least 0.67.
+End the audition after repeated first-attempt failures.
+Record durable model lessons in `docs/MODEL-NOTES.md` using only executed checks and raw logs.
+
+## Task typing and scoreboard use
+
+Give every manifest task a canonical `task_type` such as `code-feature`, `code-fix`, `code-review`, `research`, `persona-review`, `site-build`, `image-gen`, `docs`, `probe`, or `bakeoff`.
+Do not leave tasks untyped because untyped results teach the scoreboard little.
+
+Use first-try pass rate as the main routing signal.
+Treat overall pass rate as including retry rescues.
+Read `docs/MODEL-NOTES.md` for judgment that the numeric scoreboard cannot carry.
+
+When the human asks to see the scoreboard, run `ringer models --open`.
+Use the generated zero-model HTML artifact instead of hand-summarizing the table.

--- a/.claude/skills/ringer/references/run-operations.md
+++ b/.claude/skills/ringer/references/run-operations.md
@@ -1,0 +1,91 @@
+# Run operations
+
+Use this reference after Ringer has been explicitly selected and before launching, integrating, or reviewing a run.
+
+## Contents
+
+- Visibility and launch
+- Harness ownership
+- Worktree behavior
+- Integration and optional publication gate
+- Failure handling
+- Post-run review
+
+## Visibility and launch
+
+Open Ringside before writing a long spec or launching work.
+Use the page at `http://127.0.0.1:8700`.
+Do not launch the parked Ringside application.
+Do not use `--no-dashboard` except in automated tests or when the user explicitly requests it.
+
+Tell the human what preparation is underway when it will take more than about 30 seconds.
+Lint the manifest before running it.
+Use a dry run when the worker plan or ownership needs review before spawning anything.
+
+## Harness ownership
+
+Let Ringer own delegated work, worker worktrees, retries, and worker verification while the run is active.
+Do not invoke firstmate, no-mistakes, or another worker scheduler inside the manifest.
+Do not start a competing repair loop when another harness owns the active branch.
+
+Use a Codex Goal only as an optional outer completion contract.
+Do not use a Goal as a worker scheduler or as a substitute for executed checks.
+
+## Worktree behavior
+
+Run-level `worktrees: true` gives each task an isolated worktree detached at the repository head.
+Account for these consequences:
+
+1. Passing task worktrees are deleted.
+2. Deliverables must leave the task worktree before deletion.
+3. Worker commits disappear with deleted worktrees unless exported.
+4. Raw logs survive under the declared log location.
+5. Gitignored outputs do not enter a staged patch automatically.
+
+Prefer workers leaving changes uncommitted.
+Have the check stage only the worker-owned paths, export a patch outside the worktree, and validate the exported patch.
+Copy required Gitignored outputs outside the worktree explicitly and validate both patch and copies.
+
+When integrating into the real checkout, stage specific paths.
+Never use `git add -A` in a checkout that may contain unrelated scratch files.
+
+## Integration and optional publication gate
+
+Review and integrate verified Ringer output into the authorized repository branch.
+Run the canonical repository checks after integration.
+
+Do not hand the branch to no-mistakes automatically.
+Start no-mistakes only when one of these conditions is true:
+
+- The user separately invoked no-mistakes.
+- The user selected the full harness.
+- The closest repository instructions require no-mistakes and the task already authorizes publication through that gate.
+
+Otherwise stop after the normal verified handoff requested by the user.
+
+If no-mistakes already owns an active review or fix round on the branch, do not route its fixes or verification back through Ringer.
+If no-mistakes raises a non-mechanical product decision, return that decision to the human.
+
+## Failure handling
+
+Run `ringer status` before a new job.
+Treat exit 2 as evidence of stranded escalations.
+Resume, re-plan, or report each escalation before clearing it.
+
+Treat a launch-class escalation as an engine, environment, or spec problem.
+Do not rerun an unchanged manifest that will fail identically.
+
+After two failed rounds in the same task family, stop the identical retry path.
+Inspect status, run JSON, and raw logs.
+Then split the task, change the model tier, repair the environment, or escalate to the human.
+
+## Post-run review
+
+1. Read the run JSON under `~/.ringer/runs/` for statuses, retries, and durations.
+2. Read the raw worker log for every retried or failed task.
+3. Spot-check at least one passing task artifact per run.
+4. Treat a useless check failure message as a check-design problem.
+5. Update `docs/MODEL-NOTES.md` when the run produced durable model evidence.
+
+Report worker-check health separately from the substantive verdict in review artifacts.
+A worker check passing does not mean the reviewed system has no findings.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,26 @@
+name: Test
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install Tauri system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+      - name: Run Python tests
+        run: python3 -m unittest discover -s tests -p 'test_*.py'
+      - name: Check Ringside HUD
+        run: cargo check --locked --manifest-path hud/Cargo.toml

--- a/.no-mistakes.yaml
+++ b/.no-mistakes.yaml
@@ -1,0 +1,4 @@
+allow_repo_commands: false
+commands:
+  test: "python3 -m unittest discover -s tests -p 'test_*.py' && cargo check --locked --manifest-path hud/Cargo.toml"
+  lint: "git diff --check"

--- a/.no-mistakes.yaml
+++ b/.no-mistakes.yaml
@@ -1,4 +1,4 @@
 allow_repo_commands: false
 commands:
   test: "python3 -m unittest discover -s tests -p 'test_*.py' && cargo check --locked --manifest-path hud/Cargo.toml"
-  lint: "git diff --check"
+  lint: "git diff --check origin/main...HEAD"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,12 @@ Frontier models are finally good enough to trust with real implementation — bu
 
 So split the roles. Your best model writes the specs and reviews the results. A swarm of cheap workers — Codex, Grok, anything with a CLI — does the implementation in parallel. Your premium budget stops scaling with lines of code written and starts scaling with decisions made.
 
-One problem: parallel agents lie. "Done" doesn't mean working. Ringer doesn't take the worker's word for anything — it **executes your check command** against the artifact. Pass or fail is decided by running the code, not by reading the agent's summary. Failures retry once with the failure context injected, and every attempt is logged so your setup gets measurably better over time.
+One problem: parallel agents lie.
+"Done" does not mean working.
+Ringer does not take the worker's word for anything because it **executes your check command** against the artifact.
+Pass or fail is decided by running the code, not by reading the agent's summary.
+Eligible `FAIL` and `TIMEOUT` outcomes run once more with the failure context injected, while a `FAIL` after a fast nonzero worker exit stops immediately as a launch-class failure instead of replaying a broken launch.
+Every attempt is logged so your setup gets measurably better over time.
 
 And because a swarm you can't see is a swarm you don't trust: **Ringside**, a local web page every run opens automatically, showing every live swarm on your machine — who's running it, what each worker is doing, elapsed time, token burn — in real time, plus a versioned library of what past runs produced.
 
@@ -18,7 +23,7 @@ And because a swarm you can't see is a swarm you don't trust: **Ringside**, a lo
 manifest.json ──▶ ringer.py ──▶ N parallel workers (codex exec, each in its own dir)
                       │                │
                       │                ▼
-                      │         executed checks ── fail ──▶ retry once w/ failure context
+                      │         executed checks ── retryable fail ──▶ retry once w/ failure context
                       │                │
                       ▼                ▼
               ~/.ringer/runs/    eval log (JSONL or Postgres)
@@ -83,6 +88,34 @@ Run your own batch:
 ```
 
 Each task gets its own directory, its own worker, its own log, and its own verdict. `check` is any shell command — exit 0 is the only thing Ringer believes.
+
+Check for stranded work after a run or an interrupted orchestrator:
+
+```bash
+./ringer.py status
+./ringer.py status --clear-escalations
+```
+
+`status` reports active runs and every unacknowledged task escalation, including tasks recovered from a dead orchestrator.
+Every terminal non-PASS task appends a best-effort JSON record to `<state_dir>/escalations.jsonl` (default `~/.ringer/escalations.jsonl`) and prints a loud `ESCALATION` line.
+Each record identifies the run and task and carries its verdict, failure class, attempt count, check excerpt, and worker-log path.
+If persistence fails, Ringer prints `FAILED TO RECORD` without replacing the run's own outcome.
+The displayed failure class distinguishes ordinary `work` failures from `launch`, `prepare`, `cancelled`, and `orchestrator` failures; the same field is present in the final run-state JSON.
+
+The launch guard classifies a `FAIL` as `launch` when its worker process exits nonzero in less than 10,000 ms by default.
+Worker spawn errors are also `launch` class, while other `ERROR` outcomes are terminal without a retry.
+The threshold measures worker process time, not verification time, and a fast worker exit with code 0 still gets the normal retry because its executed check is what failed.
+Set `RINGER_LAUNCH_CLASS_THRESHOLD_MS` to an integer millisecond value to tune the guard; values below `0` clamp to `0`, which disables the guard, and non-integer values use the 10,000 ms default.
+Fix the engine, environment, or spec before rerunning a `launch` failure.
+
+`status` exit codes are `0` when no stranded work remains, `2` while escalations or dead runs awaiting matching-state recovery remain, and `1` when recovery, review snapshot, or clear persistence fails.
+Active runs are informational and do not by themselves make `status` return nonzero.
+The cross-run recovery registry lives at `$RINGER_HOME/active-runs.json` (default `~/.ringer/active-runs.json`) and records each run's configured state location and task-log paths.
+Dead-run recovery is scoped to the configured `state_dir`; for a non-default config, put the global option before the command: `./ringer.py --config /path/to/config.toml status`.
+
+Use `--clear-escalations` only after acting on records shown by a preceding plain `status` call.
+Plain `status` writes the acknowledgement snapshot to `<state_dir>/escalations.jsonl.review.json`.
+When escalation records exist, the clear operation refuses to proceed without that snapshot and acknowledges only the records in it, so later concurrent or recovered records remain visible.
 
 > **Write checks that print why they fail.** A silent `exit 1` (the `git diff --quiet` style) costs you twice: the retry prompt gets no failure context to fix against, and the eval log records an undiagnosable row. `diff` beats `diff -q`; an assert with a message beats a bare test.
 
@@ -156,7 +189,17 @@ Per-task `"engine": "mymodel"` routes work to it — the invariants (stdin close
 
 Unless a model ships its own first-class harness (Codex does), OpenCode is the harness that runs it — one engine block covers every OpenRouter-served model. `config.sample.toml` includes a ready-to-uncomment engine whose `{model}` placeholder is filled per task from the manifest's `"model"` field, with `model_default` as the fallback. The shipped default is OpenRouter's `z-ai/glm-5.2` — roughly $0.74/M input and $2.33/M output (2026-07), about 20-30x cheaper output than frontier coding models; a complete write-code-and-pass-the-check task lands around a penny.
 
-OpenCode ships no OS sandbox, so the engine's `bin` points at an absolute path to `engines/opencode-sandboxed.sh` (ringer does not resolve engine bins relative to the repo): a macOS Seatbelt wrapper that leaves network and reads open but confines writes to the task dir, a per-run scratch dir (wired as the agent's `TMPDIR`/`XDG_CACHE_HOME`), and OpenCode's own state/config dirs. Its `--dangerously-skip-permissions` flag only silences OpenCode's interactive prompts; Seatbelt is the actual containment. Task paths reach the profile as `sandbox-exec -D` parameters rather than string interpolation, so a task dir with quotes or parens can't inject sandbox rules. `--no-sandbox` is wired as the engine's `full_access_args`, so ringer's `allow_full_access` gate still governs escapes. Non-macOS installs need their own sandbox (or full-access mode).
+OpenCode ships no OS sandbox, so the engine's `bin` points at an absolute path to `engines/opencode-sandboxed.sh` because Ringer does not resolve engine bins relative to the repo.
+The macOS Seatbelt wrapper leaves network open and confines writes to the task dir, a per-run scratch dir (wired as the agent's `TMPDIR`/`XDG_CACHE_HOME`), and OpenCode's own state/config dirs.
+Reads stay broadly open because workers must read repos and docs, except for the default credential deny-list: `~/.ssh`, `~/.aws`, `~/.gnupg`, `~/.secrets`, `~/.netrc`, `~/.npmrc`, `~/.config/gh`, `~/.config/gcloud`, `~/.codex`, `~/.claude`, and `~/Library/Keychains`.
+Add machine-local paths one per line in `~/.config/ringer/opencode-deny-read.txt`; blank lines and lines starting with `#` are ignored, and a leading `~` expands to the home directory.
+`RINGER_OPENCODE_DENY_READ_FILE` selects a different file, while `RINGER_OPENCODE_DENY_READ` adds colon-separated paths.
+Only paths that exist when the wrapper starts are emitted into the profile.
+Each deny matches both the path as written and its symlink-resolved target because Seatbelt matches the *presented* path, so a cloud-drive symlink would bypass a resolved-only deny.
+Its `--dangerously-skip-permissions` flag only silences OpenCode's interactive prompts; Seatbelt is the actual containment.
+Task paths and deny paths reach the profile as `sandbox-exec -D` parameters rather than string interpolation, so a path with quotes or parentheses cannot inject sandbox rules.
+`--no-sandbox` is wired as the engine's `full_access_args`, so Ringer's `allow_full_access` gate still governs escapes.
+Non-macOS installs need their own sandbox or full-access mode.
 
 Setting it up takes about five minutes:
 
@@ -227,7 +270,9 @@ Read it with:
 ./ringer.py models          # per-(model, task_type) scoreboard across the local log
 ```
 
-The scoreboard reports, per model and task_type: tasks, attempts, `pass_rate`, `first_try_pass_rate`, median duration and token count, and `last_seen`. The signal for routing is `first_try_pass_rate` — the share of tasks that passed on attempt 1 without a retry; `pass_rate` is the rescued rate after Ringer's single retry, so the gap between the two is the cost of the retry lane. Slice the log with `--log` (a different JSONL), `--task-type`, `--model`, `--engine`, `--since`, or `--json` for piping elsewhere.
+The scoreboard reports, per model and task_type: tasks, attempts, `pass_rate`, `first_try_pass_rate`, median duration and token count, and `last_seen`.
+The signal for routing is `first_try_pass_rate`, the share of tasks that passed on attempt 1 without a retry; `pass_rate` is the final rate after any eligible single retry, so the gap between the two is the cost of the retry lane.
+Slice the log with `--log` (a different JSONL), `--task-type`, `--model`, `--engine`, `--since`, or `--json` for piping elsewhere.
 
 History from before the `model` / `task_type` / `retry` columns existed can be seeded in one pass:
 
@@ -282,7 +327,12 @@ Models with local evidence are sorted into tiers:
 - **probation** — some attempts logged but not enough volume or not enough first-try passes. Use it; don't lean on it.
 - **untested** — nothing in the log yet. Pulled from the catalog: text→text, 32k+ context window, up to 10 candidates, FREE models first then cheapest. These are your audition queue.
 
-The promotion ladder is the point. A model enters as **untested**. You spend a small slice of suitable runs — about one task per run — auditioning cheap or free candidates on small, low-stakes work where the executed check is strong and the single retry absorbs the failure: docs sweeps, mechanical edits, persona reviews. While evidence accumulates the model sits on **probation**. At 3+ tasks with `first_try_pass_rate >= 0.67` it's **proven** for that task type and earns a lane on the heavy work. The recommendation flow is the same one this ladder implies: exploit proven models for the load-bearing tasks, and keep spending that small slice auditioning untested candidates so the bench refills itself.
+The promotion ladder is the point.
+A model enters as **untested**.
+You spend a small slice of suitable runs, about one task per run, auditioning cheap or free candidates on small, low-stakes work where the executed check is strong and an eligible single retry can absorb a check failure: docs sweeps, mechanical edits, persona reviews.
+While evidence accumulates the model sits on **probation**.
+At 3+ tasks with `first_try_pass_rate >= 0.67` it is **proven** for that task type and earns a lane on the heavy work.
+The recommendation flow is the same one this ladder implies: exploit proven models for the load-bearing tasks, and keep spending that small slice auditioning untested candidates so the bench refills itself.
 
 The per-user philosophy, stated plainly: every user's workload is different, so the scoreboard learns what works for *your* tasks on *your* machine. A model that's proven in someone else's log is untested in yours until you've run it. The numbers are not portable between users, and the routing recommendations get personal as the log grows — which is exactly why the catalog and the change log stay local and the explore tiers are computed from your own `runs.jsonl`, not from anyone's aggregate.
 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ A check that cannot fail is trusting the worker with extra steps.
 
 ## Make your agent actually use this
 
-Between swarms, agents drift back to invisible inline work. Reminders decay, so enforcement ships with the product.
+Ringer is an explicit execution mode, so its integration should stay lightweight until the user or repository selects it.
 
 Run one command:
 
@@ -132,14 +132,17 @@ Run one command:
 ./ringer.py install-agent
 ```
 
-It installs the Ringer skill at the universal `.agents` path, keeps Claude Code compatibility, and registers two gentle hooks for Claude Code and Codex.
-A Bash hook notices model-calling or harness commands running outside a live Ringer run, and an edit-loop hook notices batch editing without a run.
-Each hook nudges once per session, pointing the agent at the skill.
+It installs the compact Ringer skill and its on-demand references at the universal `.agents` path, keeps Claude Code compatibility, and registers one advisory Bash hook for Claude Code and Codex.
+The hook notices model-calling or harness commands running outside a live Ringer run.
+It advises the agent not to load or launch Ringer automatically, and it stays silent for ordinary commands and edit loops.
+The advisory appears at most once per session.
 
 The hook script is installed as a copy (`~/.local/share/ringer/hooks/` for user scope, `./.agents/ringer/hooks/` with `--project`), so the hooks keep working even if the clone moves.
 Re-run `./ringer.py install-agent` after updating the repo; it refreshes the copy and replaces any stale hook registrations in place.
 
-The hooks never block anything. A user who says "just do it inline" is obeyed; uninstall with `./ringer.py uninstall-agent`.
+The hook never blocks anything.
+Ringer still requires explicit user selection or an explicit closest-repository requirement.
+Uninstall with `./ringer.py uninstall-agent`.
 
 For CI and evals, `config.sample.toml` includes `[engines.mock]` so the enforcement stack can be tested without an API bill.
 The repo's own CI (`.github/workflows/test.yml`) runs the Python test suite and a Ringside `cargo check` on every pull request and push to `main`; run the tests locally with `python3 -m unittest discover -s tests -p 'test_*.py'`.

--- a/README.md
+++ b/README.md
@@ -132,7 +132,9 @@ Run one command:
 ./ringer.py install-agent
 ```
 
-It installs the ringer skill — the orchestrator playbook — user-level for Claude Code, and registers two gentle hooks: a Bash hook that notices model-calling or harness commands running outside a live Ringer run, and an edit-loop hook that notices batch editing without a run. Each hook nudges ONCE per session, pointing the agent at the skill.
+It installs the Ringer skill at the universal `.agents` path, keeps Claude Code compatibility, and registers two gentle hooks for Claude Code and Codex.
+A Bash hook notices model-calling or harness commands running outside a live Ringer run, and an edit-loop hook notices batch editing without a run.
+Each hook nudges once per session, pointing the agent at the skill.
 
 The hooks never block anything. A user who says "just do it inline" is obeyed; uninstall with `./ringer.py uninstall-agent`.
 

--- a/README.md
+++ b/README.md
@@ -136,9 +136,13 @@ It installs the Ringer skill at the universal `.agents` path, keeps Claude Code 
 A Bash hook notices model-calling or harness commands running outside a live Ringer run, and an edit-loop hook notices batch editing without a run.
 Each hook nudges once per session, pointing the agent at the skill.
 
+The hook script is installed as a copy (`~/.local/share/ringer/hooks/` for user scope, `./.agents/ringer/hooks/` with `--project`), so the hooks keep working even if the clone moves.
+Re-run `./ringer.py install-agent` after updating the repo; it refreshes the copy and replaces any stale hook registrations in place.
+
 The hooks never block anything. A user who says "just do it inline" is obeyed; uninstall with `./ringer.py uninstall-agent`.
 
 For CI and evals, `config.sample.toml` includes `[engines.mock]` so the enforcement stack can be tested without an API bill.
+The repo's own CI (`.github/workflows/test.yml`) runs the Python test suite and a Ringside `cargo check` on every pull request and push to `main`; run the tests locally with `python3 -m unittest discover -s tests -p 'test_*.py'`.
 
 ## Engines are pluggable
 

--- a/README.md
+++ b/README.md
@@ -183,6 +183,8 @@ opencode auth login   # select OpenRouter, paste the key
 
 Route with per-task `"engine": "opencode"`, pick the model with per-task `"model": "openrouter/<any-model>"`, and set reasoning effort via `engine_args`: `["--variant", "low|high|max"]`. A sensible split: mechanical or tightly-specced tasks on the cheap lane, gnarly ones on your frontier engine — the executed check catches shortfalls either way, and `swarm_runs` rows tell you whether the cheap lane's pass rate holds.
 
+If you run several lanes, it helps to give the tiers stable local names. The shipped Ringer skill references three optional aliases — **Sol** (frontier: decomposition, architecture, rescues), **Terra** (workhorse: implementation, debugging, review), and **Luna** (cheap: mechanical edits, tests, verification with an exact check) — but these are operator-defined: names you choose to map to your own engine and `model` values in `~/.config/ringer/config.toml`, not shipped model IDs. Ringer does not resolve them, and the skill's alias guidance applies only if your local configuration defines them; without the aliases, apply the same tier split with explicit `engine`/`model` values.
+
 ### The plan lane: Grok Build CLI
 
 If you already pay for SuperGrok or X Premium Plus, Grok Build is a second flat-rate worker lane — no per-token bill:

--- a/config.sample.toml
+++ b/config.sample.toml
@@ -7,8 +7,18 @@
 # value > short hostname.
 # identity_default = "codex-mini"
 
-# State files live under <state_dir>/runs/<run_id>.json.
+# Run state files live under <state_dir>/runs/<run_id>.json. Terminal non-PASS
+# task escalations append to <state_dir>/escalations.jsonl.
+# Plain `status` writes <state_dir>/escalations.jsonl.review.json so a later
+# clear acknowledges exactly the displayed records. The cross-run recovery
+# registry lives at <RINGER_HOME>/active-runs.json (default
+# ~/.ringer/active-runs.json).
 state_dir = "~/.ringer"
+
+# Environment override: a FAIL whose worker exits nonzero in less than 10,000
+# ms of worker time is launch-class and does not retry.
+# RINGER_LAUNCH_CLASS_THRESHOLD_MS accepts integer milliseconds; values below
+# 0 clamp to 0 and disable the guard, while non-integers use 10,000.
 
 # First localhost port tried for the per-run dashboard. The server will scan the
 # next 49 ports if this one is busy.
@@ -98,6 +108,8 @@ token_regex = "tokens\\s+used\\s*:?\\s*([0-9][0-9,]*)"
 # token_regex = "\"total_tokens\"\\s*:\\s*([0-9]+)"
 
 # For CI, acceptance evals, and trying Ringer without an API bill.
+# Set RINGER_LAUNCH_CLASS_THRESHOLD_MS=0 when an instant nonzero mock failure
+# must exercise the retry path instead of the launch guard.
 # [engines.mock]
 # bin = "python3"
 # args_template = [
@@ -113,8 +125,12 @@ token_regex = "tokens\\s+used\\s*:?\\s*([0-9][0-9,]*)"
 # default: GLM-5.2 (z-ai/glm-5.2, roughly $0.74/M input, $2.33/M output as of
 # 2026-07) — the cheap-intelligence lane.
 # OpenCode has no OS sandbox, so `bin` points at engines/opencode-sandboxed.sh
-# (macOS Seatbelt: network + reads open, writes confined to the task dir, a
-# per-run scratch dir, and OpenCode's state/config dirs). Auth: put your
+# (macOS Seatbelt: network open; reads open except a credential deny-list;
+# writes confined to the task dir, a per-run scratch dir, and OpenCode's
+# state/config dirs). Extend the read deny-list one path per line through
+# ~/.config/ringer/opencode-deny-read.txt, select another file with
+# RINGER_OPENCODE_DENY_READ_FILE, or add colon-separated paths with
+# RINGER_OPENCODE_DENY_READ. Auth: put your
 # OpenRouter key where your OpenCode version expects it — commonly
 # ~/.local/share/opencode/auth.json ({"openrouter": {"type": "api", "key": "..."}});
 # confirm the path with your installed CLI.

--- a/docs/MODEL-NOTES.md
+++ b/docs/MODEL-NOTES.md
@@ -265,6 +265,8 @@ checks and raw logs support — no vibes, no worker self-reports.
   before blaming the model.
 - 2026-07-06 — opencode sqlite "database is locked" again with just 2
   simultaneous opencode spawns (page-news + page-about-faq); retry absorbed it.
+- 2026-07-13: The launch guard changes the current response to the two sqlite-lock observations above.
+  A `FAIL` with a nonzero worker exit under the default 10-second threshold now stops without retry, so stagger or repair OpenCode startup instead of expecting the retry lane to absorb it.
 
 ## codex (2026-07-06, bench-operator-proofing)
 - 8/8 code-feature tasks passed attempt 1 across 3 rounds (worktrees mode, Python harness refactor; 108k-406k tokens/task). Specs embedded the approved architecture doc + exact file ownership; checks built fresh uv venvs and ran the full pytest suite.

--- a/engines/opencode-sandboxed.sh
+++ b/engines/opencode-sandboxed.sh
@@ -3,7 +3,8 @@
 #
 # OpenCode has no OS-level sandbox of its own — its --dangerously-skip-permissions
 # flag (required for headless runs) disables ALL of its interactive approval
-# prompts. This wrapper supplies the real containment: full network and reads,
+# prompts. This wrapper supplies the real containment: full network; reads open
+# EXCEPT a deny-list of credential/secret paths (see DENY_READ_CANDIDATES below);
 # writes confined to the task dir, a per-run scratch/cache dir, and OpenCode's
 # own state dirs.
 #
@@ -68,6 +69,83 @@ cat > "$PROFILE" <<'SBEOF'
   (literal "/dev/tty"))
 SBEOF
 
+# Read-surface hardening. The worker keeps network and broad filesystem reads
+# (it must read repos and call APIs), but nothing a worker does should require
+# reading the operator's credentials. Seatbelt evaluates rules in order and the
+# LAST match wins, so denies appended after `(allow default)` close the read
+# hole for the paths below. Values reach the profile as -D parameters, never
+# interpolated into profile text, so a path containing quotes or parens cannot
+# inject rules. Missing paths are skipped.
+#
+# Machine-local additions (cloud drives, work directories, extra key stores):
+#   - one path per line in the file selected by RINGER_OPENCODE_DENY_READ_FILE
+#     (default ~/.config/ringer/opencode-deny-read.txt; '#' comments and leading
+#     '~' both supported), or
+#   - RINGER_OPENCODE_DENY_READ, colon-separated.
+DENY_READ_CANDIDATES=(
+  "$HOME/.ssh"
+  "$HOME/.aws"
+  "$HOME/.gnupg"
+  "$HOME/.secrets"
+  "$HOME/.netrc"
+  "$HOME/.npmrc"
+  "$HOME/.config/gh"
+  "$HOME/.config/gcloud"
+  "$HOME/.codex"
+  "$HOME/.claude"
+  "$HOME/Library/Keychains"
+)
+DENY_READ_FILE="${RINGER_OPENCODE_DENY_READ_FILE:-$HOME/.config/ringer/opencode-deny-read.txt}"
+if [ -f "$DENY_READ_FILE" ]; then
+  while IFS= read -r _line || [ -n "$_line" ]; do
+    case "$_line" in ''|'#'*) continue ;; esac
+    DENY_READ_CANDIDATES+=("${_line/#\~/$HOME}")
+  done < "$DENY_READ_FILE"
+fi
+if [ -n "${RINGER_OPENCODE_DENY_READ:-}" ]; then
+  _saved_ifs="$IFS"; IFS=':'
+  for _extra in $RINGER_OPENCODE_DENY_READ; do
+    [ -n "$_extra" ] && DENY_READ_CANDIDATES+=("${_extra/#\~/$HOME}")
+  done
+  IFS="$_saved_ifs"
+fi
+
+DENY_ARGS=()
+_deny_rules=""
+_deny_idx=0
+_deny_seen="|"
+
+# Seatbelt matches the path as PRESENTED, not the symlink-resolved path
+# (verified on macOS: with only realpath(p) denied, a cloud-drive symlink like
+# "~/OneDrive" -> ~/Library/CloudStorage/OneDrive-... stays readable through
+# the symlinked spelling). So deny BOTH the path as written and its resolved
+# target; denying only one leaves the other as a bypass.
+# subpath covers directories and their contents; literal covers plain files.
+_add_deny() {
+  case "$_deny_seen" in *"|$1|"*) return 0 ;; esac
+  _deny_seen="${_deny_seen}$1|"
+  DENY_ARGS+=( -D "DENY_READ_${_deny_idx}=$1" )
+  _deny_rules="${_deny_rules}  (subpath (param \"DENY_READ_${_deny_idx}\"))
+  (literal (param \"DENY_READ_${_deny_idx}\"))
+"
+  _deny_idx=$((_deny_idx + 1))
+  return 0
+}
+
+for _p in "${DENY_READ_CANDIDATES[@]}"; do
+  [ -e "$_p" ] || continue
+  _add_deny "$_p"
+  _real="$(/bin/realpath "$_p" 2>/dev/null || true)"
+  if [ -n "$_real" ] && [ "$_real" != "$_p" ]; then _add_deny "$_real"; fi
+done
+if [ "$_deny_idx" -gt 0 ]; then
+  {
+    printf '(deny file-read*\n'
+    printf '%s' "$_deny_rules"
+    printf ')\n'
+  } >> "$PROFILE"
+fi
+
 export TMPDIR="$SCRATCH"
 export XDG_CACHE_HOME="$SCRATCH/cache"
 mkdir -p "$XDG_CACHE_HOME"
@@ -81,6 +159,7 @@ set +e
   -D "OC_SHARE=$HOME/.local/share/opencode" \
   -D "OC_STATE=$HOME/.local/state/opencode" \
   -D "OC_CONFIG=$HOME/.config/opencode" \
+  ${DENY_ARGS[@]+"${DENY_ARGS[@]}"} \
   -f "$PROFILE" "$OPENCODE_BIN" "$@" < /dev/null
 status=$?
 set -e

--- a/hooks/ringer_nudge.py
+++ b/hooks/ringer_nudge.py
@@ -29,6 +29,10 @@ HARNESS_RE = re.compile(
     r"\.(?:mjs|js|ts|py)\b",
     re.IGNORECASE,
 )
+PATCH_PATH_RE = re.compile(
+    r"^\*\*\*\s+(?:Add|Update|Delete)\s+File:\s*(.+?)\s*$",
+    re.MULTILINE,
+)
 
 
 def ringer_home() -> Path:
@@ -138,6 +142,27 @@ def command_references_active_workdir(command: str, active_runs: dict[str, dict[
     return False
 
 
+def path_is_inside(path: str, root: str) -> bool:
+    try:
+        Path(path).expanduser().resolve().relative_to(Path(root).expanduser().resolve())
+    except (OSError, ValueError):
+        return False
+    return True
+
+
+def payload_is_inside_active_workdir(
+    payload: dict[str, Any], active_runs: dict[str, dict[str, Any]]
+) -> bool:
+    cwd = payload.get("cwd")
+    if not isinstance(cwd, str) or not cwd.strip():
+        return False
+    for entry in active_runs.values():
+        workdir = entry.get("workdir")
+        if isinstance(workdir, str) and workdir.strip() and path_is_inside(cwd, workdir):
+            return True
+    return False
+
+
 def should_nudge_pre_bash(payload: dict[str, Any], home: Path) -> bool:
     tool_input = payload.get("tool_input")
     if not isinstance(tool_input, dict):
@@ -151,7 +176,7 @@ def should_nudge_pre_bash(payload: dict[str, Any], home: Path) -> bool:
         return False
 
     active_runs = read_live_active_runs(home)
-    if active_runs:
+    if payload_is_inside_active_workdir(payload, active_runs):
         return False
     if command_references_active_workdir(command, active_runs):
         return False
@@ -178,17 +203,28 @@ def load_post_edit_state(path: Path) -> dict[str, Any]:
     return {"count": count, "file_paths": [str(path) for path in file_paths]}
 
 
+def edited_file_paths(payload: dict[str, Any]) -> set[str]:
+    tool_input = payload.get("tool_input")
+    if not isinstance(tool_input, dict):
+        return set()
+
+    files: set[str] = set()
+    file_path = tool_input.get("file_path")
+    if isinstance(file_path, str) and file_path.strip():
+        files.add(file_path.strip())
+
+    command = tool_input.get("command")
+    if isinstance(command, str):
+        files.update(match.strip() for match in PATCH_PATH_RE.findall(command) if match.strip())
+    return files
+
+
 def record_post_edit(payload: dict[str, Any], home: Path) -> tuple[int, int]:
     path = post_edit_state_path(home, payload.get("session_id"))
     state = load_post_edit_state(path)
     count = int(state["count"]) + 1
     files = set(str(item) for item in state["file_paths"])
-
-    tool_input = payload.get("tool_input")
-    if isinstance(tool_input, dict):
-        file_path = tool_input.get("file_path")
-        if isinstance(file_path, str) and file_path.strip():
-            files.add(file_path)
+    files.update(edited_file_paths(payload))
 
     next_state = {"count": count, "file_paths": sorted(files)}
     write_json_atomic(path, next_state)
@@ -196,10 +232,13 @@ def record_post_edit(payload: dict[str, Any], home: Path) -> tuple[int, int]:
 
 
 def should_nudge_post_edit(payload: dict[str, Any], home: Path) -> bool:
+    active_runs = read_live_active_runs(home)
+    if payload_is_inside_active_workdir(payload, active_runs):
+        return False
     count, distinct_files = record_post_edit(payload, home)
     if count < 8 or distinct_files < 3:
         return False
-    return not read_live_active_runs(home)
+    return True
 
 
 def load_stdin_payload() -> dict[str, Any] | None:

--- a/hooks/ringer_nudge.py
+++ b/hooks/ringer_nudge.py
@@ -5,6 +5,7 @@ import hashlib
 import json
 import os
 import re
+import subprocess
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
@@ -12,11 +13,31 @@ from typing import Any
 
 
 NUDGE_TEXT = (
-    "Ringer routing check: this looks like swarm-shaped work happening inline "
-    "(model call/harness/edit loop outside a live Ringer run). Load the ringer "
-    "skill and route it as a manifest — a single task is a one-task manifest. "
-    "If the user explicitly asked for inline work, proceed."
+    "Ringer advisory: this command appears to call a model provider or "
+    "conversational harness outside a live Ringer run. Do not load or launch "
+    "Ringer automatically. If the user selected Ringer or the closest repository "
+    "instructions require it, use the Ringer skill. Otherwise continue directly "
+    "and recommend Ringer at most once only when the job has at least two genuinely "
+    "independent lanes."
 )
+
+NO_MISTAKES_FIX_OWNERSHIP_STATES = {
+    "fixing",
+    "awaiting_approval",
+    "fix_review",
+}
+NO_MISTAKES_PROBE_TIMEOUT_SECONDS = 1.5
+TOON_TABLE_HEADER_RE = re.compile(
+    r"^(?P<name>[A-Za-z][A-Za-z0-9_-]*)(?:\[\d+\])?\{(?P<columns>[^}]+)\}:$"
+)
+POST_PUBLICATION_STEPS = {
+    "ci",
+    "deploy",
+    "deployment",
+    "publish",
+    "published",
+    "publication",
+}
 
 PROVIDER_RE = re.compile(
     r"(api\.anthropic\.com|api\.openai\.com|openrouter\.ai|"
@@ -28,10 +49,6 @@ HARNESS_RE = re.compile(
     r"(?:simulat|probe|smoke|harness|persona|grader|eval)\S*"
     r"\.(?:mjs|js|ts|py)\b",
     re.IGNORECASE,
-)
-PATCH_PATH_RE = re.compile(
-    r"^\*\*\*\s+(?:Add|Update|Delete)\s+File:\s*(.+?)\s*$",
-    re.MULTILINE,
 )
 
 
@@ -61,9 +78,9 @@ def pid_is_alive(pid: Any) -> bool:
 def write_json_atomic(path: Path, payload: dict[str, Any]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     tmp_path = path.with_name(f".{path.name}.{os.getpid()}.tmp")
-    with tmp_path.open("w", encoding="utf-8") as fh:
-        json.dump(payload, fh, sort_keys=True)
-        fh.write("\n")
+    with tmp_path.open("w", encoding="utf-8") as handle:
+        json.dump(payload, handle, sort_keys=True)
+        handle.write("\n")
     os.replace(tmp_path, path)
 
 
@@ -71,8 +88,8 @@ def read_live_active_runs(home: Path) -> dict[str, dict[str, Any]]:
     path = home / "active-runs.json"
     if not path.exists():
         return {}
-    with path.open("r", encoding="utf-8") as fh:
-        raw = json.load(fh)
+    with path.open("r", encoding="utf-8") as handle:
+        raw = json.load(handle)
     if not isinstance(raw, dict):
         return {}
 
@@ -92,40 +109,30 @@ def read_live_active_runs(home: Path) -> dict[str, dict[str, Any]]:
     return live
 
 
-def safe_session_id(value: Any) -> str:
-    text = str(value or "unknown-session")
-    safe = re.sub(r"[^A-Za-z0-9_.-]+", "_", text).strip("._")
-    return safe or "unknown-session"
-
-
-def state_dir(home: Path) -> Path:
-    return home / "nudge-state"
-
-
-def marker_path(home: Path, session_id: Any, event: str) -> Path:
-    key = f"{session_id}\0{event}".encode("utf-8", errors="replace")
+def marker_path(home: Path, session_id: Any) -> Path:
+    key = f"{session_id}\0pre-bash".encode("utf-8", errors="replace")
     digest = hashlib.sha256(key).hexdigest()
-    return state_dir(home) / f"{digest}.{event}.nudged"
+    return home / "nudge-state" / f"{digest}.pre-bash.nudged"
 
 
-def claim_dedupe_marker(home: Path, session_id: Any, event: str) -> bool:
-    directory = state_dir(home)
+def claim_dedupe_marker(home: Path, session_id: Any) -> bool:
+    directory = home / "nudge-state"
     directory.mkdir(parents=True, exist_ok=True)
-    marker = marker_path(home, session_id, event)
+    marker = marker_path(home, session_id)
     try:
-        with marker.open("x", encoding="utf-8") as fh:
-            fh.write(datetime.now(timezone.utc).isoformat())
-            fh.write("\n")
+        with marker.open("x", encoding="utf-8") as handle:
+            handle.write(datetime.now(timezone.utc).isoformat())
+            handle.write("\n")
     except FileExistsError:
         return False
     return True
 
 
-def output_nudge(event_name: str) -> None:
+def output_nudge() -> None:
     json.dump(
         {
             "hookSpecificOutput": {
-                "hookEventName": event_name,
+                "hookEventName": "PreToolUse",
                 "additionalContext": NUDGE_TEXT,
             }
         },
@@ -134,7 +141,9 @@ def output_nudge(event_name: str) -> None:
     sys.stdout.write("\n")
 
 
-def command_references_active_workdir(command: str, active_runs: dict[str, dict[str, Any]]) -> bool:
+def command_references_active_workdir(
+    command: str, active_runs: dict[str, dict[str, Any]]
+) -> bool:
     for entry in active_runs.values():
         workdir = str(entry.get("workdir") or "").strip()
         if workdir and workdir in command:
@@ -163,6 +172,109 @@ def payload_is_inside_active_workdir(
     return False
 
 
+def current_branch(cwd: str) -> str | None:
+    try:
+        result = subprocess.run(
+            ["git", "-C", cwd, "branch", "--show-current"],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            timeout=NO_MISTAKES_PROBE_TIMEOUT_SECONDS,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    branch = result.stdout.strip()
+    return branch or None
+
+
+def normalize_no_mistakes_value(value: str) -> str:
+    return value.strip().lower().replace("-", "_")
+
+
+def toon_mapping(output: str, mapping_name: str) -> dict[str, str]:
+    values: dict[str, str] = {}
+    in_mapping = False
+    for line in output.splitlines():
+        stripped = line.strip()
+        if not line[:1].isspace():
+            if stripped == f"{mapping_name}:":
+                in_mapping = True
+                continue
+            if in_mapping:
+                break
+        if not in_mapping:
+            continue
+        key, separator, value = stripped.partition(":")
+        if separator:
+            values[normalize_no_mistakes_value(key)] = value.strip().lower()
+    return values
+
+
+def toon_rows(output: str, table_name: str) -> list[dict[str, str]]:
+    rows: list[dict[str, str]] = []
+    columns: list[str] | None = None
+    for line in output.splitlines():
+        header = TOON_TABLE_HEADER_RE.match(line.strip())
+        if header:
+            if normalize_no_mistakes_value(header.group("name")) == table_name:
+                columns = [
+                    normalize_no_mistakes_value(column)
+                    for column in header.group("columns").split(",")
+                ]
+            else:
+                columns = None
+            continue
+        if columns is None or not line.strip() or ":" in line:
+            continue
+        values = [value.strip().lower() for value in line.split(",")]
+        if len(values) == len(columns):
+            rows.append(dict(zip(columns, values)))
+    return rows
+
+
+def no_mistakes_owns_branch(output: str, branch: str) -> bool:
+    run = toon_mapping(output, "run")
+    if run.get("branch") != branch.strip().lower():
+        return False
+    for step in toon_rows(output, "steps"):
+        name = normalize_no_mistakes_value(step.get("step", ""))
+        status = normalize_no_mistakes_value(step.get("status", ""))
+        if name == "review" and status == "running":
+            return True
+        if name and name not in POST_PUBLICATION_STEPS and status in NO_MISTAKES_FIX_OWNERSHIP_STATES:
+            return True
+    return False
+
+
+def no_mistakes_owns_current_branch(payload: dict[str, Any]) -> bool:
+    cwd = payload.get("cwd")
+    if not isinstance(cwd, str) or not cwd.strip():
+        return False
+    branch = current_branch(cwd)
+    if branch is None:
+        return False
+    try:
+        result = subprocess.run(
+            ["no-mistakes", "axi", "status"],
+            cwd=cwd,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            timeout=NO_MISTAKES_PROBE_TIMEOUT_SECONDS,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+    if result.returncode != 0:
+        return False
+    return no_mistakes_owns_branch(result.stdout, branch)
+
+
 def should_nudge_pre_bash(payload: dict[str, Any], home: Path) -> bool:
     tool_input = payload.get("tool_input")
     if not isinstance(tool_input, dict):
@@ -170,73 +282,17 @@ def should_nudge_pre_bash(payload: dict[str, Any], home: Path) -> bool:
     command = tool_input.get("command")
     if not isinstance(command, str) or not command.strip():
         return False
-    if "ringer.py" in command:
+    if "ringer.py" in command or "/ringer " in command:
         return False
     if not (PROVIDER_RE.search(command) or HARNESS_RE.search(command)):
+        return False
+    if no_mistakes_owns_current_branch(payload):
         return False
 
     active_runs = read_live_active_runs(home)
     if payload_is_inside_active_workdir(payload, active_runs):
         return False
     if command_references_active_workdir(command, active_runs):
-        return False
-    return True
-
-
-def post_edit_state_path(home: Path, session_id: Any) -> Path:
-    return state_dir(home) / f"{safe_session_id(session_id)}.json"
-
-
-def load_post_edit_state(path: Path) -> dict[str, Any]:
-    if not path.exists():
-        return {"count": 0, "file_paths": []}
-    with path.open("r", encoding="utf-8") as fh:
-        raw = json.load(fh)
-    if not isinstance(raw, dict):
-        return {"count": 0, "file_paths": []}
-    count = raw.get("count")
-    file_paths = raw.get("file_paths")
-    if not isinstance(count, int):
-        count = 0
-    if not isinstance(file_paths, list):
-        file_paths = []
-    return {"count": count, "file_paths": [str(path) for path in file_paths]}
-
-
-def edited_file_paths(payload: dict[str, Any]) -> set[str]:
-    tool_input = payload.get("tool_input")
-    if not isinstance(tool_input, dict):
-        return set()
-
-    files: set[str] = set()
-    file_path = tool_input.get("file_path")
-    if isinstance(file_path, str) and file_path.strip():
-        files.add(file_path.strip())
-
-    command = tool_input.get("command")
-    if isinstance(command, str):
-        files.update(match.strip() for match in PATCH_PATH_RE.findall(command) if match.strip())
-    return files
-
-
-def record_post_edit(payload: dict[str, Any], home: Path) -> tuple[int, int]:
-    path = post_edit_state_path(home, payload.get("session_id"))
-    state = load_post_edit_state(path)
-    count = int(state["count"]) + 1
-    files = set(str(item) for item in state["file_paths"])
-    files.update(edited_file_paths(payload))
-
-    next_state = {"count": count, "file_paths": sorted(files)}
-    write_json_atomic(path, next_state)
-    return count, len(files)
-
-
-def should_nudge_post_edit(payload: dict[str, Any], home: Path) -> bool:
-    active_runs = read_live_active_runs(home)
-    if payload_is_inside_active_workdir(payload, active_runs):
-        return False
-    count, distinct_files = record_post_edit(payload, home)
-    if count < 8 or distinct_files < 3:
         return False
     return True
 
@@ -248,26 +304,17 @@ def load_stdin_payload() -> dict[str, Any] | None:
 
 
 def run(argv: list[str]) -> int:
-    if len(argv) != 2:
+    if len(argv) != 2 or argv[1] != "pre-bash":
         return 0
-    mode = argv[1]
-    if mode not in {"pre-bash", "post-edit"}:
-        return 0
-
     payload = load_stdin_payload()
     if payload is None:
         return 0
 
     home = ringer_home()
-    session_id = payload.get("session_id")
-
-    if mode == "pre-bash":
-        if should_nudge_pre_bash(payload, home) and claim_dedupe_marker(home, session_id, mode):
-            output_nudge("PreToolUse")
-        return 0
-
-    if should_nudge_post_edit(payload, home) and claim_dedupe_marker(home, session_id, mode):
-        output_nudge("PostToolUse")
+    if should_nudge_pre_bash(payload, home) and claim_dedupe_marker(
+        home, payload.get("session_id")
+    ):
+        output_nudge()
     return 0
 
 

--- a/hud/Cargo.lock
+++ b/hud/Cargo.lock
@@ -1479,6 +1479,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-range"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21dec9db110f5f872ed9699c3ecf50cf16f423502706ba5c72462e28d3157573"
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3295,6 +3301,7 @@ dependencies = [
  "gtk",
  "heck 0.5.0",
  "http",
+ "http-range",
  "image",
  "jni",
  "libc",

--- a/hud/Cargo.toml
+++ b/hud/Cargo.toml
@@ -13,7 +13,7 @@ tauri-build = { version = "2.5.1", features = [] }
 chrono = { version = "0.4.41", default-features = false, features = ["clock", "std"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-tauri = { version = "2.11.5", features = ["image-png", "macos-private-api", "tray-icon"] }
+tauri = { version = "2.11.5", features = ["image-png", "macos-private-api", "protocol-asset", "tray-icon"] }
 tauri-plugin-single-instance = "2.4.2"
 tauri-plugin-window-state = "2.4.1"
 toml = "0.9.12"

--- a/ringer.py
+++ b/ringer.py
@@ -7853,7 +7853,7 @@ def agent_scope_root(project: bool) -> Path:
 
 
 def ringer_skill_source() -> Path:
-    return repo_root() / ".claude" / "skills" / "ringer" / "SKILL.md"
+    return repo_root() / ".claude" / "skills" / "ringer"
 
 
 def ringer_hook_source() -> Path:
@@ -7886,16 +7886,16 @@ def skill_targets(project: bool) -> list[Path]:
     base = agent_scope_root(project)
     return unique_paths(
         [
-            base / ".agents" / "skills" / "ringer" / "SKILL.md",
-            claude_root(project) / "skills" / "ringer" / "SKILL.md",
+            base / ".agents" / "skills" / "ringer",
+            claude_root(project) / "skills" / "ringer",
         ]
     )
 
 
-def hook_config_specs(project: bool) -> list[tuple[Path, str]]:
+def hook_config_paths(project: bool) -> list[Path]:
     return [
-        (claude_root(project) / "settings.json", "Edit|Write"),
-        (codex_root(project) / "hooks.json", "apply_patch"),
+        claude_root(project) / "settings.json",
+        codex_root(project) / "hooks.json",
     ]
 
 
@@ -7972,12 +7972,16 @@ def merge_ringer_hook(settings: dict[str, Any], event: str, matcher: str, comman
     return True
 
 
-def remove_ringer_hooks(settings: dict[str, Any]) -> int:
+def remove_ringer_hooks(
+    settings: dict[str, Any], events: set[str] | None = None
+) -> int:
     hooks = settings.get("hooks")
     if not isinstance(hooks, dict):
         return 0
     removed = 0
     for event in list(hooks):
+        if events is not None and event not in events:
+            continue
         groups = hooks[event]
         if not isinstance(groups, list):
             continue
@@ -8011,12 +8015,14 @@ def remove_ringer_hooks(settings: dict[str, Any]) -> int:
 
 def install_agent(project: bool = False) -> int:
     skill_source = ringer_skill_source()
-    if not skill_source.exists():
+    if not (skill_source / "SKILL.md").exists():
         raise ValueError(f"ringer skill source not found: {skill_source}")
     targets = skill_targets(project)
     for skill_target in targets:
+        if skill_target.exists():
+            shutil.rmtree(skill_target)
         skill_target.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copy2(skill_source, skill_target)
+        shutil.copytree(skill_source, skill_target)
 
     hook_source = ringer_hook_source()
     if not hook_source.exists():
@@ -8026,20 +8032,14 @@ def install_agent(project: bool = False) -> int:
     shutil.copy2(hook_source, hook_target)
 
     hook_results: list[tuple[Path, bool]] = []
-    for settings_path, post_matcher in hook_config_specs(project):
+    for settings_path in hook_config_paths(project):
         settings = load_settings(settings_path)
-        changed = False
+        changed = bool(remove_ringer_hooks(settings, events={"PostToolUse"}))
         changed |= merge_ringer_hook(
             settings,
             "PreToolUse",
             "Bash",
             ringer_hook_command("pre-bash", hook_target),
-        )
-        changed |= merge_ringer_hook(
-            settings,
-            "PostToolUse",
-            post_matcher,
-            ringer_hook_command("post-edit", hook_target),
         )
         if changed or not settings_path.exists():
             write_settings(settings_path, settings)
@@ -8048,7 +8048,7 @@ def install_agent(project: bool = False) -> int:
     scope = "project" if project else "user"
     print(f"Installed ringer agent for {scope} scope.")
     for skill_target in targets:
-        print(f"Skill: {skill_target}")
+        print(f"Skill directory: {skill_target}")
     print(f"Hook script: {hook_target}")
     for settings_path, changed in hook_results:
         status = "added" if changed else "already present"
@@ -8058,7 +8058,7 @@ def install_agent(project: bool = False) -> int:
 
 def uninstall_agent(project: bool = False) -> int:
     removed_hooks = 0
-    for settings_path, _ in hook_config_specs(project):
+    for settings_path in hook_config_paths(project):
         if not settings_path.exists():
             continue
         settings = load_settings(settings_path)
@@ -8069,9 +8069,8 @@ def uninstall_agent(project: bool = False) -> int:
 
     removed_skills = 0
     for skill_target in skill_targets(project):
-        skill_dir = skill_target.parent
-        if skill_dir.exists():
-            shutil.rmtree(skill_dir)
+        if skill_target.exists():
+            shutil.rmtree(skill_target)
             removed_skills += 1
 
     hook_target = installed_hook_path(project)

--- a/ringer.py
+++ b/ringer.py
@@ -7940,25 +7940,23 @@ def merge_ringer_hook(settings: dict[str, Any], event: str, matcher: str, comman
     groups = hooks.setdefault(event, [])
     if not isinstance(groups, list):
         raise ValueError(f"settings hooks.{event} field must be a JSON array")
+    kept_groups: list[Any] = []
     for group in groups:
         if not isinstance(group, dict):
+            kept_groups.append(group)
             continue
         handlers = group.get("hooks")
         if not isinstance(handlers, list):
+            kept_groups.append(group)
             continue
-        ringer_handlers = [handler for handler in handlers if hook_command_contains(handler)]
-        if not ringer_handlers:
-            continue
-        if len(handlers) == 1:
-            expected = {"type": "command", "command": command}
-            if group.get("matcher") == matcher and handlers[0] == expected:
-                return False
-            group["matcher"] = matcher
-            group["hooks"] = [expected]
-            return True
-        group["hooks"] = [handler for handler in handlers if not hook_command_contains(handler)]
-        break
-    groups.append(
+        kept_handlers = [handler for handler in handlers if not hook_command_contains(handler)]
+        if len(kept_handlers) == len(handlers):
+            kept_groups.append(group)
+        elif kept_handlers:
+            new_group = dict(group)
+            new_group["hooks"] = kept_handlers
+            kept_groups.append(new_group)
+    kept_groups.append(
         {
             "matcher": matcher,
             "hooks": [
@@ -7969,6 +7967,9 @@ def merge_ringer_hook(settings: dict[str, Any], event: str, matcher: str, comman
             ],
         }
     )
+    if kept_groups == groups:
+        return False
+    hooks[event] = kept_groups
     return True
 
 

--- a/ringer.py
+++ b/ringer.py
@@ -7845,13 +7845,59 @@ def claude_root(project: bool) -> Path:
     return (Path.cwd() if project else Path.home()) / ".claude"
 
 
+def codex_root(project: bool) -> Path:
+    return (Path.cwd() if project else Path.home()) / ".codex"
+
+
+def agent_scope_root(project: bool) -> Path:
+    return Path.cwd() if project else Path.home()
+
+
 def ringer_skill_source() -> Path:
     return repo_root() / ".claude" / "skills" / "ringer" / "SKILL.md"
 
 
-def ringer_hook_command(action: str) -> str:
-    hook_path = repo_root() / "hooks" / "ringer_nudge.py"
+def ringer_hook_source() -> Path:
+    return repo_root() / "hooks" / "ringer_nudge.py"
+
+
+def installed_hook_path(project: bool) -> Path:
+    if project:
+        return agent_scope_root(project) / ".agents" / "ringer" / "hooks" / "ringer_nudge.py"
+    return Path.home() / ".local" / "share" / "ringer" / "hooks" / "ringer_nudge.py"
+
+
+def ringer_hook_command(action: str, hook_path: Path) -> str:
     return f"python3 {shlex.quote(str(hook_path))} {action}"
+
+
+def unique_paths(paths: Iterable[Path]) -> list[Path]:
+    unique: list[Path] = []
+    seen: set[Path] = set()
+    for path in paths:
+        resolved = path.resolve(strict=False)
+        if resolved in seen:
+            continue
+        seen.add(resolved)
+        unique.append(path)
+    return unique
+
+
+def skill_targets(project: bool) -> list[Path]:
+    base = agent_scope_root(project)
+    return unique_paths(
+        [
+            base / ".agents" / "skills" / "ringer" / "SKILL.md",
+            claude_root(project) / "skills" / "ringer" / "SKILL.md",
+        ]
+    )
+
+
+def hook_config_specs(project: bool) -> list[tuple[Path, str]]:
+    return [
+        (claude_root(project) / "settings.json", "Edit|Write"),
+        (codex_root(project) / "hooks.json", "apply_patch"),
+    ]
 
 
 def backup_file(path: Path) -> Path | None:
@@ -7887,18 +7933,6 @@ def hook_command_contains(value: Any, needle: str = "ringer_nudge.py") -> bool:
     return isinstance(value, dict) and needle in str(value.get("command", ""))
 
 
-def event_has_ringer_hook(groups: Any) -> bool:
-    if not isinstance(groups, list):
-        return False
-    for group in groups:
-        if not isinstance(group, dict):
-            continue
-        handlers = group.get("hooks")
-        if isinstance(handlers, list) and any(hook_command_contains(handler) for handler in handlers):
-            return True
-    return False
-
-
 def merge_ringer_hook(settings: dict[str, Any], event: str, matcher: str, command: str) -> bool:
     hooks = settings.setdefault("hooks", {})
     if not isinstance(hooks, dict):
@@ -7906,8 +7940,24 @@ def merge_ringer_hook(settings: dict[str, Any], event: str, matcher: str, comman
     groups = hooks.setdefault(event, [])
     if not isinstance(groups, list):
         raise ValueError(f"settings hooks.{event} field must be a JSON array")
-    if event_has_ringer_hook(groups):
-        return False
+    for group in groups:
+        if not isinstance(group, dict):
+            continue
+        handlers = group.get("hooks")
+        if not isinstance(handlers, list):
+            continue
+        ringer_handlers = [handler for handler in handlers if hook_command_contains(handler)]
+        if not ringer_handlers:
+            continue
+        if len(handlers) == 1:
+            expected = {"type": "command", "command": command}
+            if group.get("matcher") == matcher and handlers[0] == expected:
+                return False
+            group["matcher"] = matcher
+            group["hooks"] = [expected]
+            return True
+        group["hooks"] = [handler for handler in handlers if not hook_command_contains(handler)]
+        break
     groups.append(
         {
             "matcher": matcher,
@@ -7960,62 +8010,83 @@ def remove_ringer_hooks(settings: dict[str, Any]) -> int:
 
 
 def install_agent(project: bool = False) -> int:
-    root = claude_root(project)
     skill_source = ringer_skill_source()
-    skill_target = root / "skills" / "ringer" / "SKILL.md"
     if not skill_source.exists():
         raise ValueError(f"ringer skill source not found: {skill_source}")
-    skill_target.parent.mkdir(parents=True, exist_ok=True)
-    shutil.copy2(skill_source, skill_target)
+    targets = skill_targets(project)
+    for skill_target in targets:
+        skill_target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(skill_source, skill_target)
 
-    settings_path = root / "settings.json"
-    settings = load_settings(settings_path)
-    changed = False
-    changed |= merge_ringer_hook(
-        settings,
-        "PreToolUse",
-        "Bash",
-        ringer_hook_command("pre-bash"),
-    )
-    changed |= merge_ringer_hook(
-        settings,
-        "PostToolUse",
-        "Edit|Write",
-        ringer_hook_command("post-edit"),
-    )
-    if changed or not settings_path.exists():
-        write_settings(settings_path, settings)
+    hook_source = ringer_hook_source()
+    if not hook_source.exists():
+        raise ValueError(f"ringer hook source not found: {hook_source}")
+    hook_target = installed_hook_path(project)
+    hook_target.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(hook_source, hook_target)
+
+    hook_results: list[tuple[Path, bool]] = []
+    for settings_path, post_matcher in hook_config_specs(project):
+        settings = load_settings(settings_path)
+        changed = False
+        changed |= merge_ringer_hook(
+            settings,
+            "PreToolUse",
+            "Bash",
+            ringer_hook_command("pre-bash", hook_target),
+        )
+        changed |= merge_ringer_hook(
+            settings,
+            "PostToolUse",
+            post_matcher,
+            ringer_hook_command("post-edit", hook_target),
+        )
+        if changed or not settings_path.exists():
+            write_settings(settings_path, settings)
+        hook_results.append((settings_path, changed))
 
     scope = "project" if project else "user"
     print(f"Installed ringer agent for {scope} scope.")
-    print(f"Skill: {skill_target}")
-    if changed:
-        print(f"Hooks: added PreToolUse Bash and PostToolUse Edit|Write in {settings_path}")
-    else:
-        print(f"Hooks: already present in {settings_path}")
+    for skill_target in targets:
+        print(f"Skill: {skill_target}")
+    print(f"Hook script: {hook_target}")
+    for settings_path, changed in hook_results:
+        status = "added" if changed else "already present"
+        print(f"Hooks: {status} in {settings_path}")
     return 0
 
 
 def uninstall_agent(project: bool = False) -> int:
-    root = claude_root(project)
-    settings_path = root / "settings.json"
     removed_hooks = 0
-    if settings_path.exists():
+    for settings_path, _ in hook_config_specs(project):
+        if not settings_path.exists():
+            continue
         settings = load_settings(settings_path)
-        removed_hooks = remove_ringer_hooks(settings)
-        if removed_hooks:
+        removed = remove_ringer_hooks(settings)
+        removed_hooks += removed
+        if removed:
             write_settings(settings_path, settings)
 
-    skill_dir = root / "skills" / "ringer"
-    removed_skill = False
-    if skill_dir.exists():
-        shutil.rmtree(skill_dir)
-        removed_skill = True
+    removed_skills = 0
+    for skill_target in skill_targets(project):
+        skill_dir = skill_target.parent
+        if skill_dir.exists():
+            shutil.rmtree(skill_dir)
+            removed_skills += 1
+
+    hook_target = installed_hook_path(project)
+    removed_hook_script = hook_target.exists()
+    if removed_hook_script:
+        hook_target.unlink()
+        for directory in (hook_target.parent, hook_target.parent.parent):
+            with contextlib.suppress(OSError):
+                directory.rmdir()
 
     scope = "project" if project else "user"
     print(f"Uninstalled ringer agent for {scope} scope.")
     print(f"Hooks removed: {removed_hooks}")
-    print(f"Skill removed: {'yes' if removed_skill else 'no'}")
+    print(f"Skills removed: {removed_skills}")
+    print(f"Hook script removed: {'yes' if removed_hook_script else 'no'}")
     return 0
 
 
@@ -8205,11 +8276,11 @@ def build_parser() -> argparse.ArgumentParser:
     )
     demo_parser.add_argument("--dry-run", action="store_true", help="print the demo plan without spawning codex")
 
-    install_parser = subparsers.add_parser("install-agent", help="install the ringer Claude Code skill and hooks")
-    install_parser.add_argument("--project", action="store_true", help="install into ./.claude instead of ~/.claude")
+    install_parser = subparsers.add_parser("install-agent", help="install the ringer agent skill and Claude/Codex hooks")
+    install_parser.add_argument("--project", action="store_true", help="install into project-local agent config")
 
-    uninstall_parser = subparsers.add_parser("uninstall-agent", help="remove the ringer Claude Code skill and hooks")
-    uninstall_parser.add_argument("--project", action="store_true", help="remove from ./.claude instead of ~/.claude")
+    uninstall_parser = subparsers.add_parser("uninstall-agent", help="remove the ringer agent skill and Claude/Codex hooks")
+    uninstall_parser.add_argument("--project", action="store_true", help="remove from project-local agent config")
     return parser
 
 

--- a/ringer.py
+++ b/ringer.py
@@ -33,6 +33,7 @@ import tomllib
 import urllib.parse
 import urllib.request
 import webbrowser
+from collections import Counter
 from dataclasses import dataclass, field, replace as dataclass_replace
 from datetime import datetime, timezone
 from decimal import Decimal, InvalidOperation
@@ -811,6 +812,7 @@ class TaskRuntime:
     last_check_returncode: int | None = None
     last_check_timed_out: bool = False
     last_check_output: str = ""
+    failure_class: str | None = None
 
     def elapsed_s(self, now: float) -> float:
         if self.started_at_monotonic is None:
@@ -825,6 +827,7 @@ class WorkerResult:
     timed_out: bool
     tokens: int | None
     error: str | None = None
+    failure_class: str | None = None
 
 
 @dataclass(frozen=True)
@@ -1010,6 +1013,7 @@ class StateWriter:
                         "elapsed_s": round(runtime.elapsed_s(now), 1),
                         "tokens": runtime.tokens,
                         "attempts": runtime.attempts,
+                        "failure_class": runtime.failure_class,
                         "children": ProcessTree.count_named_descendants(
                             runtime.worker_pid, children, commands, process_name
                         ),
@@ -1784,6 +1788,27 @@ def active_runs_path() -> Path:
     return ringer_home() / "active-runs.json"
 
 
+def active_runs_lock_path() -> Path:
+    path = active_runs_path()
+    return path.with_name(path.name + ".lock")
+
+
+@contextlib.contextmanager
+def exclusive_file_lock(path: Path) -> Iterable[None]:
+    try:
+        import fcntl
+    except ImportError:
+        yield
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a+b") as fh:
+        fcntl.flock(fh.fileno(), fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
+
+
 def pid_is_alive(pid: int) -> bool:
     if pid <= 0:
         return False
@@ -1814,43 +1839,182 @@ def _read_active_runs_raw(path: Path) -> dict[str, dict[str, Any]]:
     return runs
 
 
-def _prune_active_runs(runs: dict[str, dict[str, Any]]) -> dict[str, dict[str, Any]]:
-    pruned: dict[str, dict[str, Any]] = {}
-    for run_id, entry in runs.items():
-        pid = entry.get("pid")
-        if isinstance(pid, bool):
+def _normalize_active_run(entry: dict[str, Any]) -> dict[str, Any]:
+    pid = entry.get("pid")
+    try:
+        pid_int = 0 if isinstance(pid, bool) else int(pid)
+    except (TypeError, ValueError):
+        pid_int = 0
+    normalized: dict[str, Any] = {
+        "pid": pid_int,
+        "identity": str(entry.get("identity", "")),
+        "run_name": str(entry.get("run_name", "")),
+        "workdir": str(entry.get("workdir", "")),
+        "started_at": str(entry.get("started_at", "")),
+    }
+    for key in ("state_dir", "state_path"):
+        value = entry.get(key)
+        if isinstance(value, str) and value:
+            normalized[key] = value
+    tasks = entry.get("tasks")
+    if isinstance(tasks, list):
+        normalized_tasks: list[dict[str, str]] = []
+        for task in tasks:
+            if not isinstance(task, dict):
+                continue
+            key = str(task.get("key", "")).strip()
+            if not key:
+                continue
+            normalized_tasks.append(
+                {
+                    "key": key,
+                    "log_path": str(task.get("log_path", "")),
+                }
+            )
+        if normalized_tasks:
+            normalized["tasks"] = normalized_tasks
+    return normalized
+
+
+def _read_dead_run_state(entry: dict[str, Any]) -> dict[str, Any]:
+    raw_path = entry.get("state_path")
+    if not isinstance(raw_path, str) or not raw_path:
+        return {}
+    try:
+        data = json.loads(Path(raw_path).read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _dead_run_task_records(entry: dict[str, Any], state: dict[str, Any]) -> list[dict[str, Any]]:
+    by_key: dict[str, dict[str, Any]] = {}
+    for source in (entry.get("tasks"), state.get("tasks")):
+        if not isinstance(source, list):
             continue
+        for task in source:
+            if not isinstance(task, dict):
+                continue
+            key = str(task.get("key", "")).strip()
+            if key:
+                by_key[key] = {**by_key.get(key, {}), **task}
+    return list(by_key.values())
+
+
+def _dead_run_state_dir(entry: dict[str, Any]) -> Path:
+    raw_state_dir = entry.get("state_dir")
+    if isinstance(raw_state_dir, str) and raw_state_dir:
+        return Path(raw_state_dir)
+    raw_state_path = entry.get("state_path")
+    return Path(raw_state_path).parent.parent if raw_state_path else ringer_home()
+
+
+def _dead_run_escalations(run_id: str, entry: dict[str, Any]) -> tuple[Path, list[dict[str, Any]]]:
+    state = _read_dead_run_state(entry)
+    state_dir = _dead_run_state_dir(entry)
+    tasks = _dead_run_task_records(entry, state)
+    if not tasks:
+        tasks = [{"key": "(unknown-task)", "log_path": entry.get("workdir", "")}]
+    records: list[dict[str, Any]] = []
+    for task in tasks:
+        status = str(task.get("status", "queued"))
+        if status == "pass":
+            continue
+        task_key = str(task.get("key", "(unknown-task)"))
+        verdict = str(task.get("verdict") or "ERROR")
+        failure_class = task.get("failure_class")
+        if not failure_class:
+            failure_class = "work" if status == "fail" else "orchestrator"
         try:
-            pid_int = int(pid)
+            attempts = int(task.get("attempts", 0))
         except (TypeError, ValueError):
-            continue
-        if not pid_is_alive(pid_int):
-            continue
-        pruned[run_id] = {
-            "pid": pid_int,
-            "identity": str(entry.get("identity", "")),
-            "run_name": str(entry.get("run_name", "")),
-            "workdir": str(entry.get("workdir", "")),
-            "started_at": str(entry.get("started_at", "")),
-        }
-    return pruned
+            attempts = 0
+        records.append(
+            {
+                "escalation_id": f"{run_id}:{task_key}",
+                "logged_at": datetime.now(timezone.utc).isoformat(),
+                "run_id": run_id,
+                "task_key": task_key,
+                "verdict": verdict,
+                "failure_class": str(failure_class),
+                "attempts": attempts,
+                "check_excerpt": str(task.get("check_output_tail", ""))[:400],
+                "log_path": str(task.get("log_path", "")),
+            }
+        )
+    return state_dir, records
+
+
+def _reconcile_dead_run(run_id: str, entry: dict[str, Any]) -> list[str]:
+    state_dir, records = _dead_run_escalations(run_id, entry)
+    failures: list[str] = []
+    for record in records:
+        if not append_escalation(state_dir, record):
+            failures.append(f"{run_id}:{record.get('task_key', '(unknown-task)')}")
+    return failures
 
 
 def _write_active_runs(runs: dict[str, dict[str, Any]]) -> None:
     path = active_runs_path()
-    path.parent.mkdir(parents=True, exist_ok=True)
-    tmp = path.with_name(f".{path.name}.{os.getpid()}.tmp")
-    tmp.write_text(json.dumps(_prune_active_runs(runs), indent=2, sort_keys=True), encoding="utf-8")
-    os.replace(tmp, path)
+    atomic_write_text(path, json.dumps(runs, indent=2, sort_keys=True) + "\n")
 
 
-def read_active_runs() -> dict[str, dict[str, Any]]:
+def _reconcile_active_runs_locked(
+    path: Path,
+    recovery_state_dir: Path | None = None,
+) -> tuple[
+    dict[str, dict[str, Any]],
+    dict[str, dict[str, Any]],
+    list[str],
+    dict[str, dict[str, Any]],
+]:
+    raw_runs = _read_active_runs_raw(path)
+    live: dict[str, dict[str, Any]] = {}
+    retained: dict[str, dict[str, Any]] = {}
+    recovery_failures: list[str] = []
+    pending_dead: dict[str, dict[str, Any]] = {}
+    for run_id, raw_entry in raw_runs.items():
+        entry = _normalize_active_run(raw_entry)
+        if pid_is_alive(int(entry["pid"])):
+            live[run_id] = entry
+            retained[run_id] = entry
+        elif recovery_state_dir is None:
+            retained[run_id] = entry
+            pending_dead[run_id] = entry
+        elif (
+            _dead_run_state_dir(entry).expanduser().resolve()
+            != recovery_state_dir.expanduser().resolve()
+        ):
+            retained[run_id] = entry
+            pending_dead[run_id] = entry
+        else:
+            failures = _reconcile_dead_run(run_id, entry)
+            if failures:
+                retained[run_id] = entry
+                pending_dead[run_id] = entry
+                recovery_failures.extend(failures)
+    if retained != raw_runs:
+        _write_active_runs(retained)
+    return live, retained, recovery_failures, pending_dead
+
+
+def read_active_runs_with_recovery(
+    recovery_state_dir: Path,
+) -> tuple[dict[str, dict[str, Any]], list[str], dict[str, dict[str, Any]]]:
     path = active_runs_path()
-    runs = _read_active_runs_raw(path)
-    pruned = _prune_active_runs(runs)
-    if pruned != runs:
-        _write_active_runs(pruned)
-    return pruned
+    with exclusive_file_lock(active_runs_lock_path()):
+        live, _retained, recovery_failures, pending_dead = _reconcile_active_runs_locked(
+            path,
+            recovery_state_dir,
+        )
+    return live, recovery_failures, pending_dead
+
+
+def read_active_runs(recovery_state_dir: Path | None = None) -> dict[str, dict[str, Any]]:
+    live, _recovery_failures, _pending_dead = read_active_runs_with_recovery(
+        recovery_state_dir or ringer_home()
+    )
+    return live
 
 
 def register_active_run(
@@ -1861,22 +2025,38 @@ def register_active_run(
     *,
     pid: int | None = None,
     started_at: datetime | None = None,
+    state_dir: Path | None = None,
+    state_path: Path | None = None,
+    tasks: list[dict[str, str]] | None = None,
 ) -> None:
-    runs = read_active_runs()
-    runs[run_id] = {
-        "pid": int(pid if pid is not None else os.getpid()),
-        "identity": identity,
-        "run_name": run_name,
-        "workdir": str(workdir),
-        "started_at": (started_at or datetime.now(timezone.utc)).isoformat(),
-    }
-    _write_active_runs(runs)
+    with exclusive_file_lock(active_runs_lock_path()):
+        _live, runs, _recovery_failures, _pending_dead = _reconcile_active_runs_locked(
+            active_runs_path()
+        )
+        entry: dict[str, Any] = {
+            "pid": int(pid if pid is not None else os.getpid()),
+            "identity": identity,
+            "run_name": run_name,
+            "workdir": str(workdir),
+            "started_at": (started_at or datetime.now(timezone.utc)).isoformat(),
+        }
+        if state_dir is not None:
+            entry["state_dir"] = str(state_dir)
+        if state_path is not None:
+            entry["state_path"] = str(state_path)
+        if tasks:
+            entry["tasks"] = tasks
+        runs[run_id] = _normalize_active_run(entry)
+        _write_active_runs(runs)
 
 
 def unregister_active_run(run_id: str) -> None:
-    runs = read_active_runs()
-    runs.pop(run_id, None)
-    _write_active_runs(runs)
+    with exclusive_file_lock(active_runs_lock_path()):
+        _live, runs, _recovery_failures, _pending_dead = _reconcile_active_runs_locked(
+            active_runs_path()
+        )
+        runs.pop(run_id, None)
+        _write_active_runs(runs)
 
 
 def artifacts_dir(state_dir: Path) -> Path:
@@ -6770,6 +6950,14 @@ class Verifier:
             except asyncio.TimeoutError:
                 kill_process_group(proc)
                 stdout, _ = await proc.communicate()
+        except asyncio.CancelledError:
+            terminate_process_group(proc)
+            try:
+                await asyncio.wait_for(proc.communicate(), timeout=5)
+            except asyncio.TimeoutError:
+                kill_process_group(proc)
+                await proc.communicate()
+            raise
         output = stdout.decode("utf-8", errors="replace") if stdout else ""
         if timed_out:
             output += f"\n[ringer.py] check timed out after {CHECK_TIMEOUT_S}s\n"
@@ -6823,22 +7011,28 @@ class RingerRunner:
     async def run(self) -> int:
         self.manifest.workdir.mkdir(parents=True, exist_ok=True)
         final_state = False
+        task_runs: list[asyncio.Task[None]] = []
         try:
             self.state_writer.start()
             if self.dashboard is not None:
                 self.state_writer.set_port(self.dashboard.start())
-            await asyncio.gather(*(self._run_task(runtime) for runtime in self.runtimes))
+            task_runs = [asyncio.create_task(self._run_task(runtime)) for runtime in self.runtimes]
+            await asyncio.gather(*task_runs)
             final_state = True
             return 0 if all(runtime.status == "pass" for runtime in self.runtimes) else 1
         except asyncio.CancelledError:
-            await self.kill_all_workers()
-            with self.lock:
-                now = time.monotonic()
-                for runtime in self.runtimes:
-                    if runtime.status not in {"pass", "fail"}:
-                        runtime.status = "fail"
-                        runtime.final_verdict = "ERROR"
-                        runtime.ended_at_monotonic = runtime.ended_at_monotonic or now
+            await self._cancel_task_runs(task_runs)
+            with contextlib.suppress(Exception):
+                await self.kill_all_workers()
+            self._finish_unfinished_tasks("cancelled")
+            self.state_writer.flush()
+            final_state = True
+            raise
+        except Exception:
+            await self._cancel_task_runs(task_runs)
+            with contextlib.suppress(Exception):
+                await self.kill_all_workers()
+            self._finish_unfinished_tasks("orchestrator")
             self.state_writer.flush()
             final_state = True
             raise
@@ -6858,6 +7052,15 @@ class RingerRunner:
                     print(f"\nYour results: {results_page}")
                     print("Open it in a browser, or run './ringer.py hud' for the full Ringside view (http://127.0.0.1:8700).")
 
+    @staticmethod
+    async def _cancel_task_runs(task_runs: Iterable[asyncio.Task[None]]) -> None:
+        tasks = list(task_runs)
+        for task in tasks:
+            if not task.done():
+                task.cancel()
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
+
     async def kill_all_workers(self) -> None:
         procs = list(self.active_processes.values())
         for proc in procs:
@@ -6868,6 +7071,15 @@ class RingerRunner:
         for proc in procs:
             if proc.returncode is None:
                 kill_process_group(proc)
+        if procs:
+            await asyncio.gather(*(proc.wait() for proc in procs))
+        for proc in procs:
+            self.active_processes.pop(proc.pid, None)
+
+    def _finish_unfinished_tasks(self, failure_class: str) -> None:
+        for runtime in self.runtimes:
+            if runtime.status not in {"pass", "fail"}:
+                self._finish_failed_task(runtime, "ERROR", failure_class=failure_class)
 
     async def _run_task(self, runtime: TaskRuntime) -> None:
         async with self.semaphore:
@@ -6886,6 +7098,7 @@ class RingerRunner:
                     runtime.status = "retrying" if retrying else "running"
                 attempt_started = time.monotonic()
                 worker = await self._run_worker(runtime, current_spec, attempt)
+                worker_duration_ms = int((time.monotonic() - attempt_started) * 1000)
                 with self.lock:
                     runtime.worker_pid = None
                     runtime.status = "verifying"
@@ -6907,17 +7120,28 @@ class RingerRunner:
                         runtime.ended_at_monotonic = time.monotonic()
                     await self._cleanup_worktree_on_pass(runtime)
                     return
-                if attempt < max_attempts and verdict in {"FAIL", "TIMEOUT"}:
+                decision = retry_decision(
+                    verdict, worker_duration_ms, attempt, max_attempts, worker.returncode
+                )
+                if decision == "retry":
                     failure_context = build_failure_context(runtime.log_path, verify.raw_output_excerpt)
                     current_spec = (
                         f"{runtime.task.spec}\n\n"
                         f"Previous attempt failed: {failure_context}. Fix it."
                     )
                     continue
-                with self.lock:
-                    runtime.status = "fail"
-                    runtime.final_verdict = verdict
-                    runtime.ended_at_monotonic = time.monotonic()
+                failure_class = worker.failure_class
+                if worker.error and failure_class is None:
+                    failure_class = "launch"
+                if decision == "terminal-launch":
+                    failure_class = "launch"
+                    append_text(
+                        runtime.log_path,
+                        f"[ringer.py] launch-class failure: worker exited after {worker_duration_ms}ms, "
+                        "before real work could happen; an identical retry cannot succeed. "
+                        "Fix the engine, environment, or spec, then rerun.\n",
+                    )
+                self._finish_failed_task(runtime, verdict, failure_class=failure_class)
                 return
 
     def _harvest_deliverables_on_pass(self, runtime: TaskRuntime) -> None:
@@ -7055,9 +7279,6 @@ class RingerRunner:
     async def _record_prepare_error(self, runtime: TaskRuntime, error: str) -> None:
         with self.lock:
             runtime.attempts = 1
-            runtime.status = "fail"
-            runtime.final_verdict = "ERROR"
-            runtime.ended_at_monotonic = time.monotonic()
         verify = VerifyResult(
             ok=False,
             check_returncode=None,
@@ -7066,6 +7287,60 @@ class RingerRunner:
         )
         worker = WorkerResult(returncode=None, timed_out=False, tokens=None, error=error)
         self._log_attempt(runtime, runtime.task.spec, False, worker, verify, "ERROR", 0)
+        self._finish_failed_task(runtime, "ERROR", failure_class="prepare")
+
+    def _finish_failed_task(
+        self,
+        runtime: TaskRuntime,
+        verdict: str,
+        *,
+        failure_class: str | None = None,
+    ) -> None:
+        with self.lock:
+            runtime.worker_pid = None
+            runtime.status = "fail"
+            runtime.final_verdict = verdict
+            runtime.ended_at_monotonic = runtime.ended_at_monotonic or time.monotonic()
+            if failure_class is not None:
+                runtime.failure_class = failure_class
+        self._record_task_escalation(runtime, verdict)
+
+    def _record_task_escalation(self, runtime: TaskRuntime, verdict: str) -> None:
+        # A task that ends non-PASS with nobody told is how work strands
+        # (2026-07-13: a review-fix chain died at 4:19 AM and sat invisible
+        # for 11 hours). The record survives the orchestrator's death.
+        recorded = append_escalation(
+            self.config.state_dir,
+            {
+                "escalation_id": f"{self.run_id}:{runtime.task.key}",
+                "logged_at": datetime.now(timezone.utc).isoformat(),
+                "run_id": self.run_id,
+                "task_key": runtime.task.key,
+                "verdict": verdict,
+                "failure_class": runtime.failure_class,
+                "attempts": runtime.attempts,
+                "check_excerpt": (runtime.last_check_output or "")[:400],
+                "log_path": str(runtime.log_path),
+            },
+        )
+        message = (
+            f"[ringer.py] ESCALATION {runtime.task.key}: {verdict} after "
+            f"{runtime.attempts} attempt(s) [{runtime.failure_class or 'work'}-class]. "
+        )
+        if recorded:
+            print(
+                message
+                + "Recorded for `ringer.py status`; this task is stranded until someone acts.",
+                flush=True,
+            )
+        else:
+            print(
+                message
+                + f"FAILED TO RECORD at {escalations_path(self.config.state_dir)}; "
+                "this task is stranded and requires immediate human action.",
+                file=sys.stderr,
+                flush=True,
+            )
 
     async def _run_worker(self, runtime: TaskRuntime, spec: str, attempt: int) -> WorkerResult:
         log_path = runtime.log_path
@@ -7076,6 +7351,7 @@ class RingerRunner:
                 timed_out=False,
                 tokens=None,
                 error=f"unknown worker engine: {runtime.task.engine}",
+                failure_class="prepare",
             )
         if runtime.task.full_access and not self.config.allow_full_access:
             return WorkerResult(
@@ -7086,6 +7362,7 @@ class RingerRunner:
                     f"task requested full_access with engine {runtime.task.engine}, "
                     "but config allow_full_access is false"
                 ),
+                failure_class="prepare",
             )
         cmd = build_worker_command(
             engine,
@@ -7106,7 +7383,13 @@ class RingerRunner:
         try:
             log_fh = log_path.open("ab")
         except OSError as exc:
-            return WorkerResult(returncode=None, timed_out=False, tokens=None, error=str(exc))
+            return WorkerResult(
+                returncode=None,
+                timed_out=False,
+                tokens=None,
+                error=str(exc),
+                failure_class="prepare",
+            )
         async with AsyncFileCloser(log_fh):
             try:
                 proc = await asyncio.create_subprocess_exec(
@@ -7121,29 +7404,44 @@ class RingerRunner:
                 message = f"[ringer.py] worker spawn failed: {exc}\n"
                 log_fh.write(message.encode("utf-8", errors="replace"))
                 log_fh.flush()
-                return WorkerResult(returncode=None, timed_out=False, tokens=None, error=str(exc))
+                return WorkerResult(
+                    returncode=None,
+                    timed_out=False,
+                    tokens=None,
+                    error=str(exc),
+                    failure_class="launch",
+                )
             with self.lock:
                 runtime.worker_pid = proc.pid
             self.active_processes[proc.pid] = proc
             reader = asyncio.create_task(self._tee_stream(proc, log_fh, capture))
             timed_out = False
             try:
-                await asyncio.wait_for(proc.wait(), timeout=runtime.task.timeout_s)
-            except asyncio.TimeoutError:
-                timed_out = True
-                terminate_process_group(proc)
                 try:
-                    await asyncio.wait_for(proc.wait(), timeout=5)
+                    await asyncio.wait_for(proc.wait(), timeout=runtime.task.timeout_s)
                 except asyncio.TimeoutError:
-                    kill_process_group(proc)
-                    await proc.wait()
-            try:
-                await asyncio.wait_for(reader, timeout=5)
-            except asyncio.TimeoutError:
-                reader.cancel()
-                with contextlib.suppress(asyncio.CancelledError):
-                    await reader
-            self.active_processes.pop(proc.pid, None)
+                    timed_out = True
+                    terminate_process_group(proc)
+                    try:
+                        await asyncio.wait_for(proc.wait(), timeout=5)
+                    except asyncio.TimeoutError:
+                        kill_process_group(proc)
+                        await proc.wait()
+                try:
+                    await asyncio.wait_for(reader, timeout=5)
+                except asyncio.TimeoutError:
+                    reader.cancel()
+                    with contextlib.suppress(asyncio.CancelledError):
+                        await reader
+            finally:
+                if not reader.done():
+                    reader.cancel()
+                try:
+                    with contextlib.suppress(asyncio.CancelledError):
+                        await reader
+                finally:
+                    if proc.returncode is not None:
+                        self.active_processes.pop(proc.pid, None)
         output_tail = capture.text()
         tokens = parse_token_count(output_tail, engine.token_regex)
         if timed_out:
@@ -7280,6 +7578,299 @@ def verdict_for(worker: WorkerResult, verify: VerifyResult) -> str:
     if verify.ok:
         return "PASS"
     return "FAIL"
+
+
+# A FAIL this fast means the worker exited before doing real work (auth,
+# sandbox denial, bad flag, missing binary). An identical retry cannot
+# succeed (2026-07-13: four sub-3s FAIL/FAIL pairs burned slots in one run).
+LAUNCH_CLASS_THRESHOLD_MS = 10_000
+
+
+def launch_class_threshold_ms() -> int:
+    """Return the worker-time launch guard in milliseconds.
+
+    RINGER_LAUNCH_CLASS_THRESHOLD_MS overrides the 10,000 ms default. Integer
+    values clamp at zero, while non-integer values fall back to the default.
+    """
+    raw = os.environ.get("RINGER_LAUNCH_CLASS_THRESHOLD_MS")
+    if raw is None:
+        return LAUNCH_CLASS_THRESHOLD_MS
+    try:
+        return max(0, int(raw))
+    except ValueError:
+        return LAUNCH_CLASS_THRESHOLD_MS
+
+
+def retry_decision(
+    verdict: str,
+    duration_ms: int,
+    attempt: int,
+    max_attempts: int,
+    worker_returncode: int | None = None,
+) -> str:
+    """Classify the follow-up to a non-PASS attempt.
+
+    Returns "retry", "terminal", or "terminal-launch". Only FAIL and TIMEOUT
+    are retryable at all. A FAIL faster than launch_class_threshold_ms() with
+    a nonzero worker exit is a launch-class failure (the CLI died before doing
+    work) and terminates immediately so the environment or spec gets fixed
+    instead of replayed. A fast FAIL with exit 0 means the worker did work
+    that flunked the check, so that retry is legitimate.
+    """
+    if attempt >= max_attempts or verdict not in {"FAIL", "TIMEOUT"}:
+        return "terminal"
+    if (
+        verdict == "FAIL"
+        and duration_ms < launch_class_threshold_ms()
+        and worker_returncode is not None
+        and worker_returncode != 0
+    ):
+        return "terminal-launch"
+    return "retry"
+
+
+def escalations_path(state_dir: Path) -> Path:
+    return state_dir / "escalations.jsonl"
+
+
+def escalation_lock_path(state_dir: Path) -> Path:
+    path = escalations_path(state_dir)
+    return path.with_name(path.name + ".lock")
+
+
+def escalation_review_path(state_dir: Path) -> Path:
+    path = escalations_path(state_dir)
+    return path.with_name(path.name + ".review.json")
+
+
+def _read_escalations_unlocked(path: Path) -> list[dict[str, Any]]:
+    try:
+        lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+    except FileNotFoundError:
+        return []
+    records: list[dict[str, Any]] = []
+    for line in lines:
+        stripped = line.strip()
+        if not stripped:
+            continue
+        try:
+            record = json.loads(stripped)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(record, dict):
+            records.append(record)
+    return records
+
+
+def escalation_identity(record: dict[str, Any]) -> str | None:
+    escalation_id = record.get("escalation_id")
+    if isinstance(escalation_id, str) and escalation_id:
+        return escalation_id
+    run_id = record.get("run_id")
+    task_key = record.get("task_key")
+    if isinstance(run_id, str) and run_id and isinstance(task_key, str) and task_key:
+        return f"{run_id}:{task_key}"
+    return None
+
+
+def escalation_record_key(record: dict[str, Any]) -> str:
+    identity = escalation_identity(record)
+    if identity is not None:
+        return f"id:{identity}"
+    payload = json.dumps(
+        record,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return f"record:{payload}"
+
+
+def _read_escalation_review_unlocked(path: Path) -> list[str] | None:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (FileNotFoundError, OSError, json.JSONDecodeError, UnicodeDecodeError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    record_keys = data.get("record_keys")
+    if not isinstance(record_keys, list) or not all(
+        isinstance(record_key, str) for record_key in record_keys
+    ):
+        return None
+    return record_keys
+
+
+def append_escalation(state_dir: Path, record: dict[str, Any]) -> bool:
+    path = escalations_path(state_dir)
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with exclusive_file_lock(escalation_lock_path(state_dir)):
+            record_identity = escalation_identity(record)
+            if record_identity is not None and any(
+                escalation_identity(existing) == record_identity
+                for existing in _read_escalations_unlocked(path)
+            ):
+                return True
+            payload = json.dumps(record, ensure_ascii=False) + "\n"
+            with path.open("a", encoding="utf-8") as fh:
+                fh.write(payload)
+        return True
+    except (OSError, TypeError, ValueError, UnicodeError):
+        return False
+
+
+def read_escalations(state_dir: Path, limit: int | None = None) -> list[dict[str, Any]]:
+    path = escalations_path(state_dir)
+    with exclusive_file_lock(escalation_lock_path(state_dir)):
+        records = _read_escalations_unlocked(path)
+    if limit is None:
+        return records
+    if limit <= 0:
+        return []
+    return records[-limit:]
+
+
+def review_escalations(state_dir: Path) -> tuple[list[dict[str, Any]], OSError | None]:
+    path = escalations_path(state_dir)
+    records: list[dict[str, Any]] = []
+    try:
+        with exclusive_file_lock(escalation_lock_path(state_dir)):
+            records = _read_escalations_unlocked(path)
+            atomic_write_json(
+                escalation_review_path(state_dir),
+                {
+                    "reviewed_at": datetime.now(timezone.utc).isoformat(),
+                    "record_keys": [escalation_record_key(record) for record in records],
+                },
+            )
+    except OSError as exc:
+        return records, exc
+    return records, None
+
+
+def clear_escalations(state_dir: Path) -> tuple[list[dict[str, Any]], OSError | None]:
+    path = escalations_path(state_dir)
+    review_path = escalation_review_path(state_dir)
+    try:
+        with exclusive_file_lock(escalation_lock_path(state_dir)):
+            records = _read_escalations_unlocked(path)
+            if not records:
+                path.unlink(missing_ok=True)
+                review_path.unlink(missing_ok=True)
+                return [], None
+            reviewed_keys = _read_escalation_review_unlocked(review_path)
+            if reviewed_keys is None:
+                return [], OSError(
+                    "no matching status snapshot; run `ringer.py status` before clearing"
+                )
+            reviewed = Counter(reviewed_keys)
+            cleared: list[dict[str, Any]] = []
+            remaining: list[dict[str, Any]] = []
+            for record in records:
+                record_key = escalation_record_key(record)
+                if reviewed[record_key] > 0:
+                    reviewed[record_key] -= 1
+                    cleared.append(record)
+                else:
+                    remaining.append(record)
+            if remaining:
+                atomic_write_text(
+                    path,
+                    "".join(
+                        json.dumps(record, ensure_ascii=False) + "\n" for record in remaining
+                    ),
+                )
+            else:
+                path.unlink(missing_ok=True)
+            review_path.unlink(missing_ok=True)
+    except OSError as exc:
+        return [], exc
+    return cleared, None
+
+
+def print_active_runs(active: dict[str, dict[str, Any]]) -> None:
+    if active:
+        print(f"active runs: {len(active)}")
+        for run_id, entry in sorted(active.items()):
+            label = entry.get("run_name") or run_id
+            print(f"  {label} ({run_id})")
+    else:
+        print("active runs: none")
+
+
+def print_escalations(records: list[dict[str, Any]]) -> None:
+    for record in records:
+        print(
+            f"  {record.get('logged_at', '?')} {record.get('run_id', '?')} "
+            f"{record.get('task_key', '?')}: {record.get('verdict', '?')} "
+            f"[{record.get('failure_class') or 'work'}-class] log={record.get('log_path', '?')}"
+        )
+
+
+def run_status_command(config: AppConfig, args: Any) -> int:
+    active, recovery_failures, pending_dead = read_active_runs_with_recovery(config.state_dir)
+    print_active_runs(active)
+    if pending_dead:
+        print(f"dead runs awaiting escalation recovery: {len(pending_dead)}")
+        for run_id, entry in sorted(pending_dead.items()):
+            print(f"  {entry.get('run_name') or run_id} ({run_id}) state={_dead_run_state_dir(entry)}")
+    if recovery_failures:
+        print(
+            "FAILED TO RECORD recovered escalations: " + ", ".join(recovery_failures),
+            file=sys.stderr,
+        )
+        if getattr(args, "clear_escalations", False):
+            return 1
+    if getattr(args, "clear_escalations", False):
+        cleared, error = clear_escalations(config.state_dir)
+        if error is not None:
+            print(
+                f"FAILED TO CLEAR escalations at {escalations_path(config.state_dir)}: {error}",
+                file=sys.stderr,
+            )
+            return 1
+        if cleared:
+            print(f"acknowledged and cleared escalations: {len(cleared)}")
+            print_escalations(cleared)
+        else:
+            print("stranded escalations: none")
+        remaining, review_error = review_escalations(config.state_dir)
+        if review_error is not None:
+            print(
+                "FAILED TO RECORD escalation review snapshot at "
+                f"{escalation_review_path(config.state_dir)}: {review_error}",
+                file=sys.stderr,
+            )
+            return 1
+        if remaining:
+            print(f"new stranded escalations: {len(remaining)}")
+            print_escalations(remaining)
+            return 2
+        return 2 if pending_dead else 0
+    escalations, review_error = review_escalations(config.state_dir)
+    if review_error is not None:
+        print(
+            "FAILED TO RECORD escalation review snapshot at "
+            f"{escalation_review_path(config.state_dir)}: {review_error}",
+            file=sys.stderr,
+        )
+    if not escalations:
+        if recovery_failures:
+            print("stranded escalations: recovery is pending after a persistence failure")
+        elif pending_dead:
+            print("stranded escalations: dead-run recovery requires the matching state directory")
+        else:
+            print("stranded escalations: none")
+        if recovery_failures or review_error is not None:
+            return 1
+        return 2 if pending_dead else 0
+    print(
+        f"stranded escalations: {len(escalations)} - resume or report each, "
+        "then acknowledge with --clear-escalations"
+    )
+    print_escalations(escalations)
+    return 1 if recovery_failures or review_error is not None else 2
 
 
 def build_run_id(run_name: str) -> str:
@@ -8039,6 +8630,12 @@ async def run_manifest(
         manifest.run_name,
         manifest.workdir,
         started_at=runner.started_at,
+        state_dir=config.state_dir,
+        state_path=runner.state_writer.path,
+        tasks=[
+            {"key": runtime.task.key, "log_path": str(runtime.log_path)}
+            for runtime in runner.runtimes
+        ],
     )
     try:
         return await runner.run()
@@ -8128,7 +8725,7 @@ def build_parser() -> argparse.ArgumentParser:
         prog="ringer.py",
         description=(
             "Ringer: deterministic parallel AI-agent orchestrator. Runs manifest tasks in parallel, "
-            "verifies artifacts with executed checks, retries failures once, logs eval rows, "
+            "verifies artifacts with executed checks, retries eligible failures once, logs eval rows, "
             "and serves a live dashboard."
         ),
     )
@@ -8142,7 +8739,11 @@ def build_parser() -> argparse.ArgumentParser:
     run_parser.add_argument("--identity", help="orchestrator identity for HUD state and eval rows")
     run_parser.add_argument("--no-dashboard", action="store_true", help="disable live dashboard")
     run_parser.add_argument("--browser", action="store_true", help="open the dashboard in the browser instead of Ringside")
-    run_parser.epilog = "Set RINGER_NO_CATALOG_REFRESH=1 to skip the non-blocking OpenRouter catalog auto-refresh."
+    run_parser.epilog = (
+        "Set RINGER_NO_CATALOG_REFRESH=1 to skip the non-blocking OpenRouter catalog "
+        "auto-refresh. Set RINGER_LAUNCH_CLASS_THRESHOLD_MS to tune the worker-time "
+        "launch guard in milliseconds; 0 disables it."
+    )
     run_parser.add_argument(
         "--no-artifact",
         action="store_true",
@@ -8157,6 +8758,20 @@ def build_parser() -> argparse.ArgumentParser:
     hud_parser.add_argument("--config", type=Path, default=argparse.SUPPRESS, help=argparse.SUPPRESS)
     hud_parser.add_argument("--port", type=int, help=f"port to bind on 127.0.0.1 (default: {DEFAULT_HUD_PORT})")
     hud_parser.add_argument("--no-open", action="store_true", help="start the server without opening a browser")
+
+    status_parser = subparsers.add_parser(
+        "status",
+        help="show active runs and stranded-task escalations (exit 2 while stranded work remains)",
+    )
+    status_parser.add_argument(
+        "--clear-escalations",
+        action="store_true",
+        help="acknowledge escalations from the latest displayed status snapshot",
+    )
+    status_parser.epilog = (
+        "Exit 0 when no stranded work remains, 2 while escalations or pending dead-run "
+        "recovery remain, and 1 on persistence failure. Active runs are informational."
+    )
 
     db_parser = subparsers.add_parser("db", help="manage the derived SQLite read model")
     db_parser.add_argument("--config", type=Path, default=argparse.SUPPRESS, help=argparse.SUPPRESS)
@@ -8238,6 +8853,8 @@ def main(argv: list[str] | None = None) -> int:
             return run_catalog_command(args)
 
         config = AppConfig.load(args.config)
+        if args.command == "status":
+            return run_status_command(config, args)
         if args.command == "db":
             return run_db_command(config, args)
         if args.command == "models":

--- a/ringer.py
+++ b/ringer.py
@@ -4192,7 +4192,6 @@ class PersistentHudServer:
                 if path.startswith("/api/open-folder"):
                     query = urllib.parse.urlparse(path).query
                     params = urllib.parse.parse_qs(query)
-                    name = (params.get("artifact") or [""])[0]
                     run_id = (params.get("run") or [""])[0]
                     artifact_root_dir = (state_dir / "artifacts").resolve()
                     target = artifact_root_dir / "deliverables"

--- a/tests/test_active_runs.py
+++ b/tests/test_active_runs.py
@@ -2,11 +2,15 @@
 from __future__ import annotations
 
 import json
+import io
 import os
 import sys
 import tempfile
 import unittest
+from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
 
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
@@ -14,7 +18,9 @@ sys.path.insert(0, str(ROOT))
 from ringer import (  # noqa: E402
     active_runs_path,
     read_active_runs,
+    read_escalations,
     register_active_run,
+    run_status_command,
     unregister_active_run,
 )
 
@@ -60,7 +66,7 @@ class ActiveRunsTests(unittest.TestCase):
         self.assertEqual([], list(marker.parent.glob("*.tmp")))
         self.assertEqual([], list(marker.parent.glob(".*.tmp")))
 
-    def test_dead_pid_pruned_on_read_and_write(self) -> None:
+    def test_dead_pid_is_retained_until_matching_recovery(self) -> None:
         marker = active_runs_path()
         marker.parent.mkdir(parents=True, exist_ok=True)
         marker.write_text(
@@ -78,12 +84,121 @@ class ActiveRunsTests(unittest.TestCase):
             encoding="utf-8",
         )
 
-        self.assertEqual({}, read_active_runs())
+        self.assertEqual({}, read_active_runs(Path(self.tmp.name) / "other-state"))
+        self.assertEqual(["dead-run"], sorted(json.loads(marker.read_text(encoding="utf-8"))))
+        self.assertEqual([], read_escalations(Path(os.environ["RINGER_HOME"])))
+
+        self.assertEqual({}, read_active_runs(Path(os.environ["RINGER_HOME"])))
         self.assertEqual({}, json.loads(marker.read_text(encoding="utf-8")))
+        records = read_escalations(Path(os.environ["RINGER_HOME"]))
+        self.assertEqual(["(unknown-task)"], [record["task_key"] for record in records])
+        self.assertEqual("orchestrator", records[0]["failure_class"])
 
         register_active_run("live-run", "agent-a", "Live", Path(self.tmp.name))
         data = json.loads(marker.read_text(encoding="utf-8"))
         self.assertEqual(["live-run"], sorted(data))
+
+    def test_dead_run_recovers_each_nonpass_task_from_run_state(self) -> None:
+        state_dir = Path(self.tmp.name) / "state"
+        state_path = state_dir / "runs" / "dead-run.json"
+        state_path.parent.mkdir(parents=True)
+        state_path.write_text(
+            json.dumps(
+                {
+                    "run_id": "dead-run",
+                    "tasks": [
+                        {
+                            "key": "done",
+                            "status": "pass",
+                            "verdict": "PASS",
+                            "attempts": 1,
+                            "log_path": str(Path(self.tmp.name) / "done.log"),
+                        },
+                        {
+                            "key": "stranded",
+                            "status": "running",
+                            "attempts": 1,
+                            "log_path": str(Path(self.tmp.name) / "stranded.log"),
+                        },
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+        register_active_run(
+            "dead-run",
+            "agent-a",
+            "Dead",
+            Path(self.tmp.name),
+            pid=99999999,
+            state_dir=state_dir,
+            state_path=state_path,
+            tasks=[
+                {"key": "done", "log_path": str(Path(self.tmp.name) / "done.log")},
+                {"key": "stranded", "log_path": str(Path(self.tmp.name) / "stranded.log")},
+            ],
+        )
+
+        self.assertEqual({}, read_active_runs(state_dir))
+        records = read_escalations(state_dir)
+        self.assertEqual(["stranded"], [record["task_key"] for record in records])
+        self.assertEqual("ERROR", records[0]["verdict"])
+        self.assertEqual("orchestrator", records[0]["failure_class"])
+
+    def test_dead_run_is_retained_when_recovery_cannot_persist(self) -> None:
+        state_dir = Path(self.tmp.name) / "state"
+        register_active_run(
+            "dead-run",
+            "agent-a",
+            "Dead",
+            Path(self.tmp.name),
+            pid=99999999,
+            state_dir=state_dir,
+            tasks=[{"key": "stranded", "log_path": str(Path(self.tmp.name) / "worker.log")}],
+        )
+
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        with mock.patch("ringer.append_escalation", return_value=False):
+            with redirect_stdout(stdout), redirect_stderr(stderr):
+                result = run_status_command(
+                    SimpleNamespace(state_dir=state_dir),
+                    SimpleNamespace(clear_escalations=False),
+                )
+            retained = json.loads(active_runs_path().read_text(encoding="utf-8"))
+
+        self.assertEqual(1, result)
+        self.assertIn("FAILED TO RECORD recovered escalations", stderr.getvalue())
+        self.assertEqual(["dead-run"], sorted(retained))
+
+    def test_dead_run_waits_for_matching_state_directory(self) -> None:
+        state_dir = Path(self.tmp.name) / "state-a"
+        other_state_dir = Path(self.tmp.name) / "state-b"
+        register_active_run(
+            "dead-run",
+            "agent-a",
+            "Dead",
+            Path(self.tmp.name),
+            pid=99999999,
+            state_dir=state_dir,
+            tasks=[{"key": "stranded", "log_path": str(Path(self.tmp.name) / "worker.log")}],
+        )
+
+        stdout = io.StringIO()
+        with redirect_stdout(stdout):
+            result = run_status_command(
+                SimpleNamespace(state_dir=other_state_dir),
+                SimpleNamespace(clear_escalations=False),
+            )
+
+        self.assertEqual(2, result)
+        self.assertIn("dead runs awaiting escalation recovery: 1", stdout.getvalue())
+        retained = json.loads(active_runs_path().read_text(encoding="utf-8"))
+        self.assertEqual(["dead-run"], sorted(retained))
+        self.assertEqual([], read_escalations(state_dir))
+
+        self.assertEqual({}, read_active_runs(state_dir))
+        self.assertEqual(["stranded"], [item["task_key"] for item in read_escalations(state_dir)])
 
 
 if __name__ == "__main__":

--- a/tests/test_agent_install.py
+++ b/tests/test_agent_install.py
@@ -61,6 +61,9 @@ class AgentInstallTests(unittest.TestCase):
         skill = self.home / ".claude" / "skills" / "ringer" / "SKILL.md"
         self.assertTrue(skill.exists())
         self.assertEqual((ROOT / ".claude" / "skills" / "ringer" / "SKILL.md").read_text(), skill.read_text())
+        skill_text = skill.read_text(encoding="utf-8")
+        self.assertIn("Run `./ringer.py status`", skill_text)
+        self.assertIn("launch-class failure", skill_text)
 
         settings = self.read_settings()
         hooks = settings["hooks"]

--- a/tests/test_agent_install.py
+++ b/tests/test_agent_install.py
@@ -64,10 +64,16 @@ class AgentInstallTests(unittest.TestCase):
 
         skill = self.home / ".claude" / "skills" / "ringer" / "SKILL.md"
         universal_skill = self.home / ".agents" / "skills" / "ringer" / "SKILL.md"
+        reference = self.home / ".agents" / "skills" / "ringer" / "references" / "manifest-design.md"
         self.assertTrue(skill.exists())
         self.assertTrue(universal_skill.exists())
+        self.assertTrue(reference.exists())
         self.assertEqual((ROOT / ".claude" / "skills" / "ringer" / "SKILL.md").read_text(), skill.read_text())
         self.assertEqual(skill.read_text(), universal_skill.read_text())
+        self.assertEqual(
+            (ROOT / ".claude" / "skills" / "ringer" / "references" / "manifest-design.md").read_text(),
+            reference.read_text(),
+        )
 
         hook_script = self.home / ".local" / "share" / "ringer" / "hooks" / "ringer_nudge.py"
         self.assertTrue(hook_script.exists())
@@ -80,13 +86,11 @@ class AgentInstallTests(unittest.TestCase):
         self.assertEqual("command", hooks["PreToolUse"][0]["hooks"][0]["type"])
         self.assertIn("ringer_nudge.py", hooks["PreToolUse"][0]["hooks"][0]["command"])
         self.assertTrue(hooks["PreToolUse"][0]["hooks"][0]["command"].endswith(" pre-bash"))
-        self.assertEqual("Edit|Write", hooks["PostToolUse"][0]["matcher"])
-        self.assertIn("ringer_nudge.py", hooks["PostToolUse"][0]["hooks"][0]["command"])
-        self.assertTrue(hooks["PostToolUse"][0]["hooks"][0]["command"].endswith(" post-edit"))
+        self.assertEqual([], hooks.get("PostToolUse", []))
 
         codex_hooks = self.read_codex_hooks()["hooks"]
         self.assertEqual("Bash", codex_hooks["PreToolUse"][0]["matcher"])
-        self.assertEqual("apply_patch", codex_hooks["PostToolUse"][0]["matcher"])
+        self.assertEqual([], codex_hooks.get("PostToolUse", []))
         self.assertIn(str(hook_script), codex_hooks["PreToolUse"][0]["hooks"][0]["command"])
 
     def test_second_install_is_idempotent(self) -> None:
@@ -102,8 +106,43 @@ class AgentInstallTests(unittest.TestCase):
 
         self.assertEqual(settings_before, settings_after)
         self.assertEqual(codex_before, codex_after)
-        self.assertEqual(2, len(self.ringer_handlers(settings_after)))
-        self.assertEqual(2, len(self.ringer_handlers(codex_after)))
+        self.assertEqual(1, len(self.ringer_handlers(settings_after)))
+        self.assertEqual(1, len(self.ringer_handlers(codex_after)))
+
+    def test_install_removes_legacy_post_edit_hook_and_preserves_unrelated_handler(self) -> None:
+        settings_path = self.home / ".claude" / "settings.json"
+        settings_path.parent.mkdir(parents=True, exist_ok=True)
+        settings_path.write_text(
+            json.dumps(
+                {
+                    "hooks": {
+                        "PostToolUse": [
+                            {
+                                "matcher": "Edit|Write",
+                                "hooks": [
+                                    {
+                                        "type": "command",
+                                        "command": "python3 /tmp/ringer_nudge.py post-edit",
+                                    },
+                                    {"type": "command", "command": "echo keep-post-hook"},
+                                ],
+                            }
+                        ]
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        result = self.run_cli("install-agent")
+        self.assertEqual(0, result.returncode, result.stderr)
+
+        settings = self.read_settings()
+        self.assertEqual(1, len(self.ringer_handlers(settings)))
+        self.assertEqual(
+            [{"type": "command", "command": "echo keep-post-hook"}],
+            settings["hooks"]["PostToolUse"][0]["hooks"],
+        )
 
     def test_install_migrates_legacy_checkout_hook_to_stable_path(self) -> None:
         legacy_command = "python3 /tmp/ringer/hooks/ringer_nudge.py pre-bash 2>/dev/null || true"
@@ -315,6 +354,9 @@ class AgentInstallTests(unittest.TestCase):
         self.assertEqual(0, install.returncode, install.stderr)
         self.assertTrue((project / ".claude" / "skills" / "ringer" / "SKILL.md").exists())
         self.assertTrue((project / ".agents" / "skills" / "ringer" / "SKILL.md").exists())
+        self.assertTrue(
+            (project / ".agents" / "skills" / "ringer" / "references" / "run-operations.md").exists()
+        )
         self.assertTrue((project / ".agents" / "ringer" / "hooks" / "ringer_nudge.py").exists())
         self.assertTrue((project / ".claude" / "settings.json").exists())
         self.assertTrue((project / ".codex" / "hooks.json").exists())

--- a/tests/test_agent_install.py
+++ b/tests/test_agent_install.py
@@ -38,6 +38,10 @@ class AgentInstallTests(unittest.TestCase):
         base = self.home if root is None else root
         return json.loads((base / ".claude" / "settings.json").read_text(encoding="utf-8"))
 
+    def read_codex_hooks(self, root: Path | None = None) -> dict[str, object]:
+        base = self.home if root is None else root
+        return json.loads((base / ".codex" / "hooks.json").read_text(encoding="utf-8"))
+
     def ringer_handlers(self, settings: dict[str, object]) -> list[dict[str, object]]:
         handlers: list[dict[str, object]] = []
         hooks = settings.get("hooks")
@@ -59,8 +63,15 @@ class AgentInstallTests(unittest.TestCase):
         self.assertEqual(0, result.returncode, result.stderr)
 
         skill = self.home / ".claude" / "skills" / "ringer" / "SKILL.md"
+        universal_skill = self.home / ".agents" / "skills" / "ringer" / "SKILL.md"
         self.assertTrue(skill.exists())
+        self.assertTrue(universal_skill.exists())
         self.assertEqual((ROOT / ".claude" / "skills" / "ringer" / "SKILL.md").read_text(), skill.read_text())
+        self.assertEqual(skill.read_text(), universal_skill.read_text())
+
+        hook_script = self.home / ".local" / "share" / "ringer" / "hooks" / "ringer_nudge.py"
+        self.assertTrue(hook_script.exists())
+        self.assertEqual((ROOT / "hooks" / "ringer_nudge.py").read_text(), hook_script.read_text())
 
         settings = self.read_settings()
         hooks = settings["hooks"]
@@ -73,17 +84,55 @@ class AgentInstallTests(unittest.TestCase):
         self.assertIn("ringer_nudge.py", hooks["PostToolUse"][0]["hooks"][0]["command"])
         self.assertTrue(hooks["PostToolUse"][0]["hooks"][0]["command"].endswith(" post-edit"))
 
+        codex_hooks = self.read_codex_hooks()["hooks"]
+        self.assertEqual("Bash", codex_hooks["PreToolUse"][0]["matcher"])
+        self.assertEqual("apply_patch", codex_hooks["PostToolUse"][0]["matcher"])
+        self.assertIn(str(hook_script), codex_hooks["PreToolUse"][0]["hooks"][0]["command"])
+
     def test_second_install_is_idempotent(self) -> None:
         first = self.run_cli("install-agent")
         self.assertEqual(0, first.returncode, first.stderr)
         settings_before = self.read_settings()
+        codex_before = self.read_codex_hooks()
 
         second = self.run_cli("install-agent")
         self.assertEqual(0, second.returncode, second.stderr)
         settings_after = self.read_settings()
+        codex_after = self.read_codex_hooks()
 
         self.assertEqual(settings_before, settings_after)
+        self.assertEqual(codex_before, codex_after)
         self.assertEqual(2, len(self.ringer_handlers(settings_after)))
+        self.assertEqual(2, len(self.ringer_handlers(codex_after)))
+
+    def test_install_migrates_legacy_checkout_hook_to_stable_path(self) -> None:
+        legacy_command = "python3 /tmp/ringer/hooks/ringer_nudge.py pre-bash 2>/dev/null || true"
+        settings_path = self.home / ".claude" / "settings.json"
+        settings_path.parent.mkdir(parents=True, exist_ok=True)
+        settings_path.write_text(
+            json.dumps(
+                {
+                    "hooks": {
+                        "PreToolUse": [
+                            {
+                                "matcher": "Bash",
+                                "hooks": [{"type": "command", "command": legacy_command}],
+                            }
+                        ]
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        result = self.run_cli("install-agent")
+        self.assertEqual(0, result.returncode, result.stderr)
+
+        groups = self.read_settings()["hooks"]["PreToolUse"]
+        self.assertEqual(1, len(groups))
+        command = groups[0]["hooks"][0]["command"]
+        self.assertIn(str(self.home / ".local" / "share" / "ringer" / "hooks" / "ringer_nudge.py"), command)
+        self.assertNotIn("/tmp/ringer/hooks", command)
 
     def test_install_preserves_unrelated_hooks_and_settings_keys(self) -> None:
         claude = self.home / ".claude"
@@ -153,6 +202,9 @@ class AgentInstallTests(unittest.TestCase):
         ]
         self.assertEqual(["echo keep-me"], kept)
         self.assertFalse((self.home / ".claude" / "skills" / "ringer").exists())
+        self.assertFalse((self.home / ".agents" / "skills" / "ringer").exists())
+        self.assertFalse((self.home / ".local" / "share" / "ringer" / "hooks" / "ringer_nudge.py").exists())
+        self.assertEqual([], self.ringer_handlers(self.read_codex_hooks()))
 
     def test_project_variant_writes_under_temp_cwd(self) -> None:
         project = Path(self.tmp.name) / "project"
@@ -162,14 +214,21 @@ class AgentInstallTests(unittest.TestCase):
         install = self.run_cli("install-agent", "--project", cwd=project)
         self.assertEqual(0, install.returncode, install.stderr)
         self.assertTrue((project / ".claude" / "skills" / "ringer" / "SKILL.md").exists())
+        self.assertTrue((project / ".agents" / "skills" / "ringer" / "SKILL.md").exists())
+        self.assertTrue((project / ".agents" / "ringer" / "hooks" / "ringer_nudge.py").exists())
         self.assertTrue((project / ".claude" / "settings.json").exists())
+        self.assertTrue((project / ".codex" / "hooks.json").exists())
         self.assertFalse((self.home / ".claude").exists())
+        self.assertFalse((self.home / ".codex").exists())
 
         uninstall = self.run_cli("uninstall-agent", "--project", cwd=project)
         self.assertEqual(0, uninstall.returncode, uninstall.stderr)
         self.assertFalse((project / ".claude" / "skills" / "ringer").exists())
+        self.assertFalse((project / ".agents" / "skills" / "ringer").exists())
+        self.assertFalse((project / ".agents" / "ringer" / "hooks" / "ringer_nudge.py").exists())
         settings = self.read_settings(project)
         self.assertEqual([], self.ringer_handlers(settings))
+        self.assertEqual([], self.ringer_handlers(self.read_codex_hooks(project)))
 
 
 if __name__ == "__main__":

--- a/tests/test_agent_install.py
+++ b/tests/test_agent_install.py
@@ -134,6 +134,106 @@ class AgentInstallTests(unittest.TestCase):
         self.assertIn(str(self.home / ".local" / "share" / "ringer" / "hooks" / "ringer_nudge.py"), command)
         self.assertNotIn("/tmp/ringer/hooks", command)
 
+    def test_install_migrates_multiple_stale_ringer_groups_to_one_canonical_group(self) -> None:
+        settings_path = self.home / ".claude" / "settings.json"
+        settings_path.parent.mkdir(parents=True, exist_ok=True)
+        settings_path.write_text(
+            json.dumps(
+                {
+                    "hooks": {
+                        "PreToolUse": [
+                            {
+                                "matcher": "Bash",
+                                "hooks": [
+                                    {
+                                        "type": "command",
+                                        "command": "python3 /tmp/old-checkout/hooks/ringer_nudge.py pre-bash",
+                                    }
+                                ],
+                            },
+                            {
+                                "matcher": "Bash",
+                                "hooks": [
+                                    {
+                                        "type": "command",
+                                        "command": "python3 /tmp/other-checkout/hooks/ringer_nudge.py pre-bash",
+                                    }
+                                ],
+                            },
+                        ]
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        result = self.run_cli("install-agent")
+        self.assertEqual(0, result.returncode, result.stderr)
+
+        groups = self.read_settings()["hooks"]["PreToolUse"]
+        self.assertEqual(1, len(groups))
+        self.assertEqual("Bash", groups[0]["matcher"])
+        self.assertEqual(1, len(groups[0]["hooks"]))
+        command = groups[0]["hooks"][0]["command"]
+        self.assertIn(str(self.home / ".local" / "share" / "ringer" / "hooks" / "ringer_nudge.py"), command)
+        self.assertNotIn("/tmp/old-checkout", command)
+        self.assertNotIn("/tmp/other-checkout", command)
+
+    def test_install_strips_ringer_handler_from_mixed_group_without_leaving_empty_groups(self) -> None:
+        settings_path = self.home / ".claude" / "settings.json"
+        settings_path.parent.mkdir(parents=True, exist_ok=True)
+        settings_path.write_text(
+            json.dumps(
+                {
+                    "hooks": {
+                        "PreToolUse": [
+                            {
+                                "matcher": "Bash",
+                                "hooks": [
+                                    {"type": "command", "command": "echo unrelated"},
+                                    {
+                                        "type": "command",
+                                        "command": "python3 /tmp/old-checkout/hooks/ringer_nudge.py pre-bash",
+                                    },
+                                ],
+                            },
+                            {
+                                "matcher": "Bash",
+                                "hooks": [
+                                    {
+                                        "type": "command",
+                                        "command": "python3 /tmp/old-checkout/hooks/ringer_nudge.py pre-bash",
+                                    },
+                                    {
+                                        "type": "command",
+                                        "command": "python3 /tmp/other-checkout/hooks/ringer_nudge.py pre-bash",
+                                    },
+                                ],
+                            },
+                        ]
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        result = self.run_cli("install-agent")
+        self.assertEqual(0, result.returncode, result.stderr)
+
+        groups = self.read_settings()["hooks"]["PreToolUse"]
+        self.assertEqual(2, len(groups))
+        for group in groups:
+            self.assertNotEqual([], group["hooks"])
+        self.assertEqual("Bash", groups[0]["matcher"])
+        self.assertEqual([{"type": "command", "command": "echo unrelated"}], groups[0]["hooks"])
+        ringer_commands = [handler["command"] for handler in self.ringer_handlers(self.read_settings())]
+        pre_bash_commands = [command for command in ringer_commands if command.endswith(" pre-bash")]
+        self.assertEqual(1, len(pre_bash_commands))
+        self.assertIn(
+            str(self.home / ".local" / "share" / "ringer" / "hooks" / "ringer_nudge.py"),
+            pre_bash_commands[0],
+        )
+
     def test_install_preserves_unrelated_hooks_and_settings_keys(self) -> None:
         claude = self.home / ".claude"
         claude.mkdir()

--- a/tests/test_design_reference.py
+++ b/tests/test_design_reference.py
@@ -12,10 +12,31 @@ sys.path.insert(0, str(ROOT))
 
 from ringer import ARTIFACT_BASE_CSS, ArtifactRenderer, render_final_report_html, render_status_html  # noqa: E402
 
-REFERENCE = Path(
-    "/private/tmp/claude-501/-Users-jonathanedwards-WORKSPACE-20-CLIENTS-NATE-10-ACTIVE-SYSTEMS-ringer-system/"
-    "d4e72b45-c6bd-4928-aaf0-4e3552eb8f04/scratchpad/design-bake/design-reference.html"
-)
+EXPECTED_DARK_TOKENS = {
+    "--ground": "#0b0e14",
+    "--surface": "#141a26",
+    "--ink": "#e9eef7",
+    "--muted": "#8fa0b6",
+    "--hairline": "rgba(143,160,182,.22)",
+    "--accent": "#35d0ff",
+    "--pass": "#45d17e",
+    "--fail": "#ff5f6b",
+    "--waiting": "#6f7c92",
+    "--quote-bg": "rgba(255,95,107,.08)",
+}
+
+EXPECTED_LIGHT_TOKENS = {
+    "--ground": "#f2f5f9",
+    "--surface": "#ffffff",
+    "--ink": "#17202e",
+    "--muted": "#5a6a7e",
+    "--hairline": "rgba(90,106,126,.28)",
+    "--accent": "#007fb0",
+    "--pass": "#178a4c",
+    "--fail": "#cc3340",
+    "--waiting": "#7d8ba0",
+    "--quote-bg": "rgba(204,51,64,.07)",
+}
 
 
 def css_block(css: str, selector: str) -> str:
@@ -51,17 +72,16 @@ class DesignReferenceTests(unittest.TestCase):
         self.renderer = ArtifactRenderer(Path(self.tmp.name) / "artifacts" / "run.html")
 
     def test_renderer_tokens_match_design_reference(self) -> None:
-        reference_css = REFERENCE.read_text(encoding="utf-8")
-
-        expected_dark = token_values(css_block(reference_css, ":root"))
-        expected_light = token_values(media_light_root(reference_css))
-        expected_dark_override = token_values(css_block(reference_css, ':root[data-theme="dark"]'))
-        expected_light_override = token_values(css_block(reference_css, ':root[data-theme="light"]'))
-
-        self.assertEqual(expected_dark, token_values(css_block(ARTIFACT_BASE_CSS, ":root")))
-        self.assertEqual(expected_light, token_values(media_light_root(ARTIFACT_BASE_CSS)))
-        self.assertEqual(expected_dark_override, token_values(css_block(ARTIFACT_BASE_CSS, ':root[data-theme="dark"]')))
-        self.assertEqual(expected_light_override, token_values(css_block(ARTIFACT_BASE_CSS, ':root[data-theme="light"]')))
+        self.assertEqual(EXPECTED_DARK_TOKENS, token_values(css_block(ARTIFACT_BASE_CSS, ":root")))
+        self.assertEqual(EXPECTED_LIGHT_TOKENS, token_values(media_light_root(ARTIFACT_BASE_CSS)))
+        self.assertEqual(
+            EXPECTED_DARK_TOKENS,
+            token_values(css_block(ARTIFACT_BASE_CSS, ':root[data-theme="dark"]')),
+        )
+        self.assertEqual(
+            EXPECTED_LIGHT_TOKENS,
+            token_values(css_block(ARTIFACT_BASE_CSS, ':root[data-theme="light"]')),
+        )
 
     def test_live_page_uses_reference_structure(self) -> None:
         render_status_html(

--- a/tests/test_loop_safety.py
+++ b/tests/test_loop_safety.py
@@ -1,0 +1,548 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import asyncio
+import io
+import os
+import sys
+import tempfile
+import threading
+import time
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from dataclasses import replace as dataclass_replace
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+import ringer  # noqa: E402
+from ringer import (  # noqa: E402
+    AppConfig,
+    ArtifactConfig,
+    EngineConfig,
+    EvalConfig,
+    LAUNCH_CLASS_THRESHOLD_MS,
+    Manifest,
+    RingerRunner,
+    VerifyResult,
+    WorkerResult,
+    append_escalation,
+    clear_escalations,
+    escalations_path,
+    read_escalations,
+    review_escalations,
+    retry_decision,
+    run_status_command,
+)
+
+
+def make_runner(root: Path) -> RingerRunner:
+    state_dir = root / "state"
+    artifact = ArtifactConfig(
+        enabled=False,
+        out_template=str(root / "artifact-{run_id}.html"),
+        report_template=str(root / "report-{run_id}.html"),
+        index_out=root / "index.html",
+    )
+    engine = EngineConfig(
+        name="mock",
+        bin=sys.executable,
+        args_template=(),
+        full_access_args=(),
+        sandbox_args=(),
+    )
+    config = AppConfig(
+        path=None,
+        identity_default=None,
+        state_dir=state_dir,
+        dashboard_port_base=8787,
+        hud_port=8700,
+        hud_app_path=None,
+        allow_full_access=False,
+        eval=EvalConfig(backend="jsonl", jsonl_path=root / "runs.jsonl"),
+        engines={"mock": engine},
+        artifact=artifact,
+    )
+    manifest = Manifest.from_obj(
+        {
+            "run_name": "loop-safety-test",
+            "workdir": str(root / "work"),
+            "tasks": [
+                {
+                    "key": "task-one",
+                    "engine": "mock",
+                    "spec": "Run the deterministic test worker.",
+                    "check": "echo FAIL: deterministic test failure; exit 1",
+                }
+            ],
+        }
+    )
+    return RingerRunner(manifest, config, "test-agent", dashboard_enabled=False)
+
+
+class RetryDecisionTests(unittest.TestCase):
+    def test_fast_nonzero_fail_is_terminal_launch(self) -> None:
+        self.assertEqual(retry_decision("FAIL", 406, 1, 2, 2), "terminal-launch")
+        self.assertEqual(
+            retry_decision("FAIL", LAUNCH_CLASS_THRESHOLD_MS - 1, 1, 2, 1),
+            "terminal-launch",
+        )
+
+    def test_fast_clean_exit_fail_retries(self) -> None:
+        # Exit 0 means the worker did work that flunked the check; the
+        # failure-context retry is legitimate (mock engine relies on this).
+        self.assertEqual(retry_decision("FAIL", 406, 1, 2, 0), "retry")
+        self.assertEqual(retry_decision("FAIL", 406, 1, 2, None), "retry")
+
+    def test_slow_fail_retries(self) -> None:
+        self.assertEqual(retry_decision("FAIL", LAUNCH_CLASS_THRESHOLD_MS, 1, 2, 2), "retry")
+        self.assertEqual(retry_decision("FAIL", 120_000, 1, 2, 1), "retry")
+
+    def test_timeout_retries_regardless_of_duration(self) -> None:
+        self.assertEqual(retry_decision("TIMEOUT", 5_000, 1, 2, None), "retry")
+
+    def test_last_attempt_is_terminal(self) -> None:
+        self.assertEqual(retry_decision("FAIL", 120_000, 2, 2, 1), "terminal")
+        self.assertEqual(retry_decision("FAIL", 406, 2, 2, 2), "terminal")
+        self.assertEqual(retry_decision("TIMEOUT", 900_000, 2, 2, None), "terminal")
+
+    def test_error_and_pass_never_retry(self) -> None:
+        self.assertEqual(retry_decision("ERROR", 50, 1, 2, 1), "terminal")
+        self.assertEqual(retry_decision("PASS", 50_000, 1, 2, 0), "terminal")
+
+
+class EscalationLedgerTests(unittest.TestCase):
+    def test_append_and_read_roundtrip(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            state = Path(tmp)
+            append_escalation(state, {"task_key": "a", "verdict": "FAIL"})
+            append_escalation(state, {"task_key": "b", "verdict": "TIMEOUT"})
+            records = read_escalations(state)
+            self.assertEqual([item["task_key"] for item in records], ["a", "b"])
+            self.assertTrue(escalations_path(state).exists())
+
+    def test_read_missing_file_is_empty(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            self.assertEqual(read_escalations(Path(tmp)), [])
+
+    def test_read_skips_corrupt_lines(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            state = Path(tmp)
+            escalations_path(state).write_text(
+                '{"task_key": "ok", "verdict": "FAIL"}\nnot-json\n',
+                encoding="utf-8",
+            )
+            records = read_escalations(state)
+            self.assertEqual(len(records), 1)
+            self.assertEqual(records[0]["task_key"], "ok")
+
+    def test_read_respects_limit(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            state = Path(tmp)
+            for index in range(60):
+                append_escalation(state, {"task_key": f"t{index}"})
+            records = read_escalations(state, limit=50)
+            self.assertEqual(len(records), 50)
+            self.assertEqual(records[-1]["task_key"], "t59")
+
+    def test_read_returns_every_record_by_default(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            state = Path(tmp)
+            for index in range(60):
+                append_escalation(state, {"task_key": f"t{index}"})
+
+            records = read_escalations(state)
+
+            self.assertEqual(60, len(records))
+            self.assertEqual("t0", records[0]["task_key"])
+
+    def test_append_failure_is_reported_to_caller(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            blocker = Path(tmp) / "blocker"
+            blocker.write_text("not a directory", encoding="utf-8")
+
+            self.assertFalse(append_escalation(blocker / "state", {"task_key": "a"}))
+
+    def test_recovery_deduplicates_legacy_task_record(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            state = Path(tmp)
+            append_escalation(state, {"run_id": "run", "task_key": "task"})
+            append_escalation(
+                state,
+                {
+                    "escalation_id": "run:task",
+                    "run_id": "run",
+                    "task_key": "task",
+                },
+            )
+
+            self.assertEqual(1, len(read_escalations(state)))
+
+    def test_clear_failure_is_loud_and_nonzero(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            state = root / "state"
+            escalations_path(state).mkdir(parents=True)
+            stdout = io.StringIO()
+            stderr = io.StringIO()
+            config = SimpleNamespace(state_dir=state)
+            with mock.patch.dict(os.environ, {"RINGER_HOME": str(root / "ringer-home")}):
+                with redirect_stdout(stdout), redirect_stderr(stderr):
+                    result = run_status_command(
+                        config,
+                        SimpleNamespace(clear_escalations=True),
+                    )
+
+            self.assertEqual(1, result)
+            self.assertIn("FAILED TO CLEAR", stderr.getvalue())
+
+    def test_clear_displays_every_acknowledged_record(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            state = root / "state"
+            for index in range(60):
+                append_escalation(
+                    state,
+                    {
+                        "logged_at": "2026-07-13T00:00:00+00:00",
+                        "run_id": "run",
+                        "task_key": f"t{index}",
+                        "verdict": "FAIL",
+                        "log_path": "worker.log",
+                    },
+                )
+            stdout = io.StringIO()
+            config = SimpleNamespace(state_dir=state)
+            with mock.patch.dict(os.environ, {"RINGER_HOME": str(root / "ringer-home")}):
+                with redirect_stdout(io.StringIO()):
+                    self.assertEqual(
+                        2,
+                        run_status_command(config, SimpleNamespace(clear_escalations=False)),
+                    )
+                with redirect_stdout(stdout):
+                    result = run_status_command(
+                        config,
+                        SimpleNamespace(clear_escalations=True),
+                    )
+
+            output = stdout.getvalue()
+            self.assertEqual(0, result)
+            self.assertIn("acknowledged and cleared escalations: 60", output)
+            self.assertIn(" t0: FAIL ", output)
+            self.assertIn(" t59: FAIL ", output)
+            self.assertEqual([], read_escalations(state))
+
+    def test_append_waiting_on_clear_survives_in_new_ledger(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            state = Path(tmp)
+            append_escalation(state, {"task_key": "old"})
+            _records, review_error = review_escalations(state)
+            self.assertIsNone(review_error)
+            original_read = ringer._read_escalations_unlocked
+            writer: list[threading.Thread] = []
+            blocked: list[bool] = []
+
+            def slow_read(path: Path) -> list[dict[str, object]]:
+                records = original_read(path)
+                thread = threading.Thread(
+                    target=lambda: append_escalation(state, {"task_key": "new"})
+                )
+                writer.append(thread)
+                thread.start()
+                time.sleep(0.05)
+                blocked.append(thread.is_alive())
+                return records
+
+            with mock.patch("ringer._read_escalations_unlocked", side_effect=slow_read):
+                cleared, error = clear_escalations(state)
+            writer[0].join(timeout=2)
+
+            self.assertIsNone(error)
+            self.assertEqual(["old"], [record["task_key"] for record in cleared])
+            self.assertEqual([True], blocked)
+            self.assertEqual(["new"], [record["task_key"] for record in read_escalations(state)])
+
+    def test_clear_acknowledges_only_the_last_status_snapshot(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            state = root / "state"
+            config = SimpleNamespace(state_dir=state)
+            append_escalation(
+                state,
+                {
+                    "escalation_id": "run:old",
+                    "run_id": "run",
+                    "task_key": "old",
+                    "verdict": "FAIL",
+                },
+            )
+            with mock.patch.dict(os.environ, {"RINGER_HOME": str(root / "ringer-home")}):
+                with redirect_stdout(io.StringIO()):
+                    self.assertEqual(
+                        2,
+                        run_status_command(config, SimpleNamespace(clear_escalations=False)),
+                    )
+                append_escalation(
+                    state,
+                    {
+                        "escalation_id": "run:new",
+                        "run_id": "run",
+                        "task_key": "new",
+                        "verdict": "FAIL",
+                    },
+                )
+                stdout = io.StringIO()
+                with redirect_stdout(stdout):
+                    result = run_status_command(
+                        config,
+                        SimpleNamespace(clear_escalations=True),
+                    )
+
+            self.assertEqual(2, result)
+            self.assertIn("acknowledged and cleared escalations: 1", stdout.getvalue())
+            self.assertIn("new stranded escalations: 1", stdout.getvalue())
+            self.assertEqual(
+                ["new"],
+                [record["task_key"] for record in read_escalations(state)],
+            )
+
+    def test_clear_refuses_unreviewed_records(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            state = Path(tmp)
+            append_escalation(
+                state,
+                {
+                    "escalation_id": "run:task",
+                    "run_id": "run",
+                    "task_key": "task",
+                    "verdict": "FAIL",
+                },
+            )
+
+            cleared, error = clear_escalations(state)
+
+            self.assertEqual([], cleared)
+            self.assertIsNotNone(error)
+            self.assertEqual(["task"], [record["task_key"] for record in read_escalations(state)])
+
+
+class RunnerLifecycleTests(unittest.IsolatedAsyncioTestCase):
+    async def test_launch_class_uses_worker_elapsed_time_only(self) -> None:
+        class SlowVerifier:
+            async def verify(self, _task: object, _taskdir: Path) -> VerifyResult:
+                await asyncio.sleep(0.05)
+                return VerifyResult(
+                    ok=False,
+                    check_returncode=1,
+                    check_timed_out=False,
+                    raw_output_excerpt="FAIL: intentionally slow verifier",
+                )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            runner = make_runner(Path(tmp))
+            runtime = runner.runtimes[0]
+            runtime.taskdir.mkdir(parents=True)
+            worker = mock.AsyncMock(
+                return_value=WorkerResult(returncode=2, timed_out=False, tokens=None)
+            )
+            runner.verifier = SlowVerifier()
+            with (
+                mock.patch.object(runner, "_prepare_taskdir", new=mock.AsyncMock(return_value=(True, None))),
+                mock.patch.object(runner, "_run_worker", new=worker),
+                mock.patch.object(runner, "_log_attempt"),
+                mock.patch.object(runner, "_record_task_escalation"),
+                mock.patch.dict(os.environ, {"RINGER_LAUNCH_CLASS_THRESHOLD_MS": "10"}),
+            ):
+                await runner._run_task(runtime)
+            runner.logger.close()
+
+            self.assertEqual(1, worker.await_count)
+            self.assertEqual("launch", runtime.failure_class)
+
+    async def test_cancelled_run_records_each_unfinished_task(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            runner = make_runner(root)
+            started = asyncio.Event()
+
+            async def wait_forever(_runtime: object) -> None:
+                started.set()
+                await asyncio.Future()
+
+            runner._run_task = wait_forever  # type: ignore[method-assign]
+            runner.kill_all_workers = mock.AsyncMock()  # type: ignore[method-assign]
+            runner.state_writer.start = mock.Mock()
+            runner.state_writer.flush = mock.Mock(return_value={})
+            runner.state_writer.finish = mock.Mock()
+            runner.state_writer.stop = mock.Mock()
+            stdout = io.StringIO()
+            with redirect_stdout(stdout):
+                task = asyncio.create_task(runner.run())
+                await started.wait()
+                task.cancel()
+                with self.assertRaises(asyncio.CancelledError):
+                    await task
+
+            records = read_escalations(runner.config.state_dir)
+            self.assertEqual(["task-one"], [record["task_key"] for record in records])
+            self.assertEqual("cancelled", records[0]["failure_class"])
+
+    async def test_terminal_escalation_warns_when_persistence_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            runner = make_runner(Path(tmp))
+            runtime = runner.runtimes[0]
+            stdout = io.StringIO()
+            stderr = io.StringIO()
+            with mock.patch("ringer.append_escalation", return_value=False):
+                with redirect_stdout(stdout), redirect_stderr(stderr):
+                    runner._record_task_escalation(runtime, "FAIL")
+            runner.logger.close()
+
+            self.assertNotIn("Recorded for", stdout.getvalue())
+            self.assertIn("FAILED TO RECORD", stderr.getvalue())
+
+    async def test_unexpected_runner_error_records_unfinished_task(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            runner = make_runner(Path(tmp))
+
+            async def fail_task(_runtime: object) -> None:
+                raise RuntimeError("deterministic runner failure")
+
+            runner._run_task = fail_task  # type: ignore[method-assign]
+            runner.kill_all_workers = mock.AsyncMock()  # type: ignore[method-assign]
+            runner.state_writer.start = mock.Mock()
+            runner.state_writer.flush = mock.Mock(return_value={})
+            runner.state_writer.finish = mock.Mock()
+            runner.state_writer.stop = mock.Mock()
+            stdout = io.StringIO()
+            with redirect_stdout(stdout):
+                with self.assertRaisesRegex(RuntimeError, "deterministic runner failure"):
+                    await runner.run()
+
+            records = read_escalations(runner.config.state_dir)
+            self.assertEqual(["task-one"], [record["task_key"] for record in records])
+            self.assertEqual("orchestrator", records[0]["failure_class"])
+
+    async def test_unexpected_runner_error_cancels_siblings_before_cleanup(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            runner = make_runner(Path(tmp))
+            sibling = runner._task_runtime(
+                dataclass_replace(runner.runtimes[0].task, key="task-two")
+            )
+            runner.runtimes.append(sibling)
+            sibling_started = asyncio.Event()
+            events: list[str] = []
+
+            async def run_task(runtime: object) -> None:
+                if runtime is sibling:
+                    sibling_started.set()
+                    try:
+                        await asyncio.Future()
+                    except asyncio.CancelledError:
+                        events.append("sibling-cancelled")
+                        raise
+                await sibling_started.wait()
+                raise RuntimeError("deterministic runner failure")
+
+            async def kill_workers() -> None:
+                events.append("workers-killed")
+
+            runner._run_task = run_task  # type: ignore[method-assign]
+            runner.kill_all_workers = kill_workers  # type: ignore[method-assign]
+            runner.state_writer.start = mock.Mock()
+            runner.state_writer.flush = mock.Mock(return_value={})
+            runner.state_writer.finish = mock.Mock()
+            runner.state_writer.stop = mock.Mock()
+            with redirect_stdout(io.StringIO()):
+                with self.assertRaisesRegex(RuntimeError, "deterministic runner failure"):
+                    await runner.run()
+
+            self.assertEqual(["sibling-cancelled", "workers-killed"], events)
+
+    async def test_kill_all_workers_waits_for_process_exit(self) -> None:
+        class Process:
+            pid = 123
+            returncode: int | None = None
+            wait_count = 0
+
+            async def wait(self) -> int:
+                self.wait_count += 1
+                self.returncode = -9
+                return self.returncode
+
+        with tempfile.TemporaryDirectory() as tmp:
+            runner = make_runner(Path(tmp))
+            proc = Process()
+            runner.active_processes[proc.pid] = proc  # type: ignore[assignment]
+            with (
+                mock.patch("ringer.terminate_process_group"),
+                mock.patch("ringer.kill_process_group"),
+                mock.patch("ringer.asyncio.sleep", new=mock.AsyncMock()),
+            ):
+                await runner.kill_all_workers()
+            runner.logger.close()
+
+            self.assertEqual(1, proc.wait_count)
+            self.assertEqual({}, runner.active_processes)
+
+    async def test_worker_error_defaults_to_launch_class(self) -> None:
+        class FailingVerifier:
+            async def verify(self, _task: object, _taskdir: Path) -> VerifyResult:
+                return VerifyResult(
+                    ok=False,
+                    check_returncode=1,
+                    check_timed_out=False,
+                    raw_output_excerpt="worker did not launch",
+                )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            runner = make_runner(Path(tmp))
+            runtime = runner.runtimes[0]
+            runner.verifier = FailingVerifier()
+            with (
+                mock.patch.object(
+                    runner,
+                    "_run_worker",
+                    new=mock.AsyncMock(
+                        return_value=WorkerResult(
+                            returncode=None,
+                            timed_out=False,
+                            tokens=None,
+                            error="spawn failed",
+                        )
+                    ),
+                ),
+                mock.patch.object(runner, "_record_task_escalation"),
+            ):
+                await runner._run_task(runtime)
+            runner.logger.close()
+
+            self.assertEqual("launch", runtime.failure_class)
+
+    async def test_full_access_gate_error_is_prepare_class(self) -> None:
+        class FailingVerifier:
+            async def verify(self, _task: object, _taskdir: Path) -> VerifyResult:
+                return VerifyResult(
+                    ok=False,
+                    check_returncode=1,
+                    check_timed_out=False,
+                    raw_output_excerpt="worker did not launch",
+                )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            runner = make_runner(Path(tmp))
+            runtime = runner.runtimes[0]
+            runtime.task = dataclass_replace(runtime.task, full_access=True)
+            runner.verifier = FailingVerifier()
+            with mock.patch.object(runner, "_record_task_escalation"):
+                await runner._run_task(runtime)
+            runner.logger.close()
+
+            self.assertEqual("prepare", runtime.failure_class)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_mock_engine.py
+++ b/tests/test_mock_engine.py
@@ -108,6 +108,9 @@ class MockEngineEndToEndTests(unittest.TestCase):
             env["HOME"] = str(home)
             env["RINGER_HOME"] = str(ringer_home)
             env["XDG_CONFIG_HOME"] = str(root / "xdg-config")
+            # The mock worker simulates an instant nonzero failure; disable the
+            # launch-class guard so this e2e keeps proving the retry path.
+            env["RINGER_LAUNCH_CLASS_THRESHOLD_MS"] = "0"
 
             proc = subprocess.run(
                 [

--- a/tests/test_nudge_hook.py
+++ b/tests/test_nudge_hook.py
@@ -44,12 +44,18 @@ class NudgeHookTests(unittest.TestCase):
             check=False,
         )
 
-    def pre_bash_payload(self, command: str, session_id: str = "session-1") -> dict[str, object]:
+    def pre_bash_payload(
+        self,
+        command: str,
+        session_id: str = "session-1",
+        cwd: str = "/tmp/session-work",
+    ) -> dict[str, object]:
         return {
             "session_id": session_id,
             "hook_event_name": "PreToolUse",
             "tool_name": "Bash",
             "tool_input": {"command": command},
+            "cwd": cwd,
         }
 
     def post_edit_payload(
@@ -57,6 +63,7 @@ class NudgeHookTests(unittest.TestCase):
         file_path: str,
         session_id: str = "session-1",
         tool_name: str = "Edit",
+        cwd: str = "/tmp/session-work",
     ) -> dict[str, object]:
         return {
             "session_id": session_id,
@@ -64,6 +71,25 @@ class NudgeHookTests(unittest.TestCase):
             "tool_name": tool_name,
             "tool_input": {"file_path": file_path},
             "tool_response": {"success": True},
+            "cwd": cwd,
+        }
+
+    def codex_patch_payload(
+        self,
+        file_paths: list[str],
+        session_id: str = "codex-session",
+        cwd: str = "/tmp/session-work",
+    ) -> dict[str, object]:
+        patch_lines = ["*** Begin Patch"]
+        patch_lines.extend(f"*** Update File: {path}" for path in file_paths)
+        patch_lines.append("*** End Patch")
+        return {
+            "session_id": session_id,
+            "hook_event_name": "PostToolUse",
+            "tool_name": "apply_patch",
+            "tool_input": {"command": "\n".join(patch_lines)},
+            "tool_response": {"success": True},
+            "cwd": cwd,
         }
 
     def assertNudged(self, proc: subprocess.CompletedProcess[str], event_name: str) -> None:
@@ -112,10 +138,25 @@ class NudgeHookTests(unittest.TestCase):
         proc = self.run_hook("pre-bash", self.pre_bash_payload("python3 ringer.py run manifest.json"))
         self.assertSilent(proc)
 
-    def test_pre_bash_stays_silent_when_active_run_has_live_pid(self) -> None:
-        self.write_active_run(os.getpid())
-        proc = self.run_hook("pre-bash", self.pre_bash_payload("node probe-simulate.mjs"))
+    def test_pre_bash_stays_silent_inside_active_run_workdir(self) -> None:
+        self.write_active_run(os.getpid(), "/tmp/live-ringer-work")
+        proc = self.run_hook(
+            "pre-bash",
+            self.pre_bash_payload("node probe-simulate.mjs", cwd="/tmp/live-ringer-work/task"),
+        )
         self.assertSilent(proc)
+
+    def test_unrelated_active_run_does_not_silence_session(self) -> None:
+        self.write_active_run(os.getpid(), "/tmp/live-ringer-work")
+        proc = self.run_hook(
+            "pre-bash",
+            self.pre_bash_payload(
+                "node probe-simulate.mjs",
+                session_id="unrelated-session",
+                cwd="/tmp/other-work",
+            ),
+        )
+        self.assertNudged(proc, "PreToolUse")
 
     def test_pre_bash_dedupes_per_session(self) -> None:
         first = self.run_hook("pre-bash", self.pre_bash_payload("node probe-simulate.mjs"))
@@ -146,6 +187,33 @@ class NudgeHookTests(unittest.TestCase):
         files = ["/tmp/a.py", "/tmp/b.py", "/tmp/a.py", "/tmp/b.py", "/tmp/a.py", "/tmp/b.py", "/tmp/a.py"]
         for file_path in files:
             self.assertSilent(self.run_hook("post-edit", self.post_edit_payload(file_path, "session-2")))
+
+    def test_codex_apply_patch_paths_count_as_distinct_files(self) -> None:
+        for _ in range(7):
+            payload = self.codex_patch_payload(
+                ["src/a.py", "src/b.py"],
+                session_id="codex-session",
+            )
+            self.assertSilent(self.run_hook("post-edit", payload))
+
+        nudged = self.run_hook(
+            "post-edit",
+            self.codex_patch_payload(
+                ["src/a.py", "src/b.py", "src/c.py"],
+                session_id="codex-session",
+            ),
+        )
+        self.assertNudged(nudged, "PostToolUse")
+
+    def test_post_edit_stays_silent_inside_active_run_workdir(self) -> None:
+        self.write_active_run(os.getpid(), "/tmp/live-ringer-work")
+        for index in range(8):
+            payload = self.post_edit_payload(
+                f"/tmp/live-ringer-work/file-{index}.py",
+                session_id="worker-session",
+                cwd="/tmp/live-ringer-work/task",
+            )
+            self.assertSilent(self.run_hook("post-edit", payload))
 
     def test_malformed_stdin_exits_zero_silently(self) -> None:
         proc = self.run_hook("pre-bash", "{not json")

--- a/tests/test_nudge_hook.py
+++ b/tests/test_nudge_hook.py
@@ -14,10 +14,17 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 HOOK = ROOT / "hooks" / "ringer_nudge.py"
 NUDGE_TEXT = (
-    "Ringer routing check: this looks like swarm-shaped work happening inline "
-    "(model call/harness/edit loop outside a live Ringer run). Load the ringer "
-    "skill and route it as a manifest — a single task is a one-task manifest. "
-    "If the user explicitly asked for inline work, proceed."
+    "Ringer advisory: this command appears to call a model provider or "
+    "conversational harness outside a live Ringer run. Do not load or launch "
+    "Ringer automatically. If the user selected Ringer or the closest repository "
+    "instructions require it, use the Ringer skill. Otherwise continue directly "
+    "and recommend Ringer at most once only when the job has at least two genuinely "
+    "independent lanes."
+)
+NO_MISTAKES_FIX_OWNERSHIP_STATES = (
+    "fixing",
+    "awaiting_approval",
+    "fix_review",
 )
 
 
@@ -27,13 +34,21 @@ class NudgeHookTests(unittest.TestCase):
         self.addCleanup(self.temp.cleanup)
         self.home = Path(self.temp.name) / "home"
         self.ringer_home = Path(self.temp.name) / "ringer"
+        self.bin_dir = Path(self.temp.name) / "bin"
         self.home.mkdir()
         self.ringer_home.mkdir()
 
-    def run_hook(self, mode: str, payload: object | str) -> subprocess.CompletedProcess[str]:
+    def run_hook(
+        self,
+        mode: str,
+        payload: object | str,
+        path: str | None = None,
+    ) -> subprocess.CompletedProcess[str]:
         env = os.environ.copy()
         env["HOME"] = str(self.home)
         env["RINGER_HOME"] = str(self.ringer_home)
+        if path is not None:
+            env["PATH"] = path
         stdin = payload if isinstance(payload, str) else json.dumps(payload)
         return subprocess.run(
             [sys.executable, str(HOOK), mode],
@@ -58,52 +73,18 @@ class NudgeHookTests(unittest.TestCase):
             "cwd": cwd,
         }
 
-    def post_edit_payload(
-        self,
-        file_path: str,
-        session_id: str = "session-1",
-        tool_name: str = "Edit",
-        cwd: str = "/tmp/session-work",
-    ) -> dict[str, object]:
-        return {
-            "session_id": session_id,
-            "hook_event_name": "PostToolUse",
-            "tool_name": tool_name,
-            "tool_input": {"file_path": file_path},
-            "tool_response": {"success": True},
-            "cwd": cwd,
-        }
-
-    def codex_patch_payload(
-        self,
-        file_paths: list[str],
-        session_id: str = "codex-session",
-        cwd: str = "/tmp/session-work",
-    ) -> dict[str, object]:
-        patch_lines = ["*** Begin Patch"]
-        patch_lines.extend(f"*** Update File: {path}" for path in file_paths)
-        patch_lines.append("*** End Patch")
-        return {
-            "session_id": session_id,
-            "hook_event_name": "PostToolUse",
-            "tool_name": "apply_patch",
-            "tool_input": {"command": "\n".join(patch_lines)},
-            "tool_response": {"success": True},
-            "cwd": cwd,
-        }
-
-    def assertNudged(self, proc: subprocess.CompletedProcess[str], event_name: str) -> None:
+    def assert_nudged(self, proc: subprocess.CompletedProcess[str]) -> None:
         self.assertEqual(0, proc.returncode)
         data = json.loads(proc.stdout)
         self.assertEqual(
             {
-                "hookEventName": event_name,
+                "hookEventName": "PreToolUse",
                 "additionalContext": NUDGE_TEXT,
             },
             data["hookSpecificOutput"],
         )
 
-    def assertSilent(self, proc: subprocess.CompletedProcess[str]) -> None:
+    def assert_silent(self, proc: subprocess.CompletedProcess[str]) -> None:
         self.assertEqual(0, proc.returncode)
         self.assertEqual("", proc.stdout)
         self.assertEqual("", proc.stderr)
@@ -121,33 +102,86 @@ class NudgeHookTests(unittest.TestCase):
         }
         path.write_text(json.dumps(payload), encoding="utf-8")
 
+    def make_git_repo(self, branch: str = "feature/owned") -> Path:
+        repo = Path(self.temp.name) / "repo"
+        subprocess.run(
+            ["git", "init", "--initial-branch", branch, str(repo)],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        return repo
+
+    def install_no_mistakes(self, script: str) -> None:
+        self.bin_dir.mkdir(exist_ok=True)
+        executable = self.bin_dir / "no-mistakes"
+        executable.write_text(f"#!/bin/sh\n{script}\n", encoding="utf-8")
+        executable.chmod(0o755)
+
+    def no_mistakes_path(self) -> str:
+        return f"{self.bin_dir}{os.pathsep}{os.environ['PATH']}"
+
+    def toon_status(
+        self,
+        branch: str,
+        rows: list[tuple[str, str]],
+        run_status: str = "running",
+    ) -> str:
+        lines = [
+            "run:",
+            "  id: test-run",
+            f"  branch: {branch}",
+            f"  status: {run_status}",
+            "  head: 8f3a6c1",
+            "  steps[9]{step,status,findings,duration_ms}:",
+        ]
+        lines.extend(f"    {step},{status},1,123" for step, status in rows)
+        return "\n".join(lines) + "\n"
+
+    def toon_status_script(self, output: str) -> str:
+        return "cat <<'STATUS'\n" + output + "STATUS"
+
     def test_pre_bash_nudges_on_harness_script(self) -> None:
         proc = self.run_hook("pre-bash", self.pre_bash_payload("node probe-simulate.mjs"))
-        self.assertNudged(proc, "PreToolUse")
+        self.assert_nudged(proc)
 
     def test_pre_bash_nudges_on_provider_endpoint(self) -> None:
-        payload = self.pre_bash_payload("curl https://api.anthropic.com/v1/messages", "session-2")
-        proc = self.run_hook("pre-bash", payload)
-        self.assertNudged(proc, "PreToolUse")
+        payload = self.pre_bash_payload(
+            "curl https://api.anthropic.com/v1/messages", "session-2"
+        )
+        self.assert_nudged(self.run_hook("pre-bash", payload))
 
     def test_pre_bash_stays_silent_on_ordinary_command(self) -> None:
-        proc = self.run_hook("pre-bash", self.pre_bash_payload("ls -la"))
-        self.assertSilent(proc)
+        self.assert_silent(
+            self.run_hook("pre-bash", self.pre_bash_payload("ls -la"))
+        )
 
-    def test_pre_bash_stays_silent_when_command_contains_ringer_py(self) -> None:
-        proc = self.run_hook("pre-bash", self.pre_bash_payload("python3 ringer.py run manifest.json"))
-        self.assertSilent(proc)
+    def test_pre_bash_stays_silent_on_ringer_command(self) -> None:
+        commands = (
+            "python3 ringer.py run manifest.json",
+            "/Users/mattskinner/.local/bin/ringer run manifest.json",
+        )
+        for index, command in enumerate(commands):
+            with self.subTest(command=command):
+                self.assert_silent(
+                    self.run_hook(
+                        "pre-bash",
+                        self.pre_bash_payload(command, session_id=f"ringer-{index}"),
+                    )
+                )
 
     def test_pre_bash_stays_silent_inside_active_run_workdir(self) -> None:
-        self.write_active_run(os.getpid(), "/tmp/live-ringer-work")
+        self.write_active_run(os.getpid())
         proc = self.run_hook(
             "pre-bash",
-            self.pre_bash_payload("node probe-simulate.mjs", cwd="/tmp/live-ringer-work/task"),
+            self.pre_bash_payload(
+                "node probe-simulate.mjs", cwd="/tmp/live-ringer-work/task"
+            ),
         )
-        self.assertSilent(proc)
+        self.assert_silent(proc)
 
     def test_unrelated_active_run_does_not_silence_session(self) -> None:
-        self.write_active_run(os.getpid(), "/tmp/live-ringer-work")
+        self.write_active_run(os.getpid())
         proc = self.run_hook(
             "pre-bash",
             self.pre_bash_payload(
@@ -156,68 +190,108 @@ class NudgeHookTests(unittest.TestCase):
                 cwd="/tmp/other-work",
             ),
         )
-        self.assertNudged(proc, "PreToolUse")
+        self.assert_nudged(proc)
 
     def test_pre_bash_dedupes_per_session(self) -> None:
-        first = self.run_hook("pre-bash", self.pre_bash_payload("node probe-simulate.mjs"))
-        second = self.run_hook("pre-bash", self.pre_bash_payload("curl https://api.openai.com/v1/chat/completions"))
-        self.assertNudged(first, "PreToolUse")
-        self.assertSilent(second)
-
-    def test_post_edit_nudges_at_eight_edits_and_three_files_once(self) -> None:
-        files = [
-            "/tmp/a.py",
-            "/tmp/a.py",
-            "/tmp/b.py",
-            "/tmp/b.py",
-            "/tmp/a.py",
-            "/tmp/b.py",
-            "/tmp/a.py",
-        ]
-        for file_path in files:
-            self.assertSilent(self.run_hook("post-edit", self.post_edit_payload(file_path)))
-
-        nudged = self.run_hook("post-edit", self.post_edit_payload("/tmp/c.py"))
-        self.assertNudged(nudged, "PostToolUse")
-
-        again = self.run_hook("post-edit", self.post_edit_payload("/tmp/d.py"))
-        self.assertSilent(again)
-
-    def test_post_edit_stays_silent_for_seven_edits_and_two_files(self) -> None:
-        files = ["/tmp/a.py", "/tmp/b.py", "/tmp/a.py", "/tmp/b.py", "/tmp/a.py", "/tmp/b.py", "/tmp/a.py"]
-        for file_path in files:
-            self.assertSilent(self.run_hook("post-edit", self.post_edit_payload(file_path, "session-2")))
-
-    def test_codex_apply_patch_paths_count_as_distinct_files(self) -> None:
-        for _ in range(7):
-            payload = self.codex_patch_payload(
-                ["src/a.py", "src/b.py"],
-                session_id="codex-session",
-            )
-            self.assertSilent(self.run_hook("post-edit", payload))
-
-        nudged = self.run_hook(
-            "post-edit",
-            self.codex_patch_payload(
-                ["src/a.py", "src/b.py", "src/c.py"],
-                session_id="codex-session",
-            ),
+        first = self.run_hook(
+            "pre-bash", self.pre_bash_payload("node probe-simulate.mjs")
         )
-        self.assertNudged(nudged, "PostToolUse")
+        second = self.run_hook(
+            "pre-bash",
+            self.pre_bash_payload("curl https://api.openai.com/v1/chat/completions"),
+        )
+        self.assert_nudged(first)
+        self.assert_silent(second)
 
-    def test_post_edit_stays_silent_inside_active_run_workdir(self) -> None:
-        self.write_active_run(os.getpid(), "/tmp/live-ringer-work")
-        for index in range(8):
-            payload = self.post_edit_payload(
-                f"/tmp/live-ringer-work/file-{index}.py",
-                session_id="worker-session",
-                cwd="/tmp/live-ringer-work/task",
+    def test_active_no_mistakes_fix_ownership_suppresses_advisory(self) -> None:
+        repo = self.make_git_repo("feature/owned")
+        ownership_rows = (("review", "running"),) + tuple(
+            ("fix", state) for state in NO_MISTAKES_FIX_OWNERSHIP_STATES
+        )
+        for step, state in ownership_rows:
+            with self.subTest(step=step, state=state):
+                self.install_no_mistakes(
+                    self.toon_status_script(
+                        self.toon_status("feature/owned", [(step, state)])
+                    )
+                )
+                proc = self.run_hook(
+                    "pre-bash",
+                    self.pre_bash_payload(
+                        "node probe-simulate.mjs",
+                        session_id=f"owned-{step}-{state}",
+                        cwd=str(repo),
+                    ),
+                    path=self.no_mistakes_path(),
+                )
+                self.assert_silent(proc)
+
+    def test_no_mistakes_on_another_branch_does_not_suppress_advisory(self) -> None:
+        repo = self.make_git_repo("feature/owned")
+        self.install_no_mistakes(
+            self.toon_status_script(
+                self.toon_status("feature/other", [("review", "running")])
             )
-            self.assertSilent(self.run_hook("post-edit", payload))
+        )
+        proc = self.run_hook(
+            "pre-bash",
+            self.pre_bash_payload(
+                "node probe-simulate.mjs", "other-branch", str(repo)
+            ),
+            path=self.no_mistakes_path(),
+        )
+        self.assert_nudged(proc)
+
+    def test_post_publication_monitor_does_not_suppress_advisory(self) -> None:
+        repo = self.make_git_repo("feature/owned")
+        self.install_no_mistakes(
+            self.toon_status_script(
+                self.toon_status(
+                    "feature/owned",
+                    [("review", "completed"), ("ci", "running")],
+                )
+            )
+        )
+        proc = self.run_hook(
+            "pre-bash",
+            self.pre_bash_payload("node probe-simulate.mjs", "ci-running", str(repo)),
+            path=self.no_mistakes_path(),
+        )
+        self.assert_nudged(proc)
+
+    def test_no_mistakes_probe_failures_fail_open(self) -> None:
+        repo = self.make_git_repo()
+        cases = {
+            "absent": (None, "/usr/bin:/bin"),
+            "error": ("exit 1", None),
+            "malformed": ("printf '%s\\n' 'not a status response'", None),
+            "timeout": ("sleep 2", None),
+        }
+        for name, (script, path) in cases.items():
+            with self.subTest(name=name):
+                if script is not None:
+                    self.install_no_mistakes(script)
+                    path = self.no_mistakes_path()
+                proc = self.run_hook(
+                    "pre-bash",
+                    self.pre_bash_payload(
+                        "node probe-simulate.mjs", f"fail-open-{name}", str(repo)
+                    ),
+                    path=path,
+                )
+                self.assert_nudged(proc)
+
+    def test_removed_post_edit_mode_is_silent(self) -> None:
+        payload = {
+            "session_id": "post-edit",
+            "hook_event_name": "PostToolUse",
+            "tool_name": "Edit",
+            "tool_input": {"file_path": "/tmp/a.py"},
+        }
+        self.assert_silent(self.run_hook("post-edit", payload))
 
     def test_malformed_stdin_exits_zero_silently(self) -> None:
-        proc = self.run_hook("pre-bash", "{not json")
-        self.assertSilent(proc)
+        self.assert_silent(self.run_hook("pre-bash", "{not json"))
 
 
 if __name__ == "__main__":

--- a/tests/test_scoreboard_page.py
+++ b/tests/test_scoreboard_page.py
@@ -291,7 +291,7 @@ class ScoreboardPageTests(unittest.TestCase):
         html = self.render_to(self.root / "scoreboard.html")
 
         self.assertIn("<h1 class=\"scoreboard-title\">Model performance scoreboard</h1>", html)
-        self.assertIn("Generated July 6, 2026", html)
+        self.assertRegex(html, r"Generated [A-Z][a-z]+ \d{1,2}, 20\d{2}")
         self.assertIn('>eval log</a>', html)
         self.assertIn('>catalog</a>', html)
         self.assertIn('>model notes</a>', html)


### PR DESCRIPTION
## Summary

- Make direct execution the default and treat Ringer and no-mistakes as independent opt-in modes.
- Compact the Ringer skill and move detailed operating guidance into references loaded only after activation.
- Replace recurring post-edit nudges with one advisory pre-bash hook and preserve unrelated hooks during migration.
- Keep current main's retry, stranded-task recovery, and sandbox hardening intact.

## Validation

- `python3 -m unittest discover -s tests -p 'test_*.py'` - 169 tests passed.
- `python3 -m py_compile ringer.py hooks/ringer_nudge.py tests/test_agent_install.py` - passed.
- Ringer skill `quick_validate.py` - passed.
- `git diff --cached --check` before commit - passed.
- `cargo check --locked --manifest-path hud/Cargo.toml` will run in CI because Cargo is not installed locally.
