### PR TITLE
Add GPT-5.6 routing to Ringside

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,6 +365,7 @@ Every community PR that lands in main is credited here — that's a project rule
 - [@davekopecek](https://github.com/davekopecek) (Dave Kopecek) — committed the design-reference fixture so the design-token guard runs on every machine (#30)
 - [@snapsynapse](https://github.com/snapsynapse) (Sam Rogers) — graceful shutdown on SIGINT/SIGTERM with worker-tree cleanup and finished state, plus the 14-test end-to-end CLI regression suite (#4)
 - [@mlava](https://github.com/mlava) (Mark Lavercombe) — named setup failures across every diagnostic surface (#37) and `run --baseline`, the no-workers check preflight (#38)
+- [@revopsglobal](https://github.com/revopsglobal) (Greg Harned) — explicit GPT-5.6 routing and premium launch approval in Ringside Plan / Run (#64)
 
 Contributions are welcome — see [CONTRIBUTING.md](CONTRIBUTING.md) for the philosophy and what gets a PR merged fast. The short version: small and scoped, rebased on current main, every claim backed by an executed test. Authorship is always preserved — where a maintainer pushes a mechanical fix to your branch, you remain the commit author.
 

--- a/README.md
+++ b/README.md
@@ -109,6 +109,14 @@ Each task gets its own directory, its own worker, its own log, and its own verdi
 
 > **Worktree footgun:** on PASS the task's worktree is removed — including anything written inside it. In worktrees mode, worker logs live outside task worktrees in `workdir/logs/`; have workers write deliverables outside the worktree too, or have your `check` copy artifacts out before it exits 0.
 
+### Ringside Plan / Run
+
+Persistent Ringside includes a **Plan / Run** tab next to Runs and Models. It builds a normal Ringer manifest in the browser, previews it, validates it through `POST /api/plan/validate`, and launches through the local CLI with `POST /api/plan/run` only after the server revalidates the same manifest.
+
+The normal Codex lane is explicit `model: "gpt-5.5"`. The GPT-5.6 escalation lanes use the exact route IDs `gpt-5.6-terra`, `gpt-5.6-sol`, and `gpt-5.6-luna`; these are premium or candidate routes and are not defaults. Launch rejects any plan using those routes unless `premium_approved` is `true` and `premium_reason` is non-empty. Validation can show the premium routing without starting workers.
+
+Models remains historical performance evidence from executed runs. It helps choose future routing, but Plan / Run is the authoritative place to set the exact per-task `engine`, `model`, `task_type`, and reasoning `engine_args` before launch.
+
 Not sure what your tasks even are yet? [`docs/interview-prompt.md`](docs/interview-prompt.md) is a prompt you paste into any chatbot; it interviews you about the job and hands back a brief your orchestrating agent can turn into a manifest. Ready-made skeletons for the patterns that work live in [`templates/`](templates/).
 
 ## Lint

--- a/ringer.py
+++ b/ringer.py
@@ -4667,9 +4667,443 @@ def inject_models_tab_into_ringside_html(html: str) -> str:
     return html
 
 
+HUD_PLAN_BODY_LIMIT_BYTES = 256 * 1024
+PREMIUM_CODEX_MODELS = frozenset(
+    {
+        "gpt-5.6-luna",
+        "gpt-5.6-sol",
+        "gpt-5.6-terra",
+    }
+)
+PLAN_TASK_TYPES = (
+    "code-feature",
+    "code-fix",
+    "code-review",
+    "test-hardening",
+    "docs",
+    "research",
+    "probe",
+)
+PLAN_REASONING_EFFORTS = ("low", "medium", "high")
+
+
+def engine_accepts_model(engine: EngineConfig) -> bool:
+    return any("{model}" in item or item == "{model_args}" for item in engine.args_template)
+
+
+def build_hud_plan_payload(config: AppConfig) -> dict[str, Any]:
+    engines = []
+    for name, engine in sorted(config.engines.items()):
+        engines.append(
+            {
+                "name": name,
+                "model_default": engine.model_default,
+                "supports_model": engine_accepts_model(engine),
+                "supports_reasoning": any(item == "{engine_args}" for item in engine.args_template),
+            }
+        )
+
+    lanes: list[dict[str, Any]] = []
+    codex = config.engines.get("codex")
+    if codex is not None and engine_accepts_model(codex):
+        lanes.append(
+            {
+                "id": "codex-gpt-5.5",
+                "label": "Standard Codex GPT-5.5",
+                "engine": "codex",
+                "model": "gpt-5.5",
+                "premium": False,
+                "description": "Normal implementation, fixes, and reviews.",
+            }
+        )
+        for model, label, description in (
+            ("gpt-5.6-terra", "GPT-5.6 Terra", "Premium escalation for difficult implementation."),
+            ("gpt-5.6-sol", "GPT-5.6 Sol", "Premium escalation for hard review and synthesis."),
+            ("gpt-5.6-luna", "GPT-5.6 Luna", "Candidate escalation for explicit bakeoffs."),
+        ):
+            lanes.append(
+                {
+                    "id": model,
+                    "label": label,
+                    "engine": "codex",
+                    "model": model,
+                    "premium": True,
+                    "description": description,
+                }
+            )
+
+    return {
+        "engines": engines,
+        "lanes": lanes,
+        "task_types": list(PLAN_TASK_TYPES),
+        "reasoning_efforts": list(PLAN_REASONING_EFFORTS),
+        "defaults": {
+            "run_name": "ringer-run",
+            "workdir": str((config.state_dir / "work" / "ringer-run").resolve()),
+            "max_parallel": 2,
+            "worktrees": False,
+        },
+        "policy": {
+            "default_model": "gpt-5.5",
+            "explicit_task_models": True,
+            "premium_models": sorted(PREMIUM_CODEX_MODELS),
+            "premium_requires_approval": True,
+            "agentops_linkage": False,
+            "auto_start": False,
+        },
+    }
+
+
+def validate_hud_plan_payload(
+    payload: Any,
+    config: AppConfig,
+    *,
+    require_premium_approval: bool,
+) -> tuple[Manifest, dict[str, Any], list[str], dict[str, Any]]:
+    if not isinstance(payload, dict):
+        raise ValueError("request body must be a JSON object")
+    manifest_obj = payload.get("manifest")
+    if not isinstance(manifest_obj, dict):
+        raise ValueError("manifest must be a JSON object")
+
+    manifest = Manifest.from_obj(manifest_obj)
+    validate_manifest_engines(manifest, config)
+    for task in manifest.tasks:
+        engine = config.engines[task.engine]
+        if engine_accepts_model(engine) and not task.model:
+            raise ValueError(
+                f"task {task.key}: choose an explicit model in the orchestration plan; "
+                "Ringside will not inherit an engine default"
+            )
+        if task.full_access and not config.allow_full_access:
+            raise ValueError(
+                f"task {task.key}: full_access is disabled by config; choose sandboxed execution"
+            )
+
+    premium_tasks = [task.key for task in manifest.tasks if task.model in PREMIUM_CODEX_MODELS]
+    premium_approved = payload.get("premium_approved") is True
+    premium_reason = str(payload.get("premium_reason") or "").strip()
+    if require_premium_approval and premium_tasks and not premium_approved:
+        raise ValueError(
+            "premium routing is not approved; explicitly approve the premium tasks before launch"
+        )
+    if require_premium_approval and premium_tasks and not premium_reason:
+        raise ValueError("premium routing needs a short reason before launch")
+
+    findings = lint_manifest(manifest, include_model_log_nudges=True, config=config)
+    if require_premium_approval and findings:
+        raise ValueError("plan has lint findings: " + " | ".join(findings))
+
+    routing = {
+        "planned_at": utc_now_iso(),
+        "explicit_task_models": True,
+        "premium_approved": bool(premium_tasks and premium_approved),
+        "premium_reason": premium_reason if premium_tasks else "",
+        "premium_tasks": premium_tasks,
+        "task_models": {
+            task.key: {
+                "engine": task.engine,
+                "model": task.model,
+                "task_type": task.task_type,
+                "engine_args": list(task.engine_args),
+            }
+            for task in manifest.tasks
+        },
+    }
+    normalized = dict(manifest_obj)
+    normalized["routing"] = routing
+    return manifest, normalized, findings, routing
+
+
+def save_hud_plan(state_dir: Path, manifest_obj: dict[str, Any], run_name: str) -> Path:
+    plans_dir = state_dir / "plans"
+    plans_dir.mkdir(parents=True, exist_ok=True)
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    base = sanitize_artifact_name(run_name)
+    path = plans_dir / f"{base}-{stamp}.json"
+    suffix = 1
+    while path.exists():
+        path = plans_dir / f"{base}-{stamp}-{suffix}.json"
+        suffix += 1
+    atomic_write_json(path, manifest_obj)
+    return path
+
+
+def launch_hud_plan(config: AppConfig, manifest_path: Path) -> subprocess.Popen[bytes]:
+    command = [sys.executable, str(Path(__file__).resolve())]
+    if config.path is not None:
+        command.extend(["--config", str(config.path)])
+    command.extend(["run", str(manifest_path)])
+    log_path = config.state_dir / "plan-launches.log"
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    log_file = log_path.open("ab")
+    try:
+        return subprocess.Popen(
+            command,
+            stdout=log_file,
+            stderr=log_file,
+            stdin=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+    finally:
+        log_file.close()
+
+
+def inject_plan_tab_into_ringside_html(html: str) -> str:
+    if 'id="plan-panel"' in html or 'id="models-tab"' not in html:
+        return html
+    plan_tab = '      <button type="button" class="tab" id="plan-tab" aria-selected="false">Plan / Run</button>\n'
+    panel = """
+      <section id="plan-panel" class="panel plan-panel" hidden>
+        <form id="plan-form" class="plan-form" novalidate>
+          <header class="plan-header">
+            <div>
+              <h1>Plan / Run</h1>
+              <p>Build an explicit Ringer manifest, choose exact Codex model lanes, validate it, then launch through the local CLI.</p>
+            </div>
+            <div class="plan-metrics mono"><span id="plan-task-count">1</span> tasks <span id="plan-premium-count">0</span> premium</div>
+          </header>
+          <section class="plan-grid">
+            <label>Run name<input id="plan-run-name" required></label>
+            <label>Work directory<input id="plan-workdir" required></label>
+            <label>Repository<input id="plan-repo" placeholder="/absolute/path/to/repo"></label>
+            <label>Max parallel<input id="plan-max-parallel" type="number" min="1" max="32" value="2" required></label>
+            <label class="plan-check"><input id="plan-worktrees" type="checkbox"> Isolated worktrees</label>
+          </section>
+          <section>
+            <div class="plan-section-head">
+              <h2>Worker plan</h2>
+              <button id="plan-add-task" type="button">Add task</button>
+            </div>
+            <div id="plan-tasks" class="plan-tasks"></div>
+          </section>
+          <section id="premium-approval" class="premium-approval" hidden>
+            <h2>Premium gate</h2>
+            <p>GPT-5.6 Terra, Sol, and Luna require explicit approval and a reason before launch.</p>
+            <label class="plan-check"><input id="plan-premium-approved" type="checkbox"> I approve premium quota for the named tasks</label>
+            <label>Premium reason<input id="plan-premium-reason" placeholder="Why these tasks need GPT-5.6"></label>
+          </section>
+          <section class="plan-review">
+            <div id="plan-status" class="plan-status" role="status" aria-live="polite">Loading routing policy...</div>
+            <div class="plan-actions">
+              <button id="plan-validate" type="button">Validate plan</button>
+              <button id="plan-run" type="button">Start run</button>
+            </div>
+            <details open><summary>Manifest preview</summary><pre id="plan-manifest-preview" class="mono"></pre></details>
+          </section>
+        </form>
+      </section>
+"""
+    style = """
+    .plan-panel { padding: 0 clamp(12px, 2vw, 22px) clamp(20px, 3vw, 30px); }
+    .plan-form { display: grid; gap: 22px; max-width: 1200px; padding-top: 18px; }
+    .plan-header, .plan-section-head, .plan-actions { display: flex; align-items: center; justify-content: space-between; gap: 14px; }
+    .plan-header h1, .plan-section-head h2, .premium-approval h2 { margin: 0; }
+    .plan-header p, .premium-approval p { margin: 6px 0 0; color: var(--muted); max-width: 760px; }
+    .plan-metrics, .plan-status, .premium-approval, .plan-task { border: 1px solid var(--hairline); border-radius: 8px; padding: 12px; background: var(--surface); }
+    .plan-grid, .task-route-grid, .task-proof-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 12px; }
+    .plan-form label, .plan-task label { display: grid; gap: 6px; color: var(--muted); font-size: 12px; font-weight: 700; }
+    .plan-form input, .plan-form select, .plan-form textarea { width: 100%; min-height: 38px; border: 1px solid var(--hairline); border-radius: 8px; padding: 8px 10px; background: var(--ground); color: var(--ink); font: inherit; font-size: 13px; }
+    .plan-form textarea { min-height: 110px; resize: vertical; }
+    .plan-check { display: flex !important; grid-template-columns: none !important; align-items: center; flex-direction: row; gap: 8px; color: var(--ink) !important; }
+    .plan-check input { width: auto; min-height: auto; }
+    .plan-tasks { display: grid; gap: 12px; }
+    .task-spec { grid-column: 1 / -1; }
+    .plan-status.ready { border-color: var(--pass); }
+    .plan-status.error { border-color: var(--fail); color: var(--fail); }
+    .plan-status.working { border-color: var(--accent); }
+    .plan-review pre { max-height: 320px; overflow: auto; white-space: pre-wrap; }
+    @media (max-width: 760px) { .plan-grid, .task-route-grid, .task-proof-grid { grid-template-columns: 1fr; } .plan-header, .plan-section-head, .plan-actions { align-items: stretch; flex-direction: column; } }
+"""
+    script = r"""
+    function installPlanView() {
+      const VIEW_KEY = "ringside-view";
+      const runsPanel = document.getElementById("artifacts-panel");
+      const modelsPanel = document.getElementById("models-panel");
+      const planPanel = document.getElementById("plan-panel");
+      const runsTab = document.getElementById("runs-tab");
+      const modelsTab = document.getElementById("models-tab");
+      const planTab = document.getElementById("plan-tab");
+      const tasksRoot = document.getElementById("plan-tasks");
+      if (!runsPanel || !modelsPanel || !planPanel || !runsTab || !modelsTab || !planTab || !tasksRoot) return;
+      const state = {policy: null, tasks: []};
+      let nextTaskId = 1;
+      const el = id => document.getElementById(id);
+      const escapeHtml = value => String(value ?? "").replace(/[&<>"']/g, ch => ({"&":"&amp;","<":"&lt;",">":"&gt;",'"':"&quot;","'":"&#39;"}[ch]));
+      const slug = value => String(value || "task").toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "") || "task";
+      const longDefaultSpec = "Implement the requested scoped change. Preserve unrelated user changes, keep edits bounded to the stated ownership paths, and leave a concise summary of the verification performed.";
+      const defaultCheck = "test -s report.md || { echo 'FAIL: report.md is missing or empty'; exit 1; }";
+
+      function setStatus(message, kind = "") {
+        const status = el("plan-status");
+        status.className = `plan-status${kind ? ` ${kind}` : ""}`;
+        status.textContent = message;
+      }
+      function lanes() {
+        const policy = state.policy || {};
+        return Array.isArray(policy.lanes) && policy.lanes.length ? policy.lanes : [
+          {id:"codex-gpt-5.5", label:"Standard Codex GPT-5.5", engine:"codex", model:"gpt-5.5", premium:false},
+          {id:"gpt-5.6-terra", label:"GPT-5.6 Terra", engine:"codex", model:"gpt-5.6-terra", premium:true},
+          {id:"gpt-5.6-sol", label:"GPT-5.6 Sol", engine:"codex", model:"gpt-5.6-sol", premium:true},
+          {id:"gpt-5.6-luna", label:"GPT-5.6 Luna", engine:"codex", model:"gpt-5.6-luna", premium:true},
+        ];
+      }
+      function addTask(seed = {}) {
+        const lane = lanes()[0];
+        state.tasks.push({
+          id: `task-${nextTaskId++}`,
+          key: seed.key || `task-${state.tasks.length + 1}`,
+          task_type: seed.task_type || "code-feature",
+          lane: seed.lane || lane.id,
+          reasoning_effort: seed.reasoning_effort || "medium",
+          spec: seed.spec || longDefaultSpec,
+          check: seed.check || defaultCheck,
+          expect_files: seed.expect_files || "report.md",
+          verified: seed.verified || "report.md exists and the task-specific check passed.",
+        });
+        renderTasks();
+      }
+      function selectedLane(task) {
+        return lanes().find(item => item.id === task.lane) || lanes()[0];
+      }
+      function renderTasks() {
+        tasksRoot.innerHTML = state.tasks.map((task, index) => `
+          <article class="plan-task" data-id="${escapeHtml(task.id)}">
+            <div class="task-route-grid">
+              <label>Task key<input data-field="key" value="${escapeHtml(task.key)}"></label>
+              <label>Lane<select data-field="lane">${lanes().map(lane => `<option value="${escapeHtml(lane.id)}"${lane.id === task.lane ? " selected" : ""}>${escapeHtml(lane.label)} - ${escapeHtml(lane.model)}</option>`).join("")}</select></label>
+              <label>Reasoning effort<select data-field="reasoning_effort">${["low","medium","high"].map(effort => `<option value="${effort}"${task.reasoning_effort === effort ? " selected" : ""}>${effort}</option>`).join("")}</select></label>
+              <label>Task type<input data-field="task_type" value="${escapeHtml(task.task_type)}"></label>
+              <label class="task-spec">Spec<textarea data-field="spec">${escapeHtml(task.spec)}</textarea></label>
+              <label>Check<textarea data-field="check">${escapeHtml(task.check)}</textarea></label>
+              <label>Expected files<input data-field="expect_files" value="${escapeHtml(task.expect_files)}"></label>
+              <label>Verified sentence<input data-field="verified" value="${escapeHtml(task.verified)}"></label>
+            </div>
+            <button type="button" data-remove="${escapeHtml(task.id)}"${state.tasks.length === 1 ? " disabled" : ""}>Remove task ${index + 1}</button>
+          </article>`).join("");
+        updatePreview();
+      }
+      function taskManifest(task) {
+        const lane = selectedLane(task);
+        const engineArgs = task.reasoning_effort ? [`-c`, `model_reasoning_effort=${task.reasoning_effort}`] : [];
+        return {
+          key: slug(task.key),
+          spec: task.spec,
+          check: task.check,
+          expect_files: String(task.expect_files || "").split(",").map(item => item.trim()).filter(Boolean),
+          engine: lane.engine,
+          model: lane.model,
+          task_type: task.task_type,
+          engine_args: engineArgs,
+          verified: task.verified,
+        };
+      }
+      function buildRequest() {
+        const repo = el("plan-repo").value.trim();
+        const manifest = {
+          run_name: el("plan-run-name").value.trim(),
+          workdir: el("plan-workdir").value.trim(),
+          max_parallel: Number(el("plan-max-parallel").value || 1),
+          worktrees: el("plan-worktrees").checked,
+          tasks: state.tasks.map(taskManifest),
+        };
+        if (repo) manifest.repo = repo;
+        return {
+          manifest,
+          premium_approved: el("plan-premium-approved").checked,
+          premium_reason: el("plan-premium-reason").value.trim(),
+        };
+      }
+      function updatePreview() {
+        const request = buildRequest();
+        const premiumCount = request.manifest.tasks.filter(task => lanes().some(lane => lane.model === task.model && lane.premium)).length;
+        el("plan-task-count").textContent = String(request.manifest.tasks.length);
+        el("plan-premium-count").textContent = String(premiumCount);
+        el("premium-approval").hidden = premiumCount === 0;
+        el("plan-manifest-preview").textContent = JSON.stringify(request.manifest, null, 2);
+      }
+      async function postPlan(path) {
+        const response = await fetch(path, {method:"POST", headers:{"Content-Type":"application/json"}, body: JSON.stringify(buildRequest())});
+        const payload = await response.json();
+        if (!response.ok || payload.ok === false) throw new Error(payload.error || `HTTP ${response.status}`);
+        return payload;
+      }
+      function selectPlan(persist = true) {
+        runsPanel.hidden = true;
+        modelsPanel.hidden = true;
+        planPanel.hidden = false;
+        runsTab.setAttribute("aria-selected", "false");
+        modelsTab.setAttribute("aria-selected", "false");
+        planTab.setAttribute("aria-selected", "true");
+        if (persist) localStorage.setItem(VIEW_KEY, "plan");
+      }
+      function leavePlan() {
+        planPanel.hidden = true;
+        planTab.setAttribute("aria-selected", "false");
+      }
+      tasksRoot.addEventListener("input", event => {
+        const article = event.target.closest(".plan-task");
+        if (!article) return;
+        const task = state.tasks.find(item => item.id === article.dataset.id);
+        if (!task) return;
+        task[event.target.dataset.field] = event.target.value;
+        updatePreview();
+      });
+      tasksRoot.addEventListener("click", event => {
+        const id = event.target.dataset.remove;
+        if (!id || state.tasks.length === 1) return;
+        state.tasks = state.tasks.filter(task => task.id !== id);
+        renderTasks();
+      });
+      document.getElementById("plan-add-task").addEventListener("click", () => addTask());
+      document.getElementById("plan-validate").addEventListener("click", async () => {
+        updatePreview();
+        setStatus("Validating plan...", "working");
+        try {
+          const payload = await postPlan("/api/plan/validate");
+          setStatus(payload.ready ? "Plan is launch-ready." : `Plan validates with ${payload.findings.length} lint finding(s).`, payload.ready ? "ready" : "error");
+        } catch (error) { setStatus(error.message, "error"); }
+      });
+      document.getElementById("plan-run").addEventListener("click", async () => {
+        updatePreview();
+        setStatus("Running final preflight and starting workers...", "working");
+        try {
+          const payload = await postPlan("/api/plan/run");
+          setStatus(`Started ${payload.run_name}. Saved plan: ${payload.manifest_path}`, "ready");
+        } catch (error) { setStatus(error.message, "error"); }
+      });
+      document.querySelectorAll("#plan-form input, #plan-form textarea, #plan-form select").forEach(node => node.addEventListener("input", updatePreview));
+      planTab.addEventListener("click", () => selectPlan());
+      runsTab.addEventListener("click", leavePlan);
+      modelsTab.addEventListener("click", leavePlan);
+      fetch("/api/plan", {cache:"no-store"}).then(response => response.json()).then(policy => {
+        state.policy = policy;
+        const defaults = policy.defaults || {};
+        el("plan-run-name").value = defaults.run_name || "ringer-run";
+        el("plan-workdir").value = defaults.workdir || "";
+        el("plan-max-parallel").value = defaults.max_parallel || 2;
+        if (!state.tasks.length) addTask();
+        setStatus("Routing policy loaded.", "ready");
+        if (localStorage.getItem(VIEW_KEY) === "plan") selectPlan(false);
+      }).catch(error => {
+        setStatus(error.message || "routing policy unavailable", "error");
+        if (!state.tasks.length) addTask();
+      });
+    }
+
+"""
+    html = html.replace('      <button type="button" class="tab" id="models-tab" aria-selected="false">Models</button>\n', plan_tab + '      <button type="button" class="tab" id="models-tab" aria-selected="false">Models</button>\n', 1)
+    html = html.replace("    main {\n", style + "    main {\n", 1)
+    html = html.replace("    </main>\n", panel + "    </main>\n", 1)
+    html = html.replace("    installModelsView();\n    tickClock();\n", script + "    installModelsView();\n    installPlanView();\n    tickClock();\n", 1)
+    return html
+
+
 def read_ringside_html() -> str:
     try:
-        return inject_models_tab_into_ringside_html(RINGSIDE_HTML_PATH.read_text(encoding="utf-8"))
+        return inject_plan_tab_into_ringside_html(
+            inject_models_tab_into_ringside_html(RINGSIDE_HTML_PATH.read_text(encoding="utf-8"))
+        )
     except OSError:
         return """<!doctype html>
 <html lang="en">
@@ -4696,11 +5130,16 @@ def send_response_body(
     handler.wfile.write(body)
 
 
-def send_json_response(handler: BaseHTTPRequestHandler, data: dict[str, Any]) -> None:
+def send_json_response(
+    handler: BaseHTTPRequestHandler,
+    data: dict[str, Any],
+    *,
+    status: HTTPStatus = HTTPStatus.OK,
+) -> None:
     body = json.dumps(data, sort_keys=True).encode("utf-8")
     send_response_body(
         handler,
-        HTTPStatus.OK,
+        status,
         body,
         content_type="application/json; charset=utf-8",
         no_store=True,
@@ -4837,10 +5276,12 @@ class PersistentHudServer:
         preferred_port: int = DEFAULT_HUD_PORT,
         *,
         open_viewer: bool = True,
+        config: AppConfig | None = None,
     ) -> None:
         self.state_dir = state_dir
         self.preferred_port = preferred_port
         self.open_viewer = open_viewer
+        self.config = config
         self.httpd: ThreadingHTTPServer | None = None
         self.thread: threading.Thread | None = None
         self.port: int | None = None
@@ -4894,6 +5335,19 @@ class PersistentHudServer:
                             "rollup": [],
                             "error": str(exc) or exc.__class__.__name__,
                         }
+                    send_json_response(self, payload)
+                    return
+                if path == "/api/plan":
+                    try:
+                        config = server_ref.config or AppConfig.load()
+                        payload = build_hud_plan_payload(config)
+                    except Exception as exc:
+                        send_json_response(
+                            self,
+                            {"ok": False, "error": str(exc) or exc.__class__.__name__},
+                            status=HTTPStatus.INTERNAL_SERVER_ERROR,
+                        )
+                        return
                     send_json_response(self, payload)
                     return
                 if path.startswith("/api/open-folder"):
@@ -4957,6 +5411,90 @@ class PersistentHudServer:
                     )
                     return
                 self.send_error(HTTPStatus.NOT_FOUND)
+
+            def do_POST(self) -> None:  # noqa: N802
+                path = urllib.parse.urlparse(self.path).path
+                if path not in {"/api/plan/validate", "/api/plan/run"}:
+                    self.send_error(HTTPStatus.NOT_FOUND)
+                    return
+                content_type = self.headers.get("Content-Type", "").split(";", 1)[0].strip().lower()
+                if content_type != "application/json":
+                    send_json_response(
+                        self,
+                        {"ok": False, "error": "Content-Type must be application/json"},
+                        status=HTTPStatus.UNSUPPORTED_MEDIA_TYPE,
+                    )
+                    return
+                try:
+                    content_length = int(self.headers.get("Content-Length", "0"))
+                except ValueError:
+                    content_length = -1
+                if content_length <= 0:
+                    send_json_response(
+                        self,
+                        {"ok": False, "error": "request body is empty"},
+                        status=HTTPStatus.BAD_REQUEST,
+                    )
+                    return
+                if content_length > HUD_PLAN_BODY_LIMIT_BYTES:
+                    send_json_response(
+                        self,
+                        {"ok": False, "error": "request body is too large"},
+                        status=HTTPStatus.REQUEST_ENTITY_TOO_LARGE,
+                    )
+                    return
+                try:
+                    payload = json.loads(self.rfile.read(content_length).decode("utf-8"))
+                    config = server_ref.config or AppConfig.load()
+                    manifest, normalized, findings, routing = validate_hud_plan_payload(
+                        payload,
+                        config,
+                        require_premium_approval=path == "/api/plan/run",
+                    )
+                    if path == "/api/plan/validate":
+                        send_json_response(
+                            self,
+                            {
+                                "ok": True,
+                                "ready": not findings and (not routing["premium_tasks"] or routing["premium_approved"]),
+                                "findings": findings,
+                                "routing": routing,
+                                "manifest": normalized,
+                            },
+                        )
+                        return
+                    preflight_engine_bins(manifest, config)
+                    manifest_path = save_hud_plan(state_dir, normalized, manifest.run_name)
+                    process = launch_hud_plan(config, manifest_path)
+                    send_json_response(
+                        self,
+                        {
+                            "ok": True,
+                            "run_name": manifest.run_name,
+                            "manifest_path": str(manifest_path),
+                            "pid": process.pid,
+                            "routing": routing,
+                        },
+                        status=HTTPStatus.ACCEPTED,
+                    )
+                except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+                    send_json_response(
+                        self,
+                        {"ok": False, "error": f"invalid JSON: {exc}"},
+                        status=HTTPStatus.BAD_REQUEST,
+                    )
+                except ValueError as exc:
+                    send_json_response(
+                        self,
+                        {"ok": False, "error": str(exc)},
+                        status=HTTPStatus.BAD_REQUEST,
+                    )
+                except Exception as exc:
+                    send_json_response(
+                        self,
+                        {"ok": False, "error": str(exc) or exc.__class__.__name__},
+                        status=HTTPStatus.INTERNAL_SERVER_ERROR,
+                    )
 
             def log_message(self, _format: str, *_args: Any) -> None:
                 return
@@ -9860,6 +10398,7 @@ def run_persistent_hud(config: AppConfig, *, port: int | None, open_viewer: bool
         config.state_dir,
         preferred_port=chosen_port,
         open_viewer=open_viewer,
+        config=config,
     )
     server.model_log_path = config.eval.jsonl_path
     server.default_model_log_path = config.eval.jsonl_path

--- a/tests/test_hud_plan.py
+++ b/tests/test_hud_plan.py
@@ -241,12 +241,10 @@ class HudPlanTests(unittest.TestCase):
 
         conn = http.client.HTTPConnection(base.removeprefix("http://"), timeout=5)
         self.addCleanup(conn.close)
-        conn.request(
-            "POST",
-            "/api/plan/validate",
-            body=b"x" * (HUD_PLAN_BODY_LIMIT_BYTES + 1),
-            headers={"Content-Type": "application/json"},
-        )
+        conn.putrequest("POST", "/api/plan/validate")
+        conn.putheader("Content-Type", "application/json")
+        conn.putheader("Content-Length", str(HUD_PLAN_BODY_LIMIT_BYTES + 1))
+        conn.endheaders()
         response = conn.getresponse()
         self.assertEqual(413, response.status)
         self.assertIn("request body is too large", response.read().decode("utf-8"))

--- a/tests/test_hud_plan.py
+++ b/tests/test_hud_plan.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import http.client
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+from urllib.error import HTTPError
+from urllib.request import Request, urlopen
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+import ringer  # noqa: E402
+from ringer import (  # noqa: E402
+    AppConfig,
+    ArtifactConfig,
+    EngineConfig,
+    EvalConfig,
+    HUD_PLAN_BODY_LIMIT_BYTES,
+    PersistentHudServer,
+)
+
+
+LONG_SPEC = (
+    "Implement the requested scoped change while preserving unrelated user changes. "
+    "Keep edits bounded to the specified ownership paths and record the exact verification evidence."
+)
+GOOD_CHECK = "test -s report.md || { echo 'FAIL: report.md missing or empty'; exit 1; }"
+
+
+class HudPlanTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.old_env = os.environ.copy()
+        self.addCleanup(self.restore_env)
+        self.root = Path(self.tmp.name)
+        os.environ["HOME"] = str(self.root / "home")
+        os.environ["RINGER_HOME"] = str(self.root / "ringer-home")
+        self.state_dir = self.root / "state"
+        self.state_dir.mkdir(parents=True)
+        self.config = self.make_config()
+
+    def restore_env(self) -> None:
+        os.environ.clear()
+        os.environ.update(self.old_env)
+
+    def make_config(self) -> AppConfig:
+        return AppConfig(
+            path=None,
+            identity_default=None,
+            state_dir=self.state_dir,
+            dashboard_port_base=8787,
+            hud_port=8700,
+            hud_app_path=None,
+            allow_full_access=False,
+            eval=EvalConfig(backend="jsonl", jsonl_path=self.state_dir / "runs.jsonl"),
+            engines={
+                "codex": EngineConfig(
+                    name="codex",
+                    bin=sys.executable,
+                    args_template=(
+                        "exec",
+                        "--skip-git-repo-check",
+                        "{model_args}",
+                        "{engine_args}",
+                        "-C",
+                        "{taskdir}",
+                        "{spec}",
+                    ),
+                    full_access_args=(),
+                    sandbox_args=("--sandbox", "workspace-write"),
+                    token_regex=None,
+                    model_default="gpt-5.5",
+                )
+            },
+            artifact=ArtifactConfig(
+                enabled=False,
+                out_template=str(self.state_dir / "live.html"),
+                report_template=str(self.state_dir / "report.html"),
+                index_out=self.state_dir / "index.html",
+            ),
+        )
+
+    def start_server(self) -> tuple[PersistentHudServer, str]:
+        server = PersistentHudServer(
+            self.state_dir,
+            preferred_port=0,
+            open_viewer=False,
+            config=self.config,
+        )
+        port = server.start_background()
+        self.addCleanup(server.stop)
+        return server, f"http://127.0.0.1:{port}"
+
+    def post_json(self, base: str, path: str, body: object) -> tuple[int, dict[str, object]]:
+        data = json.dumps(body).encode("utf-8")
+        request = Request(
+            f"{base}{path}",
+            data=data,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        try:
+            with urlopen(request, timeout=5) as response:
+                return response.status, json.loads(response.read().decode("utf-8"))
+        except HTTPError as exc:
+            return exc.code, json.loads(exc.read().decode("utf-8"))
+
+    def manifest(self, *, model: str = "gpt-5.5", task_key: str = "alpha") -> dict[str, object]:
+        return {
+            "run_name": "hud-plan-test",
+            "workdir": str(self.root / "work"),
+            "max_parallel": 2,
+            "tasks": [
+                {
+                    "key": task_key,
+                    "spec": LONG_SPEC,
+                    "check": GOOD_CHECK,
+                    "expect_files": ["report.md"],
+                    "engine": "codex",
+                    "model": model,
+                    "task_type": "code-feature",
+                    "engine_args": ["-c", "model_reasoning_effort=medium"],
+                    "verified": "report.md exists and the explicit check passed.",
+                }
+            ],
+        }
+
+    def test_served_ui_and_policy_include_plan_run_and_exact_gpt56_lanes(self) -> None:
+        _server, base = self.start_server()
+
+        with urlopen(f"{base}/", timeout=5) as response:
+            page = response.read().decode("utf-8")
+        self.assertIn('id="plan-tab"', page)
+        self.assertIn("Plan / Run", page)
+        self.assertIn("/api/plan/validate", page)
+        self.assertIn("/api/plan/run", page)
+
+        with urlopen(f"{base}/api/plan", timeout=5) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+
+        lane_models = {lane["model"] for lane in payload["lanes"]}
+        self.assertIn("gpt-5.5", lane_models)
+        self.assertIn("gpt-5.6-terra", lane_models)
+        self.assertIn("gpt-5.6-sol", lane_models)
+        self.assertIn("gpt-5.6-luna", lane_models)
+        self.assertEqual(
+            ["gpt-5.6-luna", "gpt-5.6-sol", "gpt-5.6-terra"],
+            payload["policy"]["premium_models"],
+        )
+        self.assertTrue(payload["policy"]["explicit_task_models"])
+        self.assertFalse(payload["policy"]["agentops_linkage"])
+        self.assertFalse(payload["policy"]["auto_start"])
+
+    def test_validate_requires_explicit_model_for_plan_tasks(self) -> None:
+        _server, base = self.start_server()
+        manifest = self.manifest()
+        manifest["tasks"][0]["model"] = ""
+
+        status, payload = self.post_json(base, "/api/plan/validate", {"manifest": manifest})
+
+        self.assertEqual(400, status)
+        self.assertIn("choose an explicit model", str(payload["error"]))
+
+    def test_premium_validation_reports_routing_but_launch_requires_approval_and_reason(self) -> None:
+        _server, base = self.start_server()
+        request = {"manifest": self.manifest(model="gpt-5.6-terra")}
+
+        status, payload = self.post_json(base, "/api/plan/validate", request)
+        self.assertEqual(200, status)
+        self.assertTrue(payload["ok"])
+        self.assertEqual(["alpha"], payload["routing"]["premium_tasks"])
+        self.assertFalse(payload["ready"])
+
+        status, payload = self.post_json(base, "/api/plan/run", request)
+        self.assertEqual(400, status)
+        self.assertIn("premium routing is not approved", str(payload["error"]))
+
+        status, payload = self.post_json(
+            base,
+            "/api/plan/run",
+            {"manifest": self.manifest(model="gpt-5.6-sol"), "premium_approved": True},
+        )
+        self.assertEqual(400, status)
+        self.assertIn("premium routing needs a short reason", str(payload["error"]))
+
+    def test_standard_launch_persists_receipt_and_invokes_cli_wrapper(self) -> None:
+        _server, base = self.start_server()
+        with mock.patch.object(
+            ringer,
+            "launch_hud_plan",
+            return_value=SimpleNamespace(pid=4242),
+        ) as launch:
+            status, payload = self.post_json(base, "/api/plan/run", {"manifest": self.manifest()})
+
+        self.assertEqual(202, status)
+        self.assertTrue(payload["ok"])
+        self.assertEqual(4242, payload["pid"])
+        manifest_path = Path(str(payload["manifest_path"]))
+        self.assertTrue(manifest_path.is_file())
+        self.assertEqual(self.state_dir / "plans", manifest_path.parent)
+        saved = json.loads(manifest_path.read_text(encoding="utf-8"))
+        self.assertEqual("gpt-5.5", saved["tasks"][0]["model"])
+        self.assertEqual("codex", saved["tasks"][0]["engine"])
+        self.assertEqual("gpt-5.5", saved["routing"]["task_models"]["alpha"]["model"])
+        self.assertEqual([], saved["routing"]["premium_tasks"])
+        launch.assert_called_once()
+        self.assertEqual(manifest_path, launch.call_args.args[1])
+
+    def test_malformed_unsupported_and_oversized_requests_return_useful_errors(self) -> None:
+        _server, base = self.start_server()
+
+        request = Request(
+            f"{base}/api/plan/validate",
+            data=b"{",
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with self.assertRaises(HTTPError) as invalid_json:
+            urlopen(request, timeout=5)
+        self.assertEqual(400, invalid_json.exception.code)
+        self.assertIn("invalid JSON", invalid_json.exception.read().decode("utf-8"))
+
+        request = Request(
+            f"{base}/api/plan/validate",
+            data=b"{}",
+            headers={"Content-Type": "text/plain"},
+            method="POST",
+        )
+        with self.assertRaises(HTTPError) as bad_type:
+            urlopen(request, timeout=5)
+        self.assertEqual(415, bad_type.exception.code)
+        self.assertIn("Content-Type must be application/json", bad_type.exception.read().decode("utf-8"))
+
+        conn = http.client.HTTPConnection(base.removeprefix("http://"), timeout=5)
+        self.addCleanup(conn.close)
+        conn.request(
+            "POST",
+            "/api/plan/validate",
+            body=b"x" * (HUD_PLAN_BODY_LIMIT_BYTES + 1),
+            headers={"Content-Type": "application/json"},
+        )
+        response = conn.getresponse()
+        self.assertEqual(413, response.status)
+        self.assertIn("request body is too large", response.read().decode("utf-8"))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## What changed

- adds a Plan / Run tab to persistent Ringside
- exposes exact Codex routes for GPT-5.5 plus GPT-5.6 Terra, Sol, and Luna
- validates plans server-side and requires explicit approval plus a reason before any GPT-5.6 launch
- persists an auditable plan receipt and launches through the existing Ringer CLI
- keeps Models as historical execution evidence and leaves AgentOps linkage/auto-start out of scope

## Why

The model scoreboard already records exact model attribution, but current upstream lacked the user-facing planning surface that selects GPT-5.6 routes safely.

## Verification

- RINGER_NO_SELF_UPDATE=1 python3 -m py_compile ringer.py
- focused HUD/model tests: 27 passed
- RINGER_NO_SELF_UPDATE=1 python3 -m unittest discover -s tests -v: 223 passed

No real model workers were launched by the tests.