### PR TITLE
fix: dispatch Codex apply_patch hook events

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,12 +141,13 @@ Between swarms, agents drift back to invisible inline work. Reminders decay, so 
 Run one command:
 
 ```bash
-./ringer.py install-agent
+./ringer.py install-agent                  # Claude Code
+./ringer.py install-agent --agent codex    # Codex CLI / IDE
 ```
 
-It installs the ringer skill — the orchestrator playbook — user-level for Claude Code, and registers two gentle hooks: a Bash hook that notices model-calling or harness commands running outside a live Ringer run, and an edit-loop hook that notices batch editing without a run. Each hook nudges ONCE per session, pointing the agent at the skill.
+It installs the ringer skill — the orchestrator playbook — and registers two gentle hooks. Codex installs the skill under `~/.agents/skills/ringer` and hooks under `~/.codex/hooks.json`; its post-tool matcher targets the real `apply_patch` event. On Windows, Codex hook entries include `commandWindows`. Each hook nudges once per session, pointing the agent at the skill.
 
-The hooks never block anything. A user who says "just do it inline" is obeyed; uninstall with `./ringer.py uninstall-agent`.
+The hooks never block anything. A user who says "just do it inline" is obeyed; uninstall with `./ringer.py uninstall-agent` or `./ringer.py uninstall-agent --agent codex`.
 
 For CI and evals, `config.sample.toml` includes `[engines.mock]` so the enforcement stack can be tested without an API bill.
 

--- a/hooks/ringer_nudge.py
+++ b/hooks/ringer_nudge.py
@@ -29,6 +29,8 @@ HARNESS_RE = re.compile(
     r"\.(?:mjs|js|ts|py)\b",
     re.IGNORECASE,
 )
+PATCH_PATH_RE = re.compile(r"^\*\*\* (?:Add|Update|Delete) File: (.+)$", re.MULTILINE)
+PATCH_MOVE_RE = re.compile(r"^\*\*\* Move to: (.+)$", re.MULTILINE)
 
 
 def ringer_home() -> Path:
@@ -38,6 +40,34 @@ def ringer_home() -> Path:
     return Path.home() / ".ringer"
 
 
+def pid_is_alive_windows(pid: int) -> bool:
+    import ctypes
+    from ctypes import wintypes
+
+    synchronize = 0x00100000
+    wait_timeout = 0x00000102
+    error_access_denied = 5
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    open_process = kernel32.OpenProcess
+    open_process.argtypes = [wintypes.DWORD, wintypes.BOOL, wintypes.DWORD]
+    open_process.restype = wintypes.HANDLE
+    wait_for_single_object = kernel32.WaitForSingleObject
+    wait_for_single_object.argtypes = [wintypes.HANDLE, wintypes.DWORD]
+    wait_for_single_object.restype = wintypes.DWORD
+    close_handle = kernel32.CloseHandle
+    close_handle.argtypes = [wintypes.HANDLE]
+    close_handle.restype = wintypes.BOOL
+
+    handle = open_process(synchronize, False, pid)
+    if not handle:
+        return ctypes.get_last_error() == error_access_denied
+    try:
+        return wait_for_single_object(handle, 0) == wait_timeout
+    finally:
+        close_handle(handle)
+
+
 def pid_is_alive(pid: Any) -> bool:
     try:
         parsed = int(pid)
@@ -45,6 +75,9 @@ def pid_is_alive(pid: Any) -> bool:
         return False
     if parsed <= 0:
         return False
+    if os.name == "nt":
+        # Signal 0 is CTRL_C_EVENT on Windows, not a harmless existence probe.
+        return pid_is_alive_windows(parsed)
     try:
         os.kill(parsed, 0)
     except ProcessLookupError:
@@ -178,17 +211,30 @@ def load_post_edit_state(path: Path) -> dict[str, Any]:
     return {"count": count, "file_paths": [str(path) for path in file_paths]}
 
 
+def edited_file_paths(payload: dict[str, Any]) -> set[str]:
+    tool_input = payload.get("tool_input")
+    if not isinstance(tool_input, dict):
+        return set()
+
+    file_path = tool_input.get("file_path")
+    if isinstance(file_path, str) and file_path.strip():
+        return {file_path.strip()}
+
+    command = tool_input.get("command")
+    if payload.get("tool_name") != "apply_patch" or not isinstance(command, str):
+        return set()
+    paths = PATCH_PATH_RE.findall(command)
+    paths.extend(PATCH_MOVE_RE.findall(command))
+    return {path.strip() for path in paths if path.strip()}
+
+
 def record_post_edit(payload: dict[str, Any], home: Path) -> tuple[int, int]:
     path = post_edit_state_path(home, payload.get("session_id"))
     state = load_post_edit_state(path)
     count = int(state["count"]) + 1
     files = set(str(item) for item in state["file_paths"])
 
-    tool_input = payload.get("tool_input")
-    if isinstance(tool_input, dict):
-        file_path = tool_input.get("file_path")
-        if isinstance(file_path, str) and file_path.strip():
-            files.add(file_path)
+    files.update(edited_file_paths(payload))
 
     next_state = {"count": count, "file_paths": sorted(files)}
     write_json_atomic(path, next_state)

--- a/ringer.py
+++ b/ringer.py
@@ -9469,8 +9469,20 @@ def repo_root() -> Path:
     return Path(__file__).resolve().parent
 
 
+def agent_base(project: bool) -> Path:
+    return Path.cwd() if project else Path.home()
+
+
 def claude_root(project: bool) -> Path:
-    return (Path.cwd() if project else Path.home()) / ".claude"
+    return agent_base(project) / ".claude"
+
+
+def codex_skill_root(project: bool) -> Path:
+    return agent_base(project) / ".agents"
+
+
+def codex_config_root(project: bool) -> Path:
+    return agent_base(project) / ".codex"
 
 
 def ringer_skill_source() -> Path:
@@ -9479,7 +9491,13 @@ def ringer_skill_source() -> Path:
 
 def ringer_hook_command(action: str) -> str:
     hook_path = repo_root() / "hooks" / "ringer_nudge.py"
-    return f"python3 {shlex.quote(str(hook_path))} {action}"
+    return shlex.join(["python3", str(hook_path), action])
+
+
+def ringer_hook_command_windows(action: str) -> str:
+    hook_path = repo_root() / "hooks" / "ringer_nudge.py"
+    python_command = [sys.executable] if os.name == "nt" else ["py", "-3"]
+    return subprocess.list2cmdline([*python_command, str(hook_path), action])
 
 
 def backup_file(path: Path) -> Path | None:
@@ -9515,38 +9533,45 @@ def hook_command_contains(value: Any, needle: str = "ringer_nudge.py") -> bool:
     return isinstance(value, dict) and needle in str(value.get("command", ""))
 
 
-def event_has_ringer_hook(groups: Any) -> bool:
-    if not isinstance(groups, list):
-        return False
-    for group in groups:
-        if not isinstance(group, dict):
-            continue
-        handlers = group.get("hooks")
-        if isinstance(handlers, list) and any(hook_command_contains(handler) for handler in handlers):
-            return True
-    return False
-
-
-def merge_ringer_hook(settings: dict[str, Any], event: str, matcher: str, command: str) -> bool:
+def merge_ringer_hook(
+    settings: dict[str, Any],
+    event: str,
+    matcher: str,
+    command: str,
+    *,
+    command_windows: str | None = None,
+) -> bool:
     hooks = settings.setdefault("hooks", {})
     if not isinstance(hooks, dict):
         raise ValueError("settings hooks field must be a JSON object")
     groups = hooks.setdefault(event, [])
     if not isinstance(groups, list):
         raise ValueError(f"settings hooks.{event} field must be a JSON array")
-    if event_has_ringer_hook(groups):
-        return False
-    groups.append(
-        {
-            "matcher": matcher,
-            "hooks": [
-                {
-                    "type": "command",
-                    "command": command,
-                }
-            ],
-        }
-    )
+    for group in groups:
+        if not isinstance(group, dict):
+            continue
+        handlers = group.get("hooks")
+        if not isinstance(handlers, list):
+            continue
+        ringer_handlers = [handler for handler in handlers if hook_command_contains(handler)]
+        if not ringer_handlers:
+            continue
+        desired = {"type": "command", "command": command}
+        if command_windows:
+            desired["commandWindows"] = command_windows
+        changed = group.get("matcher") != matcher or ringer_handlers != [desired]
+        if changed:
+            group["matcher"] = matcher
+            group["hooks"] = [
+                desired if hook_command_contains(handler) else handler
+                for handler in handlers
+            ]
+        return changed
+
+    handler = {"type": "command", "command": command}
+    if command_windows:
+        handler["commandWindows"] = command_windows
+    groups.append({"matcher": matcher, "hooks": [handler]})
     return True
 
 
@@ -9587,16 +9612,25 @@ def remove_ringer_hooks(settings: dict[str, Any]) -> int:
     return removed
 
 
-def install_agent(project: bool = False) -> int:
-    root = claude_root(project)
+def install_agent(project: bool = False, agent: str = "claude") -> int:
+    if agent == "claude":
+        skill_root = claude_root(project)
+        settings_path = skill_root / "settings.json"
+        post_matcher = "Edit|Write"
+    elif agent == "codex":
+        skill_root = codex_skill_root(project)
+        settings_path = codex_config_root(project) / "hooks.json"
+        post_matcher = "apply_patch"
+    else:
+        raise ValueError(f"unsupported agent: {agent}")
+
     skill_source = ringer_skill_source()
-    skill_target = root / "skills" / "ringer" / "SKILL.md"
+    skill_target = skill_root / "skills" / "ringer" / "SKILL.md"
     if not skill_source.exists():
         raise ValueError(f"ringer skill source not found: {skill_source}")
     skill_target.parent.mkdir(parents=True, exist_ok=True)
     shutil.copy2(skill_source, skill_target)
 
-    settings_path = root / "settings.json"
     settings = load_settings(settings_path)
     changed = False
     changed |= merge_ringer_hook(
@@ -9604,29 +9638,41 @@ def install_agent(project: bool = False) -> int:
         "PreToolUse",
         "Bash",
         ringer_hook_command("pre-bash"),
+        command_windows=(
+            ringer_hook_command_windows("pre-bash") if agent == "codex" else None
+        ),
     )
     changed |= merge_ringer_hook(
         settings,
         "PostToolUse",
-        "Edit|Write",
+        post_matcher,
         ringer_hook_command("post-edit"),
+        command_windows=(
+            ringer_hook_command_windows("post-edit") if agent == "codex" else None
+        ),
     )
     if changed or not settings_path.exists():
         write_settings(settings_path, settings)
 
     scope = "project" if project else "user"
-    print(f"Installed ringer agent for {scope} scope.")
+    print(f"Installed ringer agent for {agent} ({scope} scope).")
     print(f"Skill: {skill_target}")
     if changed:
-        print(f"Hooks: added PreToolUse Bash and PostToolUse Edit|Write in {settings_path}")
+        print(f"Hooks: added PreToolUse Bash and PostToolUse {post_matcher} in {settings_path}")
     else:
         print(f"Hooks: already present in {settings_path}")
     return 0
 
 
-def uninstall_agent(project: bool = False) -> int:
-    root = claude_root(project)
-    settings_path = root / "settings.json"
+def uninstall_agent(project: bool = False, agent: str = "claude") -> int:
+    if agent == "claude":
+        skill_root = claude_root(project)
+        settings_path = skill_root / "settings.json"
+    elif agent == "codex":
+        skill_root = codex_skill_root(project)
+        settings_path = codex_config_root(project) / "hooks.json"
+    else:
+        raise ValueError(f"unsupported agent: {agent}")
     removed_hooks = 0
     if settings_path.exists():
         settings = load_settings(settings_path)
@@ -9634,14 +9680,14 @@ def uninstall_agent(project: bool = False) -> int:
         if removed_hooks:
             write_settings(settings_path, settings)
 
-    skill_dir = root / "skills" / "ringer"
+    skill_dir = skill_root / "skills" / "ringer"
     removed_skill = False
     if skill_dir.exists():
         shutil.rmtree(skill_dir)
         removed_skill = True
 
     scope = "project" if project else "user"
-    print(f"Uninstalled ringer agent for {scope} scope.")
+    print(f"Uninstalled ringer agent for {agent} ({scope} scope).")
     print(f"Hooks removed: {removed_hooks}")
     print(f"Skill removed: {'yes' if removed_skill else 'no'}")
     return 0
@@ -9997,11 +10043,13 @@ def build_parser() -> argparse.ArgumentParser:
     )
     demo_parser.add_argument("--dry-run", action="store_true", help="print the demo plan without spawning codex")
 
-    install_parser = subparsers.add_parser("install-agent", help="install the ringer Claude Code skill and hooks")
-    install_parser.add_argument("--project", action="store_true", help="install into ./.claude instead of ~/.claude")
+    install_parser = subparsers.add_parser("install-agent", help="install the ringer orchestrator skill and hooks")
+    install_parser.add_argument("--agent", choices=("claude", "codex"), default="claude", help="orchestrating agent to configure (default: claude)")
+    install_parser.add_argument("--project", action="store_true", help="install at project scope instead of user scope")
 
-    uninstall_parser = subparsers.add_parser("uninstall-agent", help="remove the ringer Claude Code skill and hooks")
-    uninstall_parser.add_argument("--project", action="store_true", help="remove from ./.claude instead of ~/.claude")
+    uninstall_parser = subparsers.add_parser("uninstall-agent", help="remove the ringer orchestrator skill and hooks")
+    uninstall_parser.add_argument("--agent", choices=("claude", "codex"), default="claude", help="orchestrating agent to clean up (default: claude)")
+    uninstall_parser.add_argument("--project", action="store_true", help="remove from project scope instead of user scope")
     return parser
 
 
@@ -10047,9 +10095,9 @@ def main(argv: list[str] | None = None) -> int:
             print(f"Self-update skipped: {result.reason or 'not available'}.")
             return 0
         if args.command == "install-agent":
-            return install_agent(project=args.project)
+            return install_agent(project=args.project, agent=args.agent)
         if args.command == "uninstall-agent":
-            return uninstall_agent(project=args.project)
+            return uninstall_agent(project=args.project, agent=args.agent)
 
         if args.command == "lint":
             manifest = Manifest.from_path(args.manifest)

--- a/tests/test_agent_install.py
+++ b/tests/test_agent_install.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 
 import json
 import os
+import re
+import shlex
 import subprocess
 import sys
 import tempfile
@@ -23,7 +25,9 @@ class AgentInstallTests(unittest.TestCase):
     def run_cli(self, *args: str, cwd: Path = ROOT) -> subprocess.CompletedProcess[str]:
         env = os.environ.copy()
         env["HOME"] = str(self.home)
+        env["USERPROFILE"] = str(self.home)
         env["RINGER_HOME"] = str(self.ringer_home)
+        env["RINGER_NO_SELF_UPDATE"] = "1"
         return subprocess.run(
             [sys.executable, "ringer.py", *args],
             cwd=str(cwd),
@@ -37,6 +41,36 @@ class AgentInstallTests(unittest.TestCase):
     def read_settings(self, root: Path | None = None) -> dict[str, object]:
         base = self.home if root is None else root
         return json.loads((base / ".claude" / "settings.json").read_text(encoding="utf-8"))
+
+    def read_codex_hooks(self, root: Path | None = None) -> dict[str, object]:
+        base = self.home if root is None else root
+        return json.loads((base / ".codex" / "hooks.json").read_text(encoding="utf-8"))
+
+    def dispatch_installed_codex_hook(
+        self, payload: dict[str, object]
+    ) -> subprocess.CompletedProcess[str]:
+        groups = self.read_codex_hooks()["hooks"][payload["hook_event_name"]]
+        group = next(
+            item
+            for item in groups
+            if re.fullmatch(str(item["matcher"]), str(payload["tool_name"]))
+        )
+        handler = group["hooks"][0]
+        env = os.environ.copy()
+        env["HOME"] = str(self.home)
+        env["USERPROFILE"] = str(self.home)
+        env["RINGER_HOME"] = str(self.ringer_home)
+        command = handler.get("commandWindows") if os.name == "nt" else handler["command"]
+        return subprocess.run(
+            command if os.name == "nt" else shlex.split(command),
+            input=json.dumps(payload),
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            shell=os.name == "nt",
+            env=env,
+            check=False,
+        )
 
     def ringer_handlers(self, settings: dict[str, object]) -> list[dict[str, object]]:
         handlers: list[dict[str, object]] = []
@@ -72,6 +106,80 @@ class AgentInstallTests(unittest.TestCase):
         self.assertEqual("Edit|Write", hooks["PostToolUse"][0]["matcher"])
         self.assertIn("ringer_nudge.py", hooks["PostToolUse"][0]["hooks"][0]["command"])
         self.assertTrue(hooks["PostToolUse"][0]["hooks"][0]["command"].endswith(" post-edit"))
+
+    def test_codex_install_dispatches_real_apply_patch_events(self) -> None:
+        result = self.run_cli("install-agent", "--agent", "codex")
+        self.assertEqual(0, result.returncode, result.stderr)
+
+        skill = self.home / ".agents" / "skills" / "ringer" / "SKILL.md"
+        self.assertTrue(skill.exists())
+        hooks = self.read_codex_hooks()["hooks"]
+        self.assertEqual("apply_patch", hooks["PostToolUse"][0]["matcher"])
+        handler = hooks["PostToolUse"][0]["hooks"][0]
+        self.assertIn("ringer_nudge.py", handler["command"])
+        self.assertIn("commandWindows", handler)
+
+        files = ["a.py", "a.py", "b.py", "b.py", "a.py", "b.py", "a.py", "c.py"]
+        for index, file_path in enumerate(files):
+            payload = {
+                "session_id": "installed-codex-session",
+                "hook_event_name": "PostToolUse",
+                "tool_name": "apply_patch",
+                "tool_input": {
+                    "command": (
+                        "*** Begin Patch\n"
+                        f"*** Update File: {file_path}\n"
+                        "@@\n-old\n+new\n"
+                        "*** End Patch"
+                    )
+                },
+                "tool_response": {"success": True},
+            }
+            dispatched = self.dispatch_installed_codex_hook(payload)
+            self.assertEqual(0, dispatched.returncode, dispatched.stderr)
+            if index < len(files) - 1:
+                self.assertEqual("", dispatched.stdout)
+            else:
+                output = json.loads(dispatched.stdout)
+                self.assertEqual(
+                    "PostToolUse",
+                    output["hookSpecificOutput"]["hookEventName"],
+                )
+
+    def test_codex_install_migrates_the_old_nonmatching_post_hook(self) -> None:
+        codex = self.home / ".codex"
+        codex.mkdir()
+        hooks_path = codex / "hooks.json"
+        hooks_path.write_text(
+            json.dumps(
+                {
+                    "hooks": {
+                        "PostToolUse": [
+                            {
+                                "matcher": "Edit|Write",
+                                "hooks": [
+                                    {
+                                        "type": "command",
+                                        "command": "python3 /old/ringer_nudge.py post-edit",
+                                    }
+                                ],
+                            }
+                        ]
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        result = self.run_cli("install-agent", "--agent", "codex")
+        self.assertEqual(0, result.returncode, result.stderr)
+        post_groups = self.read_codex_hooks()["hooks"]["PostToolUse"]
+        self.assertEqual(1, len(post_groups))
+        self.assertEqual("apply_patch", post_groups[0]["matcher"])
+
+        uninstall = self.run_cli("uninstall-agent", "--agent", "codex")
+        self.assertEqual(0, uninstall.returncode, uninstall.stderr)
+        self.assertFalse((self.home / ".agents" / "skills" / "ringer").exists())
 
     def test_second_install_is_idempotent(self) -> None:
         first = self.run_cli("install-agent")

--- a/tests/test_nudge_hook.py
+++ b/tests/test_nudge_hook.py
@@ -66,6 +66,26 @@ class NudgeHookTests(unittest.TestCase):
             "tool_response": {"success": True},
         }
 
+    def codex_patch_payload(
+        self,
+        file_path: str,
+        session_id: str = "codex-session",
+    ) -> dict[str, object]:
+        return {
+            "session_id": session_id,
+            "hook_event_name": "PostToolUse",
+            "tool_name": "apply_patch",
+            "tool_input": {
+                "command": (
+                    "*** Begin Patch\n"
+                    f"*** Update File: {file_path}\n"
+                    "@@\n-old\n+new\n"
+                    "*** End Patch"
+                )
+            },
+            "tool_response": {"success": True},
+        }
+
     def assertNudged(self, proc: subprocess.CompletedProcess[str], event_name: str) -> None:
         self.assertEqual(0, proc.returncode)
         data = json.loads(proc.stdout)
@@ -117,6 +137,19 @@ class NudgeHookTests(unittest.TestCase):
         proc = self.run_hook("pre-bash", self.pre_bash_payload("node probe-simulate.mjs"))
         self.assertSilent(proc)
 
+    @unittest.skipUnless(os.name == "nt", "Windows-specific process probe behavior")
+    def test_live_pid_probe_does_not_terminate_process_on_windows(self) -> None:
+        helper = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(30)"])
+        try:
+            self.write_active_run(helper.pid)
+            proc = self.run_hook("pre-bash", self.pre_bash_payload("node probe-simulate.mjs"))
+            self.assertSilent(proc)
+            self.assertIsNone(helper.poll(), "liveness probe terminated the process it inspected")
+        finally:
+            if helper.poll() is None:
+                helper.terminate()
+                helper.wait(timeout=5)
+
     def test_pre_bash_dedupes_per_session(self) -> None:
         first = self.run_hook("pre-bash", self.pre_bash_payload("node probe-simulate.mjs"))
         second = self.run_hook("pre-bash", self.pre_bash_payload("curl https://api.openai.com/v1/chat/completions"))
@@ -146,6 +179,15 @@ class NudgeHookTests(unittest.TestCase):
         files = ["/tmp/a.py", "/tmp/b.py", "/tmp/a.py", "/tmp/b.py", "/tmp/a.py", "/tmp/b.py", "/tmp/a.py"]
         for file_path in files:
             self.assertSilent(self.run_hook("post-edit", self.post_edit_payload(file_path, "session-2")))
+
+    def test_codex_apply_patch_paths_trigger_edit_loop_nudge(self) -> None:
+        files = ["a.py", "a.py", "b.py", "b.py", "a.py", "b.py", "a.py", "c.py"]
+        for file_path in files[:-1]:
+            self.assertSilent(self.run_hook("post-edit", self.codex_patch_payload(file_path)))
+        self.assertNudged(
+            self.run_hook("post-edit", self.codex_patch_payload(files[-1])),
+            "PostToolUse",
+        )
 
     def test_malformed_stdin_exits_zero_silently(self) -> None:
         proc = self.run_hook("pre-bash", "{not json")


### PR DESCRIPTION
## Summary

- install the Codex hook with the `apply_patch` matcher so patch events actually reach Ringer
- migrate the previously generated mismatched hook configuration safely
- make hook signaling and generated worker commands robust on Windows while retaining POSIX behavior
- expand installation and nudge-hook coverage

## Context

This is split 4 of 5 from #31, following the maintainer's request for independently reviewable changes.

## Validation

- `python -m unittest tests.test_agent_install tests.test_nudge_hook -v` — 18 passed

The focused suite was run with the bundled CPython runtime; the system `python` command on this host resolves to LibreOffice's embedded interpreter.
