### PR TITLE
registry: Claude-family model identities from harness evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,6 +357,7 @@ Every community PR that lands in main is credited here — that's a project rule
 - [@davekopecek](https://github.com/davekopecek) (Dave Kopecek) — committed the design-reference fixture so the design-token guard runs on every machine (#30)
 - [@snapsynapse](https://github.com/snapsynapse) (Sam Rogers) — graceful shutdown on SIGINT/SIGTERM with worker-tree cleanup and finished state, plus the 14-test end-to-end CLI regression suite (#4)
 - [@mlava](https://github.com/mlava) (Mark Lavercombe) — named setup failures across every diagnostic surface (#37) and `run --baseline`, the no-workers check preflight (#38)
+- [@datacraftdevelopment](https://github.com/datacraftdevelopment) — added the Claude-family model identity registry entries (Opus 4.8, Sonnet 5, Haiku 4.5, Fable 5), sourced from Claude Code harness evidence (this PR)
 
 Contributions are welcome — see [CONTRIBUTING.md](CONTRIBUTING.md) for the philosophy and what gets a PR merged fast. The short version: small and scoped, rebased on current main, every claim backed by an executed test. Authorship is always preserved — where a maintainer pushes a mechanical fix to your branch, you remain the commit author.
 

--- a/README.md
+++ b/README.md
@@ -357,7 +357,7 @@ Every community PR that lands in main is credited here — that's a project rule
 - [@davekopecek](https://github.com/davekopecek) (Dave Kopecek) — committed the design-reference fixture so the design-token guard runs on every machine (#30)
 - [@snapsynapse](https://github.com/snapsynapse) (Sam Rogers) — graceful shutdown on SIGINT/SIGTERM with worker-tree cleanup and finished state, plus the 14-test end-to-end CLI regression suite (#4)
 - [@mlava](https://github.com/mlava) (Mark Lavercombe) — named setup failures across every diagnostic surface (#37) and `run --baseline`, the no-workers check preflight (#38)
-- [@datacraftdevelopment](https://github.com/datacraftdevelopment) — added the Claude-family model identity registry entries (Opus 4.8, Sonnet 5, Haiku 4.5, Fable 5), sourced from Claude Code harness evidence (this PR)
+- [@datacraftdevelopment](https://github.com/datacraftdevelopment) — added the Claude-family model identity registry entries (Opus 4.8, Sonnet 5, Haiku 4.5, Fable 5), sourced from Claude Code harness evidence (#72)
 
 Contributions are welcome — see [CONTRIBUTING.md](CONTRIBUTING.md) for the philosophy and what gets a PR merged fast. The short version: small and scoped, rebased on current main, every claim backed by an executed test. Authorship is always preserved — where a maintainer pushes a mechanical fix to your branch, you remain the commit author.
 

--- a/registry/model-identity.toml
+++ b/registry/model-identity.toml
@@ -98,3 +98,50 @@ lab = "Meta"
 confidence = "verified"
 source = "manifest model field; OpenRouter slug meta-llama/llama-3.3-70b-instruct:free"
 last_verified = 2026-07-10
+
+[engines.claude]
+harness = "Claude Code"
+access = "Claude subscription"
+default_model_key = "claude-haiku-4-5"
+
+# Claude-family identities. Evidence precedence is harness-reported model first:
+# the Claude Code worker stream self-reports the model it ran in its result
+# `modelUsage` telemetry (Ringer's reported_model column stays null only because
+# its capture regex is Codex-specific). Each source cites that self-report with
+# run names + dates, plus Anthropic's own model page for the lab.
+
+[engines.claude.models."claude-opus-4-8"]
+display = "Claude Opus 4.8"
+lab = "Anthropic"
+confidence = "verified"
+source = "Claude Code modelUsage self-report: runs claude-family-audition (2026-07-12), hello-world-bakeoff (2026-07-17); Anthropic models overview https://platform.claude.com/docs/en/about-claude/models/overview"
+last_verified = 2026-07-21
+
+[engines.claude.models."claude-sonnet-5"]
+display = "Claude Sonnet 5"
+lab = "Anthropic"
+confidence = "verified"
+source = "Claude Code modelUsage self-report: runs claude-family-audition (2026-07-12), hello-world-bakeoff (2026-07-17); Anthropic models overview https://platform.claude.com/docs/en/about-claude/models/overview"
+last_verified = 2026-07-21
+
+[engines.claude.models."claude-haiku-4-5"]
+display = "Claude Haiku 4.5"
+lab = "Anthropic"
+confidence = "verified"
+source = "Claude Code modelUsage self-report: runs claude-family-audition (2026-07-12), hello-world-site (2026-07-12); Anthropic models overview https://platform.claude.com/docs/en/about-claude/models/overview"
+last_verified = 2026-07-21
+
+# Fable 5: Anthropic's Claude 5 announcement names Fable 5 / Mythos 5 as a new
+# tier above Opus sharing one underlying model; there is no public lineage beyond
+# that. Per docs/TAXONOMY.md, registry aliases are allowed only when the actual
+# model lineage is not established, and must be marked as aliases in both the
+# registry and the displayed name and never presented as a confirmed lineage.
+# The lab (Anthropic) is verified from Anthropic's own announcement; the model
+# lineage is not, so this is entered as an unverified alias, not asserted lineage.
+[engines.claude.models."claude-fable-5"]
+display = "Claude Fable 5 (Anthropic, alias)"
+lab = "Anthropic"
+alias = true
+confidence = "unverified"
+source = "Anthropic Claude 5 announcement — Fable 5 / Mythos 5, new tier above Opus, one shared underlying model, no public lineage: https://platform.claude.com/docs/en/about-claude/models/introducing-claude-fable-5; harness self-report (Claude Code modelUsage): runs fable-audition (2026-07-12), crm-build (2026-07-16), chronoline-build (2026-07-17)"
+last_verified = 2026-07-21


### PR DESCRIPTION
## What this adds

A `claude` engine block and four Claude-family model identities in `registry/model-identity.toml`:

| Model key | Display | Lab | Confidence |
|---|---|---|---|
| `claude-opus-4-8` | Claude Opus 4.8 | Anthropic | verified |
| `claude-sonnet-5` | Claude Sonnet 5 | Anthropic | verified |
| `claude-haiku-4-5` | Claude Haiku 4.5 | Anthropic | verified |
| `claude-fable-5` | Claude Fable 5 (Anthropic, alias) | Anthropic | unverified (alias) |

Engine metadata: `harness = "Claude Code"`, `access = "Claude subscription"`, `default_model_key = "claude-haiku-4-5"`.

## Evidence basis (per `docs/TAXONOMY.md`)

Evidence precedence is **harness-reported model first**. The Claude Code worker stream self-reports the model it actually ran in its result-message `modelUsage` telemetry. Ringer's `reported_model` column stays null for these rows only because the capture regex is Codex-header–specific — so the self-report was read directly from the worker logs. Every `source` cites that self-report with run names + dates, plus Anthropic's own model page for the lab:

- **Opus 4.8** — `modelUsage: {"claude-opus-4-8": …}` in `claude-family-audition` (2026-07-12) and `hello-world-bakeoff` (2026-07-17).
- **Sonnet 5** — `modelUsage: {"claude-sonnet-5": …}` in `claude-family-audition` (2026-07-12) and `hello-world-bakeoff` (2026-07-17).
- **Haiku 4.5** — `modelUsage: {"claude-haiku-4-5": …}` in `claude-family-audition` (2026-07-12) and `hello-world-site` (2026-07-12). Also the engine's `default_model_key`, matching the runtime `model_default`.
- **Fable 5** — `modelUsage: {"claude-fable-5": …}` in `fable-audition` (2026-07-12), then `crm-build` (2026-07-16) and `chronoline-build` (2026-07-17).

The self-reported slug matches the manifest/config-resolved model in every case (no drift).

## Fable 5: alias / unverified, not asserted lineage

Anthropic's Claude 5 family announcement names Fable 5 / Mythos 5 as a new tier above Opus sharing one underlying model; there is no public lineage beyond that. `docs/TAXONOMY.md` permits a registry alias **only when the actual model lineage is not established**, requires it be marked as an alias in both the registry and the displayed name, and forbids presenting it as a confirmed lineage. So Fable 5 is entered as:

- `alias = true`, display `Claude Fable 5 (Anthropic, alias)` — marked in both places.
- `confidence = "unverified"` — the lab (Anthropic) is verified from Anthropic's own announcement; the underlying model lineage is not, and is left unasserted pending public documentation.

The rationale is captured in a comment on the entry so the alias treatment isn't mistaken for an oversight.

## Contributor credit (CONTRIBUTING.md enforcement)

`tests/test_contributors.py` audits git history against README's Contributors section and fails the whole suite on any omission — per CONTRIBUTING.md, "Credit is enforced, not promised." The registry commit in this PR is authored by `datacraftdevelopment`, so a second commit adds that entry to README's Contributors section, exactly as CONTRIBUTING.md sanctions ("Every merged community contributor is listed... the test fails the whole suite if anyone with merged work is missing"). The entry's PR-number citation reads "(this PR)" pending assignment — update it to "(#N)" once this PR is open.

## Tests

All three identity/taxonomy suites the derivation quality gates on pass, and the full suite is green at current HEAD (includes the Contributors fix above):

```
python3 -m pytest -q tests/test_taxonomy.py tests/test_identity_evidence.py tests/test_model_db.py
  25 passed

python3 -m pytest -q            # full suite
  219 passed, 1 warning, 17 subtests passed
```

(The lone warning is a pre-existing `test_steering.py` return-value warning, unrelated to this change.) `test_signal_contract.py`, which loads this real registry to exercise the noncanonical-route guard, also passes — the grok route and every other existing entry resolve unchanged.

## Scope

Two commits: `registry/model-identity.toml` (+47 lines, additive — the identity data) and `README.md` (+1 line — the Contributors credit required by `tests/test_contributors.py`, see above). No code paths change; existing engine/model rows and Contributors entries are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
