### PR TITLE
fix(fix-swarm): scope `git add` to owned files instead of sweeping worktree debris

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,6 +357,7 @@ Every community PR that lands in main is credited here — that's a project rule
 - [@davekopecek](https://github.com/davekopecek) (Dave Kopecek) — committed the design-reference fixture so the design-token guard runs on every machine (#30)
 - [@snapsynapse](https://github.com/snapsynapse) (Sam Rogers) — graceful shutdown on SIGINT/SIGTERM with worker-tree cleanup and finished state, plus the 14-test end-to-end CLI regression suite (#4)
 - [@mlava](https://github.com/mlava) (Mark Lavercombe) — named setup failures across every diagnostic surface (#37) and `run --baseline`, the no-workers check preflight (#38)
+- [@jeffhamons](https://github.com/jeffhamons) (Jeff Hamons) — a private OpenCode session store per worker, ending the `database is locked` deaths that made concurrent cheap-tier workers look like model failures (#79), and fix-swarm staging scoped to owned files instead of sweeping worktree debris (#80)
 
 Contributions are welcome — see [CONTRIBUTING.md](CONTRIBUTING.md) for the philosophy and what gets a PR merged fast. The short version: small and scoped, rebased on current main, every claim backed by an executed test. Authorship is always preserved — where a maintainer pushes a mechanical fix to your branch, you remain the commit author.
 

--- a/templates/fix-swarm/checks/fix-swarm.py
+++ b/templates/fix-swarm/checks/fix-swarm.py
@@ -131,9 +131,27 @@ def main() -> int:
                 )
             )
 
-    add_result = run_git(["add", "-A"])
-    if add_result.returncode != 0:
-        failures.append(fail("git_add_failed", output_tail(add_result.stdout)))
+    if "*" in owned_files:
+        add_result = run_git(["add", "-A"])
+        if add_result.returncode != 0:
+            failures.append(fail("git_add_failed", output_tail(add_result.stdout)))
+    else:
+        # Stage tracked-file modifications (so out-of-lane edits to existing
+        # files still get caught by the owned-files check below) plus any
+        # new files under the owned paths. Deliberately does NOT `add -A`:
+        # worker/check subprocesses can leave untracked debris in the
+        # worktree (e.g. a sandboxed pytest run falling back to cwd for its
+        # basetemp) that has nothing to do with the agent's actual diff.
+        add_u_result = run_git(["add", "-u"])
+        if add_u_result.returncode != 0:
+            failures.append(fail("git_add_failed", output_tail(add_u_result.stdout)))
+        # Only pass owned paths that actually exist: `git add -- <path>` hard-fails
+        # ("did not match any files") for a declared-but-untouched owned path.
+        existing_owned = [item for item in owned_files if Path(item).exists()]
+        if existing_owned:
+            add_owned_result = run_git(["add", "--"] + existing_owned)
+            if add_owned_result.returncode != 0:
+                failures.append(fail("git_add_failed", output_tail(add_owned_result.stdout)))
 
     if not args.summary.is_absolute() and args.summary.exists():
         run_git(["reset", "--quiet", "--", str(args.summary)])


### PR DESCRIPTION
The fix-swarm check stages a worker's result with `git add -A`. That sweeps in whatever untracked debris the worker and check subprocesses happened to leave in the worktree — in my case a sandboxed `pytest` run falling back to cwd for its `basetemp` — so the task's commit contains files the task never claimed and nobody reviewed.

## The fix

- `owned_files == ["*"]` keeps `git add -A`. A task that declares it owns everything means it.
- Otherwise: `git add -u` to catch modifications and deletions of already-tracked files, plus the declared owned paths explicitly.
- Only owned paths that **actually exist** are passed, because `git add -- <path>` hard-fails with "did not match any files" for a declared-but-untouched owned path — which would turn an honest partial result into a check error.

## Proof

Full suite on macOS (Python 3.14), rebased on current `main` (2c2b599): **218 of 218 pass**.

## Overlap

#56 (Preserve fix-swarm patches across retries) touches the same file. These are independent changes — patch preservation across retries versus what gets staged — but they will conflict textually. I am happy to rebase onto whichever lands first; no need to hold either on my account.

## Motivation

This one is from a live regression rather than a hypothetical: the fix rode on my local `main` from 2026-07-19, a sync reset the branch, and every fix-swarm run for the following eight days silently went back to `add -A` before I caught it.

---

**Update:** the README credit line is now a second commit on this branch, so the suite is fully green. The same line is on #79 and #80 — identical text, so whichever merges second resolves trivially. Drop the commit if you would rather handle credit yourself.
