### PR TITLE
Fix the shutdown-test flake: two writers, one temp filename

### DIFF
--- a/ringer.py
+++ b/ringer.py
@@ -2248,10 +2248,13 @@ class StateWriter:
 
     def flush(self) -> dict[str, Any]:
         state = self.snapshot()
-        self.path.parent.mkdir(parents=True, exist_ok=True)
-        tmp = self.path.with_suffix(".json.tmp")
-        tmp.write_text(json.dumps(state, indent=2, sort_keys=True), encoding="utf-8")
-        os.replace(tmp, self.path)
+        # atomic_write_json, not a fixed "<name>.json.tmp": the background
+        # writer thread and an explicit flush (a signal handler, set_port)
+        # can overlap. With one shared temp name, the first os.replace wins
+        # and the second raises FileNotFoundError on a temp file that no
+        # longer exists — which surfaced as a ~30% flake in the shutdown
+        # tests. mkstemp gives each writer its own file; last replace wins.
+        atomic_write_json(self.path, state)
         if self.artifact.enabled:
             self._write_status_artifact_safe(state)
             self._write_index_safe()
@@ -2403,11 +2406,9 @@ class StateWriter:
             self._append_library_version_safe(state)
             # Re-flush the plain state JSON so report_ready/report_path are accurate for
             # anything (Ringside) polling the state file right after the run ends.
-            tmp = self.path.with_suffix(".json.tmp")
             state = dict(state)
             state["report_ready"] = True
-            tmp.write_text(json.dumps(state, indent=2, sort_keys=True), encoding="utf-8")
-            os.replace(tmp, self.path)
+            atomic_write_json(self.path, state)
         except Exception as exc:
             print(f"artifact render error (final report, non-fatal): {exc}", file=sys.stderr)
 

--- a/tests/test_state_writer_concurrency.py
+++ b/tests/test_state_writer_concurrency.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Concurrent flushes must not fight over one temp file.
+
+Regression: StateWriter.flush wrote `<run>.json.tmp` — one fixed name for
+every writer. The background writer thread and an explicit flush (a signal
+handler, set_port) overlap routinely, so the first os.replace consumed the
+temp file and the second raised FileNotFoundError. That crashed the process
+during shutdown and made two signal tests fail ~30% of runs.
+"""
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import threading
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from ringer import EngineConfig, StateWriter, TaskRuntime, TaskSpec
+
+
+class StateWriterConcurrencyTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._temp.cleanup)
+        self.state_dir = Path(self._temp.name)
+
+    def _writer(self) -> StateWriter:
+        taskdir = self.state_dir / "task"
+        taskdir.mkdir(parents=True, exist_ok=True)
+        log_path = taskdir / "worker.log"
+        log_path.write_text("worker output\n", encoding="utf-8")
+        runtime = TaskRuntime(
+            task=TaskSpec(
+                key="task",
+                spec="Do the thing described here in full.",
+                check="true",
+                engine="mock",
+            ),
+            taskdir=taskdir,
+            log_path=log_path,
+            status="running",
+            attempts=1,
+            spec_short="do the thing",
+        )
+        runtime.started_at_monotonic = 1.0
+        return StateWriter(
+            "run-concurrency",
+            "Concurrency Run",
+            "test-agent",
+            self.state_dir,
+            {
+                "mock": EngineConfig(
+                    name="mock",
+                    bin=sys.executable,
+                    args_template=("-c", "pass"),
+                    full_access_args=(),
+                    sandbox_args=(),
+                )
+            },
+            datetime(2026, 7, 28, tzinfo=timezone.utc),
+            [runtime],
+            threading.RLock(),
+        )
+
+    def test_parallel_flushes_never_lose_their_temp_file(self) -> None:
+        writer = self._writer()
+        errors: list[BaseException] = []
+        start = threading.Event()
+
+        def hammer() -> None:
+            start.wait()
+            for _ in range(25):
+                try:
+                    writer.flush()
+                except BaseException as exc:  # noqa: BLE001 - the point is to catch any
+                    errors.append(exc)
+
+        threads = [threading.Thread(target=hammer) for _ in range(6)]
+        for thread in threads:
+            thread.start()
+        start.set()
+        for thread in threads:
+            thread.join()
+
+        self.assertEqual([], errors, f"concurrent flush raised: {errors[:3]}")
+
+    def test_the_state_file_stays_parseable_under_concurrent_flushes(self) -> None:
+        writer = self._writer()
+        stop = threading.Event()
+        bad: list[str] = []
+
+        def flusher() -> None:
+            while not stop.is_set():
+                writer.flush()
+
+        def reader() -> None:
+            for _ in range(60):
+                try:
+                    text = writer.path.read_text(encoding="utf-8")
+                except FileNotFoundError:
+                    continue
+                if not text:
+                    continue
+                try:
+                    json.loads(text)
+                except json.JSONDecodeError as exc:
+                    bad.append(f"{exc}: {text[:120]!r}")
+
+        writer.flush()
+        writers = [threading.Thread(target=flusher) for _ in range(3)]
+        for thread in writers:
+            thread.start()
+        readers = [threading.Thread(target=reader) for _ in range(2)]
+        for thread in readers:
+            thread.start()
+        for thread in readers:
+            thread.join()
+        stop.set()
+        for thread in writers:
+            thread.join()
+
+        self.assertEqual([], bad, f"reader saw a torn state file: {bad[:2]}")
+
+    def test_no_temp_files_are_left_behind(self) -> None:
+        writer = self._writer()
+        for _ in range(10):
+            writer.flush()
+        leftovers = [p.name for p in writer.path.parent.glob("*.tmp")]
+        self.assertEqual([], leftovers, f"temp files left behind: {leftovers}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`test_sigterm_cleans_up_active_worker_and_finishes_state` and `test_second_signal_during_shutdown_does_not_cancel_cleanup` fail about **30% of runs** — measured 4/12 and 3/12 on `main`. It isn't timing sensitivity in the tests. It's a real race in `StateWriter`.

## The bug

`StateWriter.flush` wrote to `<run>.json.tmp` — one fixed temp name shared by every caller. The background writer thread flushes on a timer, while explicit flushes arrive from `set_port`, `close`, and the signal path, so two flushes overlap routinely:

1. Thread A writes `run.json.tmp`
2. Thread B writes `run.json.tmp` (same file)
3. Thread A calls `os.replace(tmp, path)` — succeeds, temp file is gone
4. Thread B calls `os.replace(tmp, path)` — **FileNotFoundError**

That reached the top-level handler, which exits 2. The test asserting exit 130 saw 2 and failed. The same fixed name appeared a second time in the end-of-run re-flush.

## The fix

Both sites now use `atomic_write_json`, which is already in the file and already correct — `tempfile.mkstemp` gives each writer its own temp file, and the final `os.replace` is atomic. Overlapping flushes become last-write-wins instead of one of them crashing.

## Verification

- **20/20 passes on each of the two tests** after the fix. Before: ~30% failure.
- **4 consecutive clean full-suite runs** (253 tests). Before, the suite failed roughly every other run.
- **The new tests actually catch the bug.** Run against pre-fix `deda7c1`, `test_parallel_flushes_never_lose_their_temp_file` fails with exactly the `FileNotFoundError` above. The other two guard adjacent invariants — no torn reads, no leaked temp files — and pass either way; they're property tests, not regression tests for this bug, and I'd rather say so than imply all three reproduce it.

## Left alone deliberately

`_write_active_runs` and `write_settings` use `.{name}.{pid}.tmp`. They're called from the main thread at run start and end, so the pid suffix is sufficient and there's no observed defect. Touching them here would be scope creep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)