### PR TITLE
docs: add sourced worker model identities

### DIFF
--- a/registry/model-identity.toml
+++ b/registry/model-identity.toml
@@ -40,6 +40,45 @@ confidence = "verified"
 source = "https://developers.openai.com/codex/models"
 last_verified = 2026-07-10
 
+[engines.cursor]
+harness = "Cursor Agent"
+access = "Cursor subscription"
+# CLI access: https://docs.cursor.com/en/cli/overview
+
+[engines.cursor.models."composer-2.5-fast"]
+display = "Composer 2.5 Fast"
+lab = "Cursor (Anysphere)"
+confidence = "verified"
+source = "https://cursor.com/en-US/composer"
+last_verified = 2026-07-20
+
+[engines.cursor.models."grok-4.5-fast-high"]
+display = "Grok 4.5"
+lab = "Cursor + SpaceXAI"
+confidence = "verified"
+source = "https://cursor.com/blog/grok-4-5"
+last_verified = 2026-07-20
+
+[engines.claude]
+harness = "Claude Code"
+access = "Claude Pro subscription"
+# Subscription access: https://code.claude.com/docs/en/authentication
+
+[engines.claude.models."claude-sonnet-5"]
+display = "Claude Sonnet 5"
+lab = "Anthropic"
+confidence = "verified"
+source = "https://platform.claude.com/docs/en/about-claude/models/whats-new-sonnet-5"
+last_verified = 2026-07-20
+
+[engines.claude.models."sonnet"]
+display = "Claude Sonnet (rolling alias)"
+lab = "Anthropic"
+alias = true
+confidence = "unverified"
+source = "https://code.claude.com/docs/en/cli-usage"
+last_verified = 2026-07-20
+
 [engines.grok]
 harness = "Grok Build CLI"
 access = "OAuth plan"

--- a/tests/test_engine_registry_entries.py
+++ b/tests/test_engine_registry_entries.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+from ringer import load_model_identity_registry
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class EngineRegistryEntryTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.registry = load_model_identity_registry(
+            ROOT / "registry" / "model-identity.toml"
+        )
+
+    def test_cursor_composer_has_sourced_canonical_identity(self) -> None:
+        identity = self.registry.resolve("cursor", "composer-2.5-fast")
+        self.assertEqual(
+            (
+                "Composer 2.5 Fast",
+                "Cursor (Anysphere)",
+                "Cursor Agent",
+                "Cursor subscription",
+            ),
+            (
+                identity.model_display,
+                identity.lab,
+                identity.harness,
+                identity.access,
+            ),
+        )
+        self.assertEqual("verified", identity.confidence)
+        self.assertEqual("https://cursor.com/en-US/composer", identity.source)
+        self.assertNotIn(
+            ("cursor", "composer-2.5-fast"),
+            self.registry.noncanonical_routes,
+        )
+
+    def test_cursor_grok_uses_the_jointly_trained_model_source(self) -> None:
+        identity = self.registry.resolve("cursor", "grok-4.5-fast-high")
+        self.assertEqual("Grok 4.5", identity.model_display)
+        self.assertEqual("Cursor + SpaceXAI", identity.lab)
+        self.assertEqual("verified", identity.confidence)
+        self.assertEqual("https://cursor.com/blog/grok-4-5", identity.source)
+        self.assertNotIn(
+            ("cursor", "grok-4.5-fast-high"),
+            self.registry.noncanonical_routes,
+        )
+
+    def test_claude_full_slug_is_verified_but_rolling_alias_is_not(self) -> None:
+        exact = self.registry.resolve("claude", "claude-sonnet-5")
+        self.assertEqual(
+            ("Claude Sonnet 5", "Anthropic", "Claude Code", "Claude Pro subscription"),
+            (exact.model_display, exact.lab, exact.harness, exact.access),
+        )
+        self.assertEqual("verified", exact.confidence)
+        self.assertEqual(
+            "https://platform.claude.com/docs/en/about-claude/models/whats-new-sonnet-5",
+            exact.source,
+        )
+
+        alias = self.registry.resolve("claude", "sonnet")
+        self.assertTrue(alias.alias)
+        self.assertIn("rolling alias", alias.model_display)
+        self.assertEqual("unverified", alias.confidence)
+        self.assertEqual("https://code.claude.com/docs/en/cli-usage", alias.source)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

- add a compact worker model-identity registry for the OpenCode, Cursor, and Claude engines
- distinguish documented model identities from rolling aliases whose backing snapshot is not publicly pinned
- include official source URLs and focused schema/source tests

## Context

This is split 5 of 5 from #31, following the maintainer's request for independently reviewable changes. It is intended to land after the related engine PRs.

## Validation

- `python -m unittest tests.test_engine_registry_entries tests.test_signal_contract -v` — 7 passed
