### PR TITLE
Add per-task check_timeout_s override

### DIFF
--- a/ringer.py
+++ b/ringer.py
@@ -395,6 +395,10 @@ class TaskSpec:
     # engine's {model} placeholder); empty means the engine's model_default.
     model: str = ""
     task_type: str = ""
+    # Overrides CHECK_TIMEOUT_S for this task's check command. Unset (None)
+    # falls back to the module default; use for checks that run a real
+    # compiled-language build (xcodebuild, gradle, cargo build, etc.).
+    check_timeout_s: int | None = None
 
     @classmethod
     def from_obj(cls, obj: dict[str, Any]) -> "TaskSpec":
@@ -435,6 +439,12 @@ class TaskSpec:
         task_type = obj.get("task_type", "")
         if not isinstance(task_type, str):
             raise ValueError(f"task {key}: task_type must be a string")
+        check_timeout_s_raw = obj.get("check_timeout_s")
+        check_timeout_s: int | None = None
+        if check_timeout_s_raw is not None:
+            check_timeout_s = int(check_timeout_s_raw)
+            if check_timeout_s <= 0:
+                raise ValueError(f"task {key}: check_timeout_s must be positive")
         return cls(
             key=key,
             spec=spec,
@@ -447,6 +457,7 @@ class TaskSpec:
             verified=verified.strip(),
             model=model.strip(),
             task_type=task_type.strip(),
+            check_timeout_s=check_timeout_s,
         )
 
 
@@ -580,6 +591,12 @@ def lint_manifest(manifest: Manifest, *, include_model_log_nudges: bool = False)
                 f"{task.key}: no 'verified' description; a reader of the results page sees "
                 "'checked' but not what the check proves — add one plain-English sentence."
             )
+        if task.check_timeout_s is None and check_invokes_build_tool(task.check):
+            findings.append(
+                f"{task.key}: check invokes a compiled-language build but has no check_timeout_s; "
+                f"the default {CHECK_TIMEOUT_S}s kills real builds before they finish — set check_timeout_s "
+                "well above the expected build time."
+            )
         if include_model_log_nudges and not task.task_type:
             findings.append(
                 f"{task.key}: no task_type; the model log buckets this as (untyped) — "
@@ -627,6 +644,22 @@ def spec_is_file_pointer(spec: str) -> bool:
     if len(text) >= 600:
         return False
     return bool(FILE_POINTER_SPEC_RE.search(text))
+
+
+BUILD_TOOL_RE = re.compile(
+    r"\b(xcodebuild|xcodegen|gradle(?:w)?|cargo\s+build|make|ninja|msbuild|xcrun\s+xcodebuild|"
+    r"swift\s+build|mvn|bazel|go\s+build)\b"
+)
+
+
+def check_invokes_build_tool(check: str) -> bool:
+    """True when a check shells out to a real compiled-language build tool.
+
+    These routinely take minutes (Xcode/xcodebuild simulator builds, Gradle,
+    cargo build --release) and will blow past the default CHECK_TIMEOUT_S,
+    failing otherwise-correct worker output on a timeout instead of a bug.
+    """
+    return bool(BUILD_TOOL_RE.search(strip_shell_comments(check)))
 
 
 def check_cannot_fail(check: str) -> bool:
@@ -6712,7 +6745,8 @@ def run_models_command(config: AppConfig, args: argparse.Namespace) -> int:
 
 class Verifier:
     async def verify(self, task: TaskSpec, taskdir: Path) -> VerifyResult:
-        check_returncode, check_timed_out, output = await self._run_check(task.check, taskdir)
+        timeout_s = task.check_timeout_s if task.check_timeout_s is not None else CHECK_TIMEOUT_S
+        check_returncode, check_timed_out, output = await self._run_check(task.check, taskdir, timeout_s)
         missing_files = tuple(
             rel for rel in task.expect_files if not self._is_nonempty_file(self._expect_file_path(taskdir, rel))
         )
@@ -6750,7 +6784,7 @@ class Verifier:
         return candidate if candidate.is_absolute() else taskdir / candidate
 
     @staticmethod
-    async def _run_check(command: str, cwd: Path) -> tuple[int | None, bool, str]:
+    async def _run_check(command: str, cwd: Path, timeout_s: int = CHECK_TIMEOUT_S) -> tuple[int | None, bool, str]:
         proc = await asyncio.create_subprocess_shell(
             command,
             cwd=str(cwd),
@@ -6761,7 +6795,7 @@ class Verifier:
         )
         timed_out = False
         try:
-            stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=CHECK_TIMEOUT_S)
+            stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=timeout_s)
         except asyncio.TimeoutError:
             timed_out = True
             terminate_process_group(proc)
@@ -6772,7 +6806,7 @@ class Verifier:
                 stdout, _ = await proc.communicate()
         output = stdout.decode("utf-8", errors="replace") if stdout else ""
         if timed_out:
-            output += f"\n[ringer.py] check timed out after {CHECK_TIMEOUT_S}s\n"
+            output += f"\n[ringer.py] check timed out after {timeout_s}s\n"
         return proc.returncode, timed_out, output
 
 

--- a/templates/repo-feature/README.md
+++ b/templates/repo-feature/README.md
@@ -16,6 +16,7 @@ Use this for narrowly scoped app pages, route additions, component changes, scri
 |---|---|
 | `{{ALLOWED_STATUS_PATHS_CSV}}` | Additional pre-existing or explicitly allowed git-status paths, comma-separated. |
 | `{{BUILD_OR_TEST_COMMAND}}` | Real repo verification command, such as `npm run build` or `pytest`. |
+| `check_timeout_s` (not a `{{}}` placeholder, edit the literal value in `manifest.json`) | Ships set to 300s. Raise it further if `{{BUILD_OR_TEST_COMMAND}}` invokes a real compiled-language build (Xcode/`xcodebuild`, Gradle, `cargo build`, `make`) rather than fast interpreted-language tests — see Gotchas. |
 | `{{CONVENTION_FILES}}` | Read-only files the worker should inspect before editing. |
 | `{{ENGINE_BUILD}}` | Engine name for the repo-edit worker. |
 | `{{FEATURE_BRIEF}}` | The concrete feature request and acceptance criteria. |
@@ -51,3 +52,5 @@ Never run `git add -A` in a checkout with untracked scratch files. Stage specifi
 The worker's `notes.md` belongs in the task directory, not the repo. The repo check should assert real source changes and git cleanliness; notes are just the build report.
 
 `expect_files` is asserted before checks run. Do not put build artifacts, screenshots, or other check-produced files there.
+
+`{{BUILD_OR_TEST_COMMAND}}` running under a fast interpreted-language test runner (pytest, jest, `npm test`) usually finishes well inside the manifest's `check_timeout_s`. A real compiled-language build — `xcodebuild`/`xcodegen` + simulator build, Gradle, `cargo build`, `make` — can legitimately take several minutes. Ringer kills the check process (not the worker) once `check_timeout_s` elapses and reports the task as failed, even when the worker's code was already correct. Set `check_timeout_s` in `manifest.json` well above the real build's wall-clock time whenever `{{BUILD_OR_TEST_COMMAND}}` is a build, not just a test run. `./ringer.py lint` warns when a check string mentions a known build tool and `check_timeout_s` was left unset.

--- a/templates/repo-feature/manifest.json
+++ b/templates/repo-feature/manifest.json
@@ -8,6 +8,7 @@
       "engine": "{{ENGINE_BUILD}}",
       "task_type": "code-feature",
       "timeout_s": 2400,
+      "check_timeout_s": 300,
       "expect_files": [
         "notes.md"
       ],


### PR DESCRIPTION
## Summary
- \`CHECK_TIMEOUT_S\` (60s) was hardcoded with no per-task override, so any check running a real compiled-language build (Xcode/xcodebuild, Gradle, cargo build) got killed before finishing — even when the worker's output was already correct.
- Adds an optional \`check_timeout_s\` manifest field, threaded through \`TaskSpec\` and \`Verifier._run_check\`; falls back to the existing 60s default when unset, so existing manifests are unaffected.
- \`lint\` now warns when a check string invokes a known build tool (\`xcodebuild\`, \`gradle\`/\`gradlew\`, \`cargo build\`, \`make\`, \`swift build\`, \`go build\`, \`mvn\`, \`bazel\`, \`ninja\`, \`msbuild\`) without an explicit \`check_timeout_s\`.
- Updates \`templates/repo-feature/manifest.json\` (sets \`check_timeout_s: 300\`) and its README to document the gotcha.

## Test plan
- [x] \`python3 -c "import ast; ast.parse(open('ringer.py').read())"\` — compiles
- [x] Manual smoke test: default/override parsing, invalid-value rejection, lint firing on \`xcodebuild\`/\`cargo build\`/etc. and staying silent when \`check_timeout_s\` is set or the check is plain tests
- [ ] pytest suite (not run — no working pytest install in this environment)