### PR TITLE
templates/bakeoff-kit: model-only research bakeoff starter kit

### DIFF
--- a/templates/bakeoff-kit/README.md
+++ b/templates/bakeoff-kit/README.md
@@ -1,0 +1,86 @@
+# Ringer model bakeoff starter kit
+
+## What it is
+
+This kit is the runnable sample for the [Chinese-model bakeoff
+guide](https://unlock-ai.natebjones.com/guides/chinese-model-bakeoff). It pairs a
+five-claim research task with local source documents, a deterministic validator,
+two fixtures, a model-only Ringer manifest, and a score sheet.
+
+The validator checks completeness, output structure, allowed statuses, and
+literal source evidence. It does not decide whether each research verdict is
+intellectually correct. Do that in the blind review described in the guide.
+
+## Files
+
+```text
+ringer-bakeoff-kit/
+├── check_result.py
+├── score-sheet.csv
+├── swarm.model-only.example.json
+├── README.md
+├── fixtures/
+│   ├── bad-result.json
+│   └── good-result.json
+└── source-packet/
+    ├── claims.json
+    └── sources/
+        ├── security-note.md
+        └── travel-policy.md
+```
+
+Everything runs locally. The validator uses Python 3.11 or newer, imports only
+the standard library, and makes no network calls.
+
+## Prove the checker
+
+Go to the included kit and run the known-good fixture:
+
+```bash
+cd '/ABSOLUTE/PATH/TO/ringer-bakeoff-kit'
+
+python3 check_result.py \
+  fixtures/good-result.json \
+  --claims source-packet/claims.json \
+  --sources source-packet/sources
+```
+
+Expected result:
+
+```text
+PASS: every requested claim is present, the schema is valid, and all cited evidence appears in an allowed source
+```
+
+Now run the known-bad fixture:
+
+```bash
+python3 check_result.py \
+  fixtures/bad-result.json \
+  --claims source-packet/claims.json \
+  --sources source-packet/sources
+```
+
+The second command must exit nonzero and name the invented quotation, missing
+source, invalid status, and omitted claim.
+
+## Use it for your work
+
+Copy `swarm.model-only.example.json` to `swarm.json`. Replace every
+`/ABSOLUTE/PATH/TO/ringer-bakeoff-kit`, both model-ID placeholders, and the dated
+work directory. Keep the assignment, sources, reasoning variant, timeout, and
+check identical for both model cells.
+
+To replace the sample task, edit `source-packet/claims.json` and the Markdown
+files under `source-packet/sources/`. Keep stable claim IDs. Each result row must
+contain `claim_id`, `status`, `source`, `quote`, and `explanation`. Run the
+validator directly against your own result before running Ringer:
+
+```bash
+python3 check_result.py \
+  /ABSOLUTE/PATH/TO/your-result.json \
+  --claims /ABSOLUTE/PATH/TO/your-claims.json \
+  --sources /ABSOLUTE/PATH/TO/your-sources
+```
+
+Add known-good and known-bad fixtures for any new output rule. A checker that
+accepts a bad fixture or rejects a good fixture is not ready to grade a model.

--- a/templates/bakeoff-kit/README.md
+++ b/templates/bakeoff-kit/README.md
@@ -32,6 +32,26 @@ ringer-bakeoff-kit/
 Everything runs locally. The validator uses Python 3.11 or newer, imports only
 the standard library, and makes no network calls.
 
+## About score-sheet.csv — do not re-enter what Ringer already tracks
+
+Eight of the fourteen columns are already computed for you on the **Models view
+in Ringside** (`./ringer.py hud`, then switch to Models), built from your own
+attempt history:
+
+`exact_model_id` · `lab` · `harness` · `provider_or_plan` ·
+`first_try_acceptance` · `acceptance_after_retry` · `total_duration` ·
+`reported_tokens`
+
+Copy those across, or just read them there. The six that are genuinely yours to
+fill are the ones Ringer cannot see:
+
+`case_type` · `ringer_commit` · `human_repair_minutes` · `provider_charge` ·
+`tool_and_infrastructure_cost` · `failure_type`
+
+That split is the point of the sheet. Ringer knows what happened; it does not
+know what it cost you. The money and the minutes are what turn a pass rate into
+a business decision.
+
 ## Prove the checker
 
 Go to the included kit and run the known-good fixture:

--- a/templates/bakeoff-kit/check_result.py
+++ b/templates/bakeoff-kit/check_result.py
@@ -1,0 +1,319 @@
+#!/usr/bin/env python3
+"""Validate one claim-research result against a local source packet.
+
+This checker validates completeness, schema, statuses, and literal evidence. It
+does not decide whether a supported, unsupported, or unclear verdict is
+intellectually correct; that judgment belongs in the human blind review.
+
+The script uses only the Python standard library and makes no network calls.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+ALLOWED_STATUSES = {"supported", "unsupported", "unclear"}
+REQUIRED_FIELDS = {"claim_id", "status", "source", "quote", "explanation"}
+PASS_MESSAGE = (
+    "PASS: every requested claim is present, the schema is valid, and all "
+    "cited evidence appears in an allowed source"
+)
+
+
+def failure(claim_id: str, detail: str) -> str:
+    """Return one consistently formatted, actionable failure."""
+    return f"FAIL [{claim_id}]: {detail}"
+
+
+def load_json(path: Path, label: str) -> tuple[Any | None, list[str]]:
+    try:
+        return json.loads(path.read_text(encoding="utf-8")), []
+    except FileNotFoundError:
+        return None, [failure(label, f"file does not exist: {path}")]
+    except OSError as exc:
+        return None, [failure(label, f"could not read {path}: {exc}")]
+    except json.JSONDecodeError as exc:
+        return None, [
+            failure(
+                label,
+                f"invalid JSON in {path} at line {exc.lineno}, column {exc.colno}: {exc.msg}",
+            )
+        ]
+
+
+def extract_rows(payload: Any, label: str) -> tuple[list[Any], list[str]]:
+    if not isinstance(payload, dict):
+        return [], [failure(label, "top-level JSON value must be an object")]
+    rows = payload.get("claims")
+    if not isinstance(rows, list):
+        return [], [failure(label, "top-level 'claims' field must be an array")]
+    return rows, []
+
+
+def normalize_whitespace(text: str) -> str:
+    """Collapse whitespace without changing any non-whitespace character."""
+    return " ".join(text.split())
+
+
+def source_path(sources_dir: Path, source_name: str) -> Path | None:
+    """Resolve an allowed source name without permitting directory traversal."""
+    root = sources_dir.resolve()
+    candidate = (root / source_name).resolve()
+    try:
+        candidate.relative_to(root)
+    except ValueError:
+        return None
+    return candidate
+
+
+def validate_claim_definitions(rows: list[Any]) -> tuple[dict[str, str], list[str]]:
+    requested: dict[str, str] = {}
+    failures: list[str] = []
+
+    for index, row in enumerate(rows, start=1):
+        label = f"claims row {index}"
+        if not isinstance(row, dict):
+            failures.append(failure(label, "claim definition must be an object"))
+            continue
+
+        claim_id = row.get("id")
+        claim_text = row.get("claim")
+        if not isinstance(claim_id, str) or not claim_id.strip():
+            failures.append(failure(label, "field 'id' must be a nonempty string"))
+            continue
+        claim_id = claim_id.strip()
+        if not isinstance(claim_text, str) or not claim_text.strip():
+            failures.append(
+                failure(claim_id, "claim definition field 'claim' must be a nonempty string")
+            )
+        if claim_id in requested:
+            failures.append(failure(claim_id, "claim id is duplicated in claims file"))
+            continue
+        requested[claim_id] = claim_text if isinstance(claim_text, str) else ""
+
+    return requested, failures
+
+
+def validate_result_rows(
+    rows: list[Any], requested: dict[str, str], sources_dir: Path
+) -> list[str]:
+    failures: list[str] = []
+    seen: dict[str, int] = {}
+
+    for index, row in enumerate(rows, start=1):
+        row_label = f"result row {index}"
+        if not isinstance(row, dict):
+            failures.append(failure(row_label, "row must be an object"))
+            continue
+
+        raw_claim_id = row.get("claim_id")
+        claim_id = (
+            raw_claim_id.strip()
+            if isinstance(raw_claim_id, str) and raw_claim_id.strip()
+            else row_label
+        )
+
+        missing_fields = sorted(REQUIRED_FIELDS - row.keys())
+        if missing_fields:
+            failures.append(
+                failure(
+                    claim_id,
+                    "missing required field(s): " + ", ".join(missing_fields),
+                )
+            )
+
+        if not isinstance(raw_claim_id, str) or not raw_claim_id.strip():
+            failures.append(
+                failure(row_label, "required field 'claim_id' must be a nonempty string")
+            )
+        else:
+            normalized_id = raw_claim_id.strip()
+            seen[normalized_id] = seen.get(normalized_id, 0) + 1
+            if normalized_id not in requested:
+                failures.append(failure(normalized_id, "unknown claim id"))
+
+        status = row.get("status")
+        source = row.get("source")
+        quote = row.get("quote")
+        explanation = row.get("explanation")
+
+        if not isinstance(status, str) or status not in ALLOWED_STATUSES:
+            failures.append(
+                failure(
+                    claim_id,
+                    "invalid status; expected one of: supported, unsupported, unclear",
+                )
+            )
+            continue
+
+        for field_name, value in (
+            ("source", source),
+            ("quote", quote),
+            ("explanation", explanation),
+        ):
+            if value is not None and not isinstance(value, str):
+                failures.append(
+                    failure(
+                        claim_id,
+                        f"field '{field_name}' must be a string or null",
+                    )
+                )
+
+        source_text = source.strip() if isinstance(source, str) else ""
+        quote_text = quote.strip() if isinstance(quote, str) else ""
+        explanation_text = explanation.strip() if isinstance(explanation, str) else ""
+
+        if status == "unsupported":
+            if source_text:
+                failures.append(
+                    failure(
+                        claim_id,
+                        "unsupported claim must not include a source citation",
+                    )
+                )
+            if quote_text:
+                failures.append(
+                    failure(
+                        claim_id,
+                        "unsupported claim must not include a quoted passage",
+                    )
+                )
+
+        if status == "unclear" and not explanation_text:
+            failures.append(
+                failure(
+                    claim_id,
+                    "unclear claim needs an explanation of what the sources do not establish",
+                )
+            )
+
+        if status == "supported":
+            if not source_text:
+                failures.append(
+                    failure(claim_id, "supported claim must name a source file")
+                )
+            if not quote_text:
+                failures.append(
+                    failure(claim_id, "supported claim must include a quoted passage")
+                )
+
+        has_citation = bool(source_text or quote_text)
+        complete_citation = bool(source_text and quote_text)
+        if status == "unclear" and has_citation and not complete_citation:
+            failures.append(
+                failure(
+                    claim_id,
+                    "a citation must include both 'source' and 'quote'",
+                )
+            )
+
+        if complete_citation and status in {"supported", "unclear"}:
+            candidate = source_path(sources_dir, source_text)
+            if candidate is None:
+                failures.append(
+                    failure(
+                        claim_id,
+                        f"source '{source_text}' is outside the allowed sources directory",
+                    )
+                )
+                continue
+            if not candidate.is_file():
+                failures.append(
+                    failure(
+                        claim_id,
+                        f"cited source file does not exist: {source_text}",
+                    )
+                )
+                continue
+
+            try:
+                document = candidate.read_text(encoding="utf-8")
+            except (OSError, UnicodeError) as exc:
+                failures.append(
+                    failure(claim_id, f"could not read cited source '{source_text}': {exc}")
+                )
+                continue
+
+            normalized_quote = normalize_whitespace(quote_text)
+            normalized_document = normalize_whitespace(document)
+            if not normalized_quote or normalized_quote not in normalized_document:
+                failures.append(
+                    failure(
+                        claim_id,
+                        f"quoted passage was not found verbatim in source '{source_text}' "
+                        "after whitespace normalization",
+                    )
+                )
+
+    for claim_id, count in sorted(seen.items()):
+        if claim_id in requested and count != 1:
+            failures.append(
+                failure(
+                    claim_id,
+                    f"requested claim appears {count} times; expected exactly once",
+                )
+            )
+
+    for claim_id in requested:
+        if claim_id not in seen:
+            failures.append(
+                failure(claim_id, "requested claim is missing from the result")
+            )
+
+    return failures
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Validate a claim-research result against local claims and sources."
+    )
+    parser.add_argument("result", type=Path, help="result JSON to validate")
+    parser.add_argument("--claims", required=True, type=Path, help="requested claims JSON")
+    parser.add_argument(
+        "--sources", required=True, type=Path, help="directory containing allowed sources"
+    )
+    args = parser.parse_args()
+
+    failures: list[str] = []
+    claims_payload, claim_load_failures = load_json(args.claims, "claims file")
+    result_payload, result_load_failures = load_json(args.result, "result file")
+    failures.extend(claim_load_failures)
+    failures.extend(result_load_failures)
+
+    if not args.sources.is_dir():
+        failures.append(
+            failure("sources directory", f"directory does not exist: {args.sources}")
+        )
+
+    if failures:
+        for item in failures:
+            print(item)
+        return 1
+
+    claim_rows, claim_shape_failures = extract_rows(claims_payload, "claims file")
+    result_rows, result_shape_failures = extract_rows(result_payload, "result file")
+    failures.extend(claim_shape_failures)
+    failures.extend(result_shape_failures)
+
+    requested, definition_failures = validate_claim_definitions(claim_rows)
+    failures.extend(definition_failures)
+
+    if not claim_shape_failures and not result_shape_failures and args.sources.is_dir():
+        failures.extend(validate_result_rows(result_rows, requested, args.sources))
+
+    if failures:
+        for item in failures:
+            print(item)
+        return 1
+
+    print(PASS_MESSAGE)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/templates/bakeoff-kit/fixtures/bad-result.json
+++ b/templates/bakeoff-kit/fixtures/bad-result.json
@@ -1,0 +1,32 @@
+{
+  "claims": [
+    {
+      "claim_id": "claim-01",
+      "status": "supported",
+      "source": "travel-policy.md",
+      "quote": "All flights must be booked in premium economy through the approved travel portal.",
+      "explanation": "This invented quotation does not appear in the cited source."
+    },
+    {
+      "claim_id": "claim-02",
+      "status": "supported",
+      "source": "expense-handbook.md",
+      "quote": "An itemized receipt is required for any single travel expense of $75 or more.",
+      "explanation": "The named source file does not exist."
+    },
+    {
+      "claim_id": "claim-03",
+      "status": "not-found",
+      "source": null,
+      "quote": null,
+      "explanation": "This status is outside the allowed set."
+    },
+    {
+      "claim_id": "claim-04",
+      "status": "unclear",
+      "source": "security-note.md",
+      "quote": "Report a lost or stolen device to the service desk promptly.",
+      "explanation": "The source does not establish a one-hour deadline."
+    }
+  ]
+}

--- a/templates/bakeoff-kit/fixtures/good-result.json
+++ b/templates/bakeoff-kit/fixtures/good-result.json
@@ -1,0 +1,39 @@
+{
+  "claims": [
+    {
+      "claim_id": "claim-01",
+      "status": "supported",
+      "source": "travel-policy.md",
+      "quote": "Flights shorter than six hours must be booked in standard economy through the approved travel portal.",
+      "explanation": "The policy states the booking channel, duration threshold, and fare class directly."
+    },
+    {
+      "claim_id": "claim-02",
+      "status": "supported",
+      "source": "travel-policy.md",
+      "quote": "An itemized receipt is required for any single travel expense of $75 or more.",
+      "explanation": "The receipt threshold exactly matches the claim."
+    },
+    {
+      "claim_id": "claim-03",
+      "status": "unsupported",
+      "source": null,
+      "quote": null,
+      "explanation": "Neither allowed source states that travelers receive an $85 daily meal allowance."
+    },
+    {
+      "claim_id": "claim-04",
+      "status": "unclear",
+      "source": "security-note.md",
+      "quote": "Report a lost or stolen device to the service desk promptly. When outside your home country, also notify the regional security contact as soon as practical.",
+      "explanation": "The source requires prompt reporting and an additional international notification, but it does not establish a one-hour deadline."
+    },
+    {
+      "claim_id": "claim-05",
+      "status": "supported",
+      "source": "security-note.md",
+      "quote": "Travelers must use a company-managed device and multi-factor authentication to access internal systems.",
+      "explanation": "The security note states both access requirements directly."
+    }
+  ]
+}

--- a/templates/bakeoff-kit/score-sheet.csv
+++ b/templates/bakeoff-kit/score-sheet.csv
@@ -1,0 +1,2 @@
+case_type,exact_model_id,lab,harness,provider_or_plan,ringer_commit,first_try_acceptance,acceptance_after_retry,human_repair_minutes,total_duration,reported_tokens,provider_charge,tool_and_infrastructure_cost,failure_type
+research,example/model-id,Example Lab,opencode,example provider or plan,<RINGER-COMMIT>,yes,yes,3,00:06:42,18250,0.21,0.00,none

--- a/templates/bakeoff-kit/source-packet/claims.json
+++ b/templates/bakeoff-kit/source-packet/claims.json
@@ -1,0 +1,24 @@
+{
+  "claims": [
+    {
+      "id": "claim-01",
+      "claim": "Economy is mandatory for flights under six hours, and those flights have to be reserved through the company's approved booking tool."
+    },
+    {
+      "id": "claim-02",
+      "claim": "Any individual travel expense at or above $75 needs an itemized receipt rather than just the card record."
+    },
+    {
+      "id": "claim-03",
+      "claim": "Travelers receive a daily meal allowance of $85."
+    },
+    {
+      "id": "claim-04",
+      "claim": "A lost or stolen device must be reported within one hour when an employee is outside their home country."
+    },
+    {
+      "id": "claim-05",
+      "claim": "Reaching internal systems while traveling requires both a company-issued device and a second authentication factor."
+    }
+  ]
+}

--- a/templates/bakeoff-kit/source-packet/sources/security-note.md
+++ b/templates/bakeoff-kit/source-packet/sources/security-note.md
@@ -1,0 +1,22 @@
+# Security Note for Travel
+
+Travelers must use a company-managed device and multi-factor authentication to access internal systems.
+
+Install pending operating-system and browser updates before departure. Do not
+disable disk encryption, endpoint protection, or the automatic screen lock.
+
+Use a personal hotspot or another trusted network when it is available. If a
+public network is the only practical option, connect through the approved
+secure-access client before opening internal tools. Do not connect an unknown
+USB drive or accept an unexpected pairing request.
+
+Keep devices with you or secured in a locked room.
+
+Report a lost or stolen device to the service desk promptly. When outside your home country, also notify the regional security contact as soon as practical.
+
+The service desk will decide whether credentials, sessions, or the device must
+be disabled. This note does not define a fixed number of minutes for either
+notification.
+
+Before returning a loaner device, upload approved work files to the designated
+workspace and follow the service desk's return instructions.

--- a/templates/bakeoff-kit/source-packet/sources/travel-policy.md
+++ b/templates/bakeoff-kit/source-packet/sources/travel-policy.md
@@ -1,0 +1,21 @@
+# Travel Policy
+
+Use the approved travel portal for all air and rail reservations.
+
+Flights shorter than six hours must be booked in standard economy through the approved travel portal.
+
+A traveler may select a refundable fare when the meeting date is likely to
+change, but the fare class does not change.
+
+Choose lodging within the nightly limit shown in the portal for the destination.
+If the listed properties are unavailable, save a screenshot of the search
+results and ask the travel desk for an exception before booking elsewhere.
+
+An itemized receipt is required for any single travel expense of $75 or more.
+For smaller expenses, the card record is sufficient unless Finance asks for
+more detail. Submit the expense report within ten calendar days after returning.
+
+Reasonable local transit to the airport, hotel, and work site is reimbursable.
+Travelers should choose the practical option, considering both cost and travel
+time. This policy does not set a meal allowance; meal reimbursement is reviewed
+under the separate expense standard.

--- a/templates/bakeoff-kit/swarm.model-only.example.json
+++ b/templates/bakeoff-kit/swarm.model-only.example.json
@@ -1,0 +1,41 @@
+{
+  "run_name": "chinese-model-research-bakeoff",
+  "workdir": "/tmp/chinese-model-research-bakeoff-2026-07-25-01",
+  "max_parallel": 1,
+  "tasks": [
+    {
+      "key": "frontier--claims-01",
+      "spec": "Read the requested claims in /ABSOLUTE/PATH/TO/ringer-bakeoff-kit/source-packet/claims.json and only the Markdown files in /ABSOLUTE/PATH/TO/ringer-bakeoff-kit/source-packet/sources. Classify every requested claim exactly once as supported, unsupported, or unclear. Write result.json in the current task directory as a JSON object with a claims array. Every row must contain claim_id, status, source, quote, and explanation. For supported claims, source must name an allowed source file and quote must reproduce an exact supporting passage. For unsupported claims, set source and quote to null. For unclear claims, explain exactly what the sources do not establish; if you cite evidence, provide both the allowed source filename and an exact passage. Do not use outside knowledge or network access. Do not modify the source packet or validator.",
+      "check": "python3 '/ABSOLUTE/PATH/TO/ringer-bakeoff-kit/check_result.py' result.json --claims '/ABSOLUTE/PATH/TO/ringer-bakeoff-kit/source-packet/claims.json' --sources '/ABSOLUTE/PATH/TO/ringer-bakeoff-kit/source-packet/sources'",
+      "expect_files": [
+        "result.json"
+      ],
+      "engine": "opencode",
+      "model": "openrouter/<CURRENT-FRONTIER-MODEL-ID>",
+      "engine_args": [
+        "--variant",
+        "high"
+      ],
+      "task_type": "research",
+      "timeout_s": 900,
+      "verified": "the result includes each requested claim exactly once, uses the required fields and statuses, and any included citations match files in the allowed source directory"
+    },
+    {
+      "key": "candidate--claims-01",
+      "spec": "Read the requested claims in /ABSOLUTE/PATH/TO/ringer-bakeoff-kit/source-packet/claims.json and only the Markdown files in /ABSOLUTE/PATH/TO/ringer-bakeoff-kit/source-packet/sources. Classify every requested claim exactly once as supported, unsupported, or unclear. Write result.json in the current task directory as a JSON object with a claims array. Every row must contain claim_id, status, source, quote, and explanation. For supported claims, source must name an allowed source file and quote must reproduce an exact supporting passage. For unsupported claims, set source and quote to null. For unclear claims, explain exactly what the sources do not establish; if you cite evidence, provide both the allowed source filename and an exact passage. Do not use outside knowledge or network access. Do not modify the source packet or validator.",
+      "check": "python3 '/ABSOLUTE/PATH/TO/ringer-bakeoff-kit/check_result.py' result.json --claims '/ABSOLUTE/PATH/TO/ringer-bakeoff-kit/source-packet/claims.json' --sources '/ABSOLUTE/PATH/TO/ringer-bakeoff-kit/source-packet/sources'",
+      "expect_files": [
+        "result.json"
+      ],
+      "engine": "opencode",
+      "model": "openrouter/<CURRENT-QWEN-MODEL-ID>",
+      "engine_args": [
+        "--variant",
+        "high"
+      ],
+      "task_type": "research",
+      "timeout_s": 900,
+      "verified": "the result includes each requested claim exactly once, uses the required fields and statuses, and any included citations match files in the allowed source directory"
+    }
+  ]
+}


### PR DESCRIPTION
The downloadable companion to the **How to Run a Chinese-Model Bakeoff in Ringer** guide, shipping with the Mon 7/27 news piece (Linear NAT-2791).

Distinct from `templates/bakeoff/`, which drives an external product and needs a session validator to prove model identity. This is the simpler model-only lane where the worker writes `result.json` directly.

## Contents (9 files, all new, nothing else touched)

- `check_result.py` — stdlib-only validator enforcing the eight rules the guide documents
- `source-packet/` — a five-claim task built so one claim is genuinely **unsupported** and one is legitimately **ambiguous**, so a model that pattern-matches gets both wrong
- `fixtures/` — known-good and known-bad, for proving your checker before you pay any model
- `swarm.model-only.example.json` — two cells, per-task pinned models, `max_parallel: 1`
- `score-sheet.csv` + `README.md`

## Verified by execution, not inspection

- Known-good fixture accepted with the exact PASS line the guide promises
- Known-bad fixture rejected naming all four promised defects: invented quote, nonexistent source, invalid status, omitted claim
- Empty payload rejected, so the check cannot pass vacuously
- Re-verified from a clean extract of the published zip

The README points the score sheet at the **Ringside Models view** — eight of its fourteen columns are already computed there from your own attempt history, so the sheet is the cost layer (money and repair minutes), not manual re-entry of the machine's own record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)