### PR TITLE
Model registry cleanup + engine reliability fixes

### DIFF
--- a/engines/mock_worker.py
+++ b/engines/mock_worker.py
@@ -13,6 +13,10 @@ def has_fail_directive(spec: str) -> bool:
     return any(line.strip() == "MOCK_FAIL" for line in spec.splitlines())
 
 
+def has_engine_down_directive(spec: str) -> bool:
+    return any(line.strip() == "MOCK_ENGINE_DOWN" for line in spec.splitlines())
+
+
 def parse_blocks(spec: str) -> list[tuple[str, str]]:
     lines = spec.splitlines()
     blocks: list[tuple[str, str]] = []
@@ -73,6 +77,9 @@ def main(argv: list[str]) -> int:
         return 2
 
     spec = argv[-1]
+    if has_engine_down_directive(spec):
+        print("mock-worker: 402 Payment Required: usage balance exhausted", file=sys.stderr)
+        return 1
     if has_fail_directive(spec):
         print("mock-worker: simulated failure")
         return 1

--- a/engines/opencode-sandboxed.sh
+++ b/engines/opencode-sandboxed.sh
@@ -5,7 +5,9 @@
 # flag (required for headless runs) disables ALL of its interactive approval
 # prompts. This wrapper supplies the real containment: full network and reads,
 # writes confined to the task dir, a per-run scratch/cache dir, and OpenCode's
-# own state dirs.
+# own state dirs. The scratch root also carries a private per-run XDG_DATA_HOME,
+# which is what keeps concurrent workers off one shared session database (see the
+# comment on that export below — it is a correctness fix for parallel runs).
 #
 # Usage (as a ringer engine bin):
 #   opencode-sandboxed.sh <taskdir> [--no-sandbox] <opencode args...>
@@ -28,6 +30,9 @@ if ! OPENCODE_BIN="$(command -v opencode)" || [ -z "$OPENCODE_BIN" ]; then
 fi
 
 if [ "$SANDBOX" = "0" ]; then
+  # Full-access mode keeps OpenCode's real ~/.local/share/opencode, so it also
+  # keeps the shared-session-DB contention documented below. Fine for a lone
+  # full-access task; do not fan out several at once.
   exec "$OPENCODE_BIN" "$@" < /dev/null
 fi
 
@@ -59,7 +64,8 @@ cat > "$PROFILE" <<'SBEOF'
   (subpath (param "SCRATCH"))
   (subpath (param "OC_SHARE"))
   (subpath (param "OC_STATE"))
-  (subpath (param "OC_CONFIG")))
+  (subpath (param "OC_CONFIG"))
+  (subpath (param "OC_BASE")))
 ; /dev is needed for /dev/null, /dev/urandom, etc.; writes there can't create
 ; persistent files without root, so a few literals are allowed rather than via param.
 (allow file-write-data
@@ -72,6 +78,25 @@ export TMPDIR="$SCRATCH"
 export XDG_CACHE_HOME="$SCRATCH/cache"
 mkdir -p "$XDG_CACHE_HOME"
 
+# Per-run DATA root — this is a concurrency fix, not just containment. OpenCode
+# keeps its session store at $XDG_DATA_HOME/opencode/opencode.db, defaulting to
+# ~/.local/share/opencode: one file, shared by every worker, opened for write,
+# growing without bound. On 2026-07-27 it stood at 1.78 GB and two of three
+# workers launched simultaneously died before their first tool call with
+# "Error: Unexpected error / database is locked" — recorded as model failures
+# though no model had run. Since every non-Codex model routes through this
+# engine, shared-DB contention penalises exactly the cheap tier, and worsens as
+# parallelism rises. A private store per worker removes the contention entirely.
+# Credentials live beside the DB, so seed the fresh root with auth.json — copy,
+# never symlink: the profile denies writes outside SCRATCH, and a symlink would
+# resolve straight back to the shared file this exists to avoid.
+export XDG_DATA_HOME="$SCRATCH/share"
+mkdir -p "$XDG_DATA_HOME/opencode"
+if [ -f "$HOME/.local/share/opencode/auth.json" ]; then
+  cp "$HOME/.local/share/opencode/auth.json" "$XDG_DATA_HOME/opencode/auth.json"
+  chmod 600 "$XDG_DATA_HOME/opencode/auth.json"
+fi
+
 # Run as a child (not exec) so the EXIT trap fires and cleans up the profile +
 # scratch dir even on the success path; propagate the child's exit status.
 set +e
@@ -81,6 +106,7 @@ set +e
   -D "OC_SHARE=$HOME/.local/share/opencode" \
   -D "OC_STATE=$HOME/.local/state/opencode" \
   -D "OC_CONFIG=$HOME/.config/opencode" \
+  -D "OC_BASE=$HOME/.opencode" \
   -f "$PROFILE" "$OPENCODE_BIN" "$@" < /dev/null
 status=$?
 set -e

--- a/registry/model-identity.toml
+++ b/registry/model-identity.toml
@@ -64,6 +64,16 @@ confidence = "verified"     # Cursor (Anysphere) model, served through xAI's Gro
 source = "https://cursor.com/blog/composer-2-5"
 last_verified = 2026-07-10
 
+[engines.grok.models."grok-4.5"]
+# Task-manifest "model" field for grok-engine tasks logs "grok-4.5" directly
+# (not the "grok-build" default_model_key above) — this is the actual slug
+# ringer observes on grok-engine attempts. Same artifact as grok-build.
+display = "Grok 4.5"
+lab = "xAI"
+confidence = "verified"
+source = "https://docs.x.ai/developers/release-notes"
+last_verified = 2026-08-01
+
 [engines.opencode]
 harness = "OpenCode"
 access = "OpenRouter API"
@@ -98,3 +108,96 @@ lab = "Meta"
 confidence = "verified"
 source = "manifest model field; OpenRouter slug meta-llama/llama-3.3-70b-instruct:free"
 last_verified = 2026-07-10
+
+[engines.opencode.models."openrouter/anthropic/claude-sonnet-5"]
+display = "Claude Sonnet 5"
+lab = "Anthropic"
+confidence = "verified"
+source = "manifest model field; OpenRouter slug anthropic/claude-sonnet-5"
+last_verified = 2026-08-01
+
+[engines.opencode.models."openrouter/cohere/north-mini-code:free"]
+display = "North Mini Code (free)"
+lab = "Cohere"
+confidence = "verified"
+source = "manifest model field; OpenRouter slug cohere/north-mini-code:free"
+last_verified = 2026-08-01
+
+[engines.opencode.models."openrouter/deepseek/deepseek-v4-flash"]
+display = "DeepSeek V4 Flash"
+lab = "DeepSeek"
+confidence = "verified"
+source = "manifest model field; OpenRouter slug deepseek/deepseek-v4-flash"
+last_verified = 2026-08-01
+
+[engines.opencode.models."openrouter/deepseek/deepseek-v4-pro"]
+display = "DeepSeek V4 Pro"
+lab = "DeepSeek"
+confidence = "verified"
+source = "manifest model field; OpenRouter slug deepseek/deepseek-v4-pro"
+last_verified = 2026-08-01
+
+[engines.opencode.models."openrouter/inclusionai/ling-2.6-flash"]
+# InclusionAI is Ant Group's AGI/open-source publishing org (home of the Ant
+# Ling team) — see https://huggingface.co/inclusionAI.
+display = "Ling 2.6 Flash"
+lab = "InclusionAI (Ant Group)"
+confidence = "verified"
+source = "https://huggingface.co/inclusionAI"
+last_verified = 2026-08-01
+
+[engines.opencode.models."openrouter/inclusionai/ling-3.0-flash:free"]
+display = "Ling 3.0 Flash (free)"
+lab = "InclusionAI (Ant Group)"
+confidence = "verified"
+source = "https://huggingface.co/inclusionAI"
+last_verified = 2026-08-01
+
+[engines.opencode.models."openrouter/moonshotai/kimi-k2.5"]
+display = "Kimi K2.5"
+lab = "Moonshot AI"
+confidence = "verified"
+source = "manifest model field; OpenRouter slug moonshotai/kimi-k2.5"
+last_verified = 2026-08-01
+
+[engines.opencode.models."openrouter/moonshotai/kimi-k2.6"]
+display = "Kimi K2.6"
+lab = "Moonshot AI"
+confidence = "verified"
+source = "https://openrouter.ai/moonshotai/kimi-k2.6"
+last_verified = 2026-08-01
+
+[engines.opencode.models."openrouter/nvidia/nemotron-3-nano-30b-a3b:free"]
+display = "Nemotron 3 Nano 30B A3B (free)"
+lab = "NVIDIA"
+confidence = "verified"
+source = "manifest model field; OpenRouter slug nvidia/nemotron-3-nano-30b-a3b:free"
+last_verified = 2026-08-01
+
+[engines.opencode.models."openrouter/nvidia/nemotron-3-super-120b-a12b"]
+display = "Nemotron 3 Super 120B A12B"
+lab = "NVIDIA"
+confidence = "verified"
+source = "manifest model field; OpenRouter slug nvidia/nemotron-3-super-120b-a12b"
+last_verified = 2026-08-01
+
+[engines.opencode.models."openrouter/nvidia/nemotron-3-ultra-550b-a55b:free"]
+display = "Nemotron 3 Ultra 550B A55B (free)"
+lab = "NVIDIA"
+confidence = "verified"
+source = "manifest model field; OpenRouter slug nvidia/nemotron-3-ultra-550b-a55b:free"
+last_verified = 2026-08-01
+
+[engines.opencode.models."openrouter/qwen/qwen3-coder"]
+display = "Qwen3 Coder 480B A35B"
+lab = "Alibaba (Qwen)"
+confidence = "verified"
+source = "manifest model field; OpenRouter slug qwen/qwen3-coder"
+last_verified = 2026-08-01
+
+[engines.opencode.models."openrouter/thinkingmachines/inkling"]
+display = "Inkling"
+lab = "Thinking Machines Lab"
+confidence = "verified"
+source = "https://openrouter.ai/thinkingmachines/inkling"
+last_verified = 2026-08-01

--- a/registry/model-identity.toml
+++ b/registry/model-identity.toml
@@ -201,3 +201,26 @@ lab = "Thinking Machines Lab"
 confidence = "verified"
 source = "https://openrouter.ai/thinkingmachines/inkling"
 last_verified = 2026-08-01
+
+[engines.opencode.models."openrouter/poolside/laguna-m.1:free"]
+# Not a typo — OpenRouter carried this slug from 2026-07-09 until it was
+# delisted 2026-08-01T23:13:22Z (same day as this entry, hours before this
+# registry check ran). Confirmed via ~/.ringer/openrouter-catalog.changes.jsonl
+# added/removed events, catalog name "Poolside: Laguna M.1 (free)". Historical
+# attempts against this slug should still resolve to Poolside identity even
+# though the model is no longer orderable.
+display = "Laguna M.1 (free)"
+lab = "Poolside"
+confidence = "verified"
+source = "OpenRouter catalog history (~/.ringer/openrouter-catalog.changes.jsonl): added 2026-07-09, delisted 2026-08-01"
+last_verified = 2026-08-01
+
+[engines.opencode.models."openrouter/nousresearch/hermes-3-llama-3.1-405b:free"]
+# Not a typo — OpenRouter carried the free tier of this model from 2026-07-09
+# until it was delisted 2026-07-19; the paid nousresearch/hermes-3-llama-3.1-405b
+# slug remains live. Catalog name "Nous: Hermes 3 405B Instruct (free)".
+display = "Hermes 3 405B Instruct (free)"
+lab = "Nous Research"
+confidence = "verified"
+source = "OpenRouter catalog history (~/.ringer/openrouter-catalog.changes.jsonl): added 2026-07-09, delisted 2026-07-19"
+last_verified = 2026-08-01

--- a/ringer.py
+++ b/ringer.py
@@ -2109,6 +2109,7 @@ class WorkerResult:
     tokens: int | None
     error: str | None = None
     reported_model: str | None = None
+    engine_down_reason: str | None = None
 
 
 @dataclass(frozen=True)
@@ -2321,14 +2322,16 @@ class StateWriter:
                 tasks.append(task_state)
             pass_count = sum(1 for item in tasks if item["status"] == "pass")
             fail_count = sum(1 for item in tasks if item["status"] == "fail")
+            engine_down_count = sum(1 for item in tasks if item["status"] == "engine-down")
             running_count = sum(
                 1 for item in tasks if item["status"] in {"running", "verifying", "retrying"}
             )
             totals = {
                 "running": running_count,
-                "done": pass_count + fail_count,
+                "done": pass_count + fail_count + engine_down_count,
                 "pass": pass_count,
                 "fail": fail_count,
+                "engine_down": engine_down_count,
                 "tokens": sum(int(item["tokens"] or 0) for item in tasks),
             }
             return {
@@ -2360,6 +2363,9 @@ class StateWriter:
             return {
                 "pass": sum(1 for runtime in self.runtimes if runtime.status == "pass"),
                 "fail": sum(1 for runtime in self.runtimes if runtime.status == "fail"),
+                "engine_down": sum(
+                    1 for runtime in self.runtimes if runtime.status == "engine-down"
+                ),
                 "tokens": sum(int(runtime.tokens or 0) for runtime in self.runtimes),
             }
 
@@ -3441,6 +3447,7 @@ STATUS_COLORS = {
     "fail": "var(--fail)",
     "error": "var(--fail)",
     "timeout": "var(--fail)",
+    "engine-down": "var(--waiting)",
     "running": "var(--running)",
     "retrying": "var(--running)",
     "verifying": "var(--running)",
@@ -5895,6 +5902,13 @@ def model_log_row_is_reserved_fixture(row: dict[str, Any]) -> bool:
     return model_log_text(row.get("model")) in RESERVED_FIXTURE_MODELS
 
 
+def model_log_row_is_engine_down(row: dict[str, Any]) -> bool:
+    # A terminal engine-level billing/auth failure isn't the model failing
+    # the task — it never got a fair attempt — so it must not drag down
+    # pass_rate/first_try_pass_rate the way a genuine FAIL would.
+    return model_log_text(row.get("verdict")).upper() == "ENGINE_DOWN"
+
+
 def model_reasoning_effort_keys(rows: list[dict[str, Any]]) -> set[tuple[str, str, bool]]:
     keys: set[tuple[str, str, bool]] = set()
     for row in rows:
@@ -6029,6 +6043,8 @@ def aggregate_model_log_rows(
         first = ordered[0]
         final = ordered[-1]
         if model_log_row_is_reserved_fixture(final):
+            continue
+        if model_log_row_is_engine_down(final):
             continue
         group_engine = model_log_row_engine(final)
         group_model = model_log_row_model(final)
@@ -7459,6 +7475,8 @@ def aggregate_model_scoreboard_rows(
         final = ordered[-1]
         if model_log_row_is_reserved_fixture(final):
             continue
+        if model_log_row_is_engine_down(final):
+            continue
         group_engine = model_log_row_engine(final)
         group_model = model_log_row_model(final)
         group_task_type = model_log_row_task_type(final)
@@ -8714,6 +8732,7 @@ class RingerRunner:
         self.verifier = Verifier()
         self.semaphore = asyncio.Semaphore(manifest.max_parallel)
         self.active_processes: dict[int, asyncio.subprocess.Process] = {}
+        self.engine_down: dict[str, str] = {}
 
     async def run(self) -> int:
         self.manifest.workdir.mkdir(parents=True, exist_ok=True)
@@ -8764,10 +8783,54 @@ class RingerRunner:
             if proc.returncode is None:
                 kill_process_group(proc)
 
+    def _engine_down_reason(self, engine_name: str) -> str | None:
+        with self.lock:
+            return self.engine_down.get(engine_name)
+
+    def _mark_engine_down(self, engine_name: str, reason: str) -> str:
+        with self.lock:
+            existing = self.engine_down.get(engine_name)
+            if existing is not None:
+                return existing
+            self.engine_down[engine_name] = reason
+            return reason
+
+    async def _finalize_engine_down(
+        self,
+        runtime: TaskRuntime,
+        reason: str,
+        *,
+        worker: WorkerResult | None,
+        attempt: int,
+        duration_ms: int,
+    ) -> None:
+        with self.lock:
+            runtime.attempts = attempt
+            runtime.status = "engine-down"
+            runtime.final_verdict = "ENGINE_DOWN"
+            runtime.ended_at_monotonic = time.monotonic()
+        effective_worker = worker or WorkerResult(returncode=None, timed_out=False, tokens=None)
+        verify = VerifyResult(
+            ok=False,
+            check_returncode=None,
+            check_timed_out=False,
+            raw_output_excerpt=(
+                f"[ringer.py] engine '{runtime.task.engine}' unavailable ({reason}); "
+                "task not attempted/verified — skipped, not a model failure."
+            ),
+        )
+        self._log_attempt(
+            runtime, runtime.task.spec, attempt > 1, effective_worker, verify, "ENGINE_DOWN", duration_ms
+        )
+
     async def _run_task(self, runtime: TaskRuntime) -> None:
         async with self.semaphore:
             with self.lock:
                 runtime.started_at_monotonic = time.monotonic()
+            down_reason = self._engine_down_reason(runtime.task.engine)
+            if down_reason is not None:
+                await self._finalize_engine_down(runtime, down_reason, worker=None, attempt=1, duration_ms=0)
+                return
             prepared, prepare_error = await self._prepare_taskdir(runtime)
             if not prepared:
                 await self._record_prepare_error(runtime, prepare_error or "taskdir preparation failed")
@@ -8775,6 +8838,12 @@ class RingerRunner:
             current_spec = runtime.task.spec
             max_attempts = runtime.task.max_attempts
             for attempt in range(1, max_attempts + 1):
+                down_reason = self._engine_down_reason(runtime.task.engine)
+                if down_reason is not None:
+                    await self._finalize_engine_down(
+                        runtime, down_reason, worker=None, attempt=attempt, duration_ms=0
+                    )
+                    return
                 retrying = attempt > 1
                 with self.lock:
                     runtime.attempts = attempt
@@ -8786,6 +8855,13 @@ class RingerRunner:
                     runtime.status = "verifying"
                     if worker.tokens is not None:
                         runtime.tokens = (runtime.tokens or 0) + worker.tokens
+                if worker.engine_down_reason is not None:
+                    reason = self._mark_engine_down(runtime.task.engine, worker.engine_down_reason)
+                    duration_ms = int((time.monotonic() - attempt_started) * 1000)
+                    await self._finalize_engine_down(
+                        runtime, reason, worker=worker, attempt=attempt, duration_ms=duration_ms
+                    )
+                    return
                 verify = await self.verifier.verify(runtime.task, runtime.taskdir)
                 verdict = verdict_for(worker, verify)
                 with self.lock:
@@ -9128,14 +9204,30 @@ class RingerRunner:
         output_tail = capture.text()
         tokens = parse_token_count(output_tail, engine.token_regex)
         reported_model = parse_reported_model(output_tail, engine.model_report_regex)
+        engine_down_reason = (
+            None
+            if timed_out or proc.returncode == 0
+            # Scan only the last stretch of output: a terminal engine error is
+            # the last thing the process prints before it dies. Scanning the
+            # full ~1MB capture would also catch a coding task's own mid-run
+            # narration about payment/auth handling it's implementing.
+            else detect_engine_down_reason(output_tail[-2000:])
+        )
         if timed_out:
             append_text(log_path, f"\n[ringer.py] worker timed out after {runtime.task.timeout_s}s\n")
         append_text(log_path, f"[ringer.py] attempt {attempt} exited rc={proc.returncode}\n")
+        if engine_down_reason is not None:
+            append_text(
+                log_path,
+                f"[ringer.py] engine-down detected ({engine_down_reason}); "
+                f"marking engine '{runtime.task.engine}' down for this run\n",
+            )
         return WorkerResult(
             returncode=proc.returncode,
             timed_out=timed_out,
             tokens=tokens,
             reported_model=reported_model,
+            engine_down_reason=engine_down_reason,
         )
 
     async def _tee_stream(
@@ -9361,6 +9453,49 @@ def verdict_for(worker: WorkerResult, verify: VerifyResult) -> str:
     if verify.ok:
         return "PASS"
     return "FAIL"
+
+
+# Terminal engine-level failures (billing exhausted, auth expired) are not the
+# model's fault and can't be fixed by retrying the same task — unlike a normal
+# FAIL, they mean every other queued task on this engine will fail the same
+# way. Detected from the worker's own stdout/stderr; each tag is a rough
+# classification for the raw log, not something callers branch on.
+ENGINE_DOWN_PATTERNS: tuple[tuple[str, "re.Pattern[str]"], ...] = (
+    ("http_402", re.compile(r'"status"\s*:\s*402\b')),
+    ("http_402", re.compile(r'"code"\s*:\s*402\b')),
+    ("payment_required", re.compile(r"payment required", re.IGNORECASE)),
+    ("balance_exhausted", re.compile(r"balance exhausted", re.IGNORECASE)),
+    (
+        "insufficient_balance",
+        re.compile(r"insufficient (?:balance|credits?|quota|funds)", re.IGNORECASE),
+    ),
+    (
+        "auth_expired",
+        re.compile(
+            r"(?:auth(?:entication|orization)?|token|api[\s_-]?key|session)"
+            r"[^\n]{0,20}\bexpired\b",
+            re.IGNORECASE,
+        ),
+    ),
+    (
+        "auth_expired",
+        re.compile(
+            r"\bexpired\b[^\n]{0,20}"
+            r"(?:auth(?:entication|orization)?|token|api[\s_-]?key|session)",
+            re.IGNORECASE,
+        ),
+    ),
+    ("invalid_api_key", re.compile(r"invalid[\s_-]*api[\s_-]?key", re.IGNORECASE)),
+    ("unauthorized", re.compile(r"\b401\b[^\n]{0,40}unauthorized", re.IGNORECASE)),
+    ("unauthorized", re.compile(r"unauthorized[^\n]{0,40}\b401\b", re.IGNORECASE)),
+)
+
+
+def detect_engine_down_reason(output: str) -> str | None:
+    for reason, pattern in ENGINE_DOWN_PATTERNS:
+        if pattern.search(output):
+            return reason
+    return None
 
 
 def build_run_id(run_name: str) -> str:

--- a/templates/fix-swarm/checks/fix-swarm.py
+++ b/templates/fix-swarm/checks/fix-swarm.py
@@ -131,9 +131,27 @@ def main() -> int:
                 )
             )
 
-    add_result = run_git(["add", "-A"])
-    if add_result.returncode != 0:
-        failures.append(fail("git_add_failed", output_tail(add_result.stdout)))
+    if "*" in owned_files:
+        add_result = run_git(["add", "-A"])
+        if add_result.returncode != 0:
+            failures.append(fail("git_add_failed", output_tail(add_result.stdout)))
+    else:
+        # Stage tracked-file modifications (so out-of-lane edits to existing
+        # files still get caught by the owned-files check below) plus any
+        # new files under the owned paths. Deliberately does NOT `add -A`:
+        # worker/check subprocesses can leave untracked debris in the
+        # worktree (e.g. a sandboxed pytest run falling back to cwd for its
+        # basetemp) that has nothing to do with the agent's actual diff.
+        add_u_result = run_git(["add", "-u"])
+        if add_u_result.returncode != 0:
+            failures.append(fail("git_add_failed", output_tail(add_u_result.stdout)))
+        # Only pass owned paths that actually exist: `git add -- <path>` hard-fails
+        # ("did not match any files") for a declared-but-untouched owned path.
+        existing_owned = [item for item in owned_files if Path(item).exists()]
+        if existing_owned:
+            add_owned_result = run_git(["add", "--"] + existing_owned)
+            if add_owned_result.returncode != 0:
+                failures.append(fail("git_add_failed", output_tail(add_owned_result.stdout)))
 
     if not args.summary.is_absolute() and args.summary.exists():
         run_git(["reset", "--quiet", "--", str(args.summary)])

--- a/tests/test_engine_down.py
+++ b/tests/test_engine_down.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python3
+"""Terminal engine-level failures (billing exhausted, auth expired) must not
+burn task attempts or count against a model's pass rate.
+
+Regression for the 2026-07-12 incident: a Grok Build 402 "usage balance
+exhausted" error caused every task on that engine to burn both attempts
+(~5s each) before failing, and all of it landed in the scoreboard as
+ordinary model failures.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from ringer import (  # noqa: E402
+    aggregate_model_log_rows,
+    aggregate_model_scoreboard_rows,
+    detect_engine_down_reason,
+)
+
+
+def toml_string(value: object) -> str:
+    return json.dumps(str(value))
+
+
+class DetectEngineDownReasonTests(unittest.TestCase):
+    def test_matches_the_incident_message(self) -> None:
+        self.assertIsNotNone(
+            detect_engine_down_reason("402 Payment Required: usage balance exhausted")
+        )
+
+    def test_matches_json_style_status_codes(self) -> None:
+        self.assertIsNotNone(detect_engine_down_reason('{"error": {"status": 402}}'))
+        self.assertIsNotNone(detect_engine_down_reason('{"error": {"code": 402}}'))
+
+    def test_matches_auth_expired_variants(self) -> None:
+        self.assertIsNotNone(detect_engine_down_reason("API key has expired"))
+        self.assertIsNotNone(detect_engine_down_reason("your session expired, please log in"))
+        self.assertIsNotNone(detect_engine_down_reason("token expired at 2026-07-12"))
+        self.assertIsNotNone(detect_engine_down_reason("invalid_api_key: invalid API key"))
+
+    def test_matches_insufficient_credit_phrasing(self) -> None:
+        self.assertIsNotNone(detect_engine_down_reason("insufficient credits remaining"))
+        self.assertIsNotNone(detect_engine_down_reason("Insufficient quota for this request"))
+
+    def test_ignores_ordinary_worker_output(self) -> None:
+        self.assertIsNone(detect_engine_down_reason("mock-worker: wrote 1 file(s): hello.txt"))
+        self.assertIsNone(
+            detect_engine_down_reason("diff shows 402 lines changed across the repo")
+        )
+        self.assertIsNone(detect_engine_down_reason(""))
+
+
+class AggregationExcludesEngineDownTests(unittest.TestCase):
+    """The scoreboard and model log must not treat ENGINE_DOWN like FAIL."""
+
+    def rows(self) -> list[dict[str, object]]:
+        return [
+            {
+                "run_id": "run1",
+                "task_key": "a",
+                "worker_engine": "grok-build",
+                "model": "grok-build",
+                "task_type": "code-feature",
+                "verdict": "PASS",
+                "duration_ms": 100,
+                "worker_tokens": 10,
+                "retry": False,
+                "logged_at": "2026-07-12T10:00:00+00:00",
+            },
+            {
+                "run_id": "run1",
+                "task_key": "b",
+                "worker_engine": "grok-build",
+                "model": "grok-build",
+                "task_type": "code-feature",
+                "verdict": "ENGINE_DOWN",
+                "duration_ms": 50,
+                "worker_tokens": 0,
+                "retry": False,
+                "logged_at": "2026-07-12T10:00:05+00:00",
+            },
+            {
+                "run_id": "run1",
+                "task_key": "c",
+                "worker_engine": "grok-build",
+                "model": "grok-build",
+                "task_type": "code-feature",
+                "verdict": "ENGINE_DOWN",
+                "duration_ms": 0,
+                "worker_tokens": None,
+                "retry": False,
+                "logged_at": "2026-07-12T10:00:06+00:00",
+            },
+        ]
+
+    def test_model_log_aggregation_excludes_engine_down_tasks(self) -> None:
+        groups = aggregate_model_log_rows(self.rows())
+        self.assertEqual(1, len(groups))
+        group = groups[0]
+        # Only the genuine PASS counts; the two ENGINE_DOWN tasks are excluded
+        # entirely rather than counted as failures.
+        self.assertEqual(1, group["tasks"])
+        self.assertEqual(1, group["passed"])
+        self.assertEqual(0, group["failed"])
+        self.assertEqual(1.0, group["pass_rate"])
+        self.assertEqual(1.0, group["first_try_pass_rate"])
+
+    def test_model_scoreboard_aggregation_excludes_engine_down_tasks(self) -> None:
+        entries = aggregate_model_scoreboard_rows(self.rows())
+        self.assertEqual(1, len(entries))
+        entry = entries[0]
+        self.assertEqual(1, entry["tasks"])
+        self.assertEqual(1, entry["passed"])
+        self.assertEqual(0, entry["failed"])
+        self.assertEqual(1.0, entry["pass_rate"])
+
+
+class EngineDownFastFailEndToEndTests(unittest.TestCase):
+    def test_engine_down_short_circuits_remaining_tasks_without_burning_attempts(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_root:
+            root = Path(temp_root)
+            home = root / "home"
+            ringer_home = root / "ringer-home"
+            state_dir = root / "state"
+            workdir = root / "work"
+            config_path = root / "config.toml"
+            manifest_path = root / "manifest.json"
+
+            home.mkdir()
+            ringer_home.mkdir()
+
+            config_path.write_text(
+                "\n".join(
+                    [
+                        f"state_dir = {toml_string(state_dir)}",
+                        "",
+                        "[eval]",
+                        'backend = "jsonl"',
+                        f"jsonl_path = {toml_string(root / 'runs.jsonl')}",
+                        "",
+                        "[artifact]",
+                        "enabled = false",
+                        "",
+                        "[engines.mock]",
+                        f"bin = {toml_string(sys.executable)}",
+                        "args_template = [",
+                        f"  {toml_string(ROOT / 'engines' / 'mock_worker.py')},",
+                        '  "{spec}",',
+                        "]",
+                        "sandbox_args = []",
+                        "full_access_args = []",
+                        "",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            # max_parallel=1 makes the ordering deterministic: task-one burns
+            # its one real (and only) attempt discovering the engine is down;
+            # task-two and task-three must never even spawn a worker.
+            manifest_path.write_text(
+                json.dumps(
+                    {
+                        "run_name": "engine-down-test",
+                        "workdir": str(workdir),
+                        "max_parallel": 1,
+                        "worktrees": False,
+                        "tasks": [
+                            {
+                                "key": "task-one",
+                                "engine": "mock",
+                                "spec": "You are the deterministic mock worker.\nMOCK_ENGINE_DOWN",
+                                "check": "test -f impossible.txt || { echo FAIL: never runs; exit 1; }",
+                            },
+                            {
+                                "key": "task-two",
+                                "engine": "mock",
+                                "spec": (
+                                    "You are the deterministic mock worker. Write only the file "
+                                    "described in this MOCK_FILE block.\n"
+                                    "MOCK_FILE: hello.txt\n"
+                                    "hello from mock\n"
+                                    "MOCK_END"
+                                ),
+                                "check": "grep -q hello hello.txt || { echo FAIL: missing; exit 1; }",
+                                "expect_files": ["hello.txt"],
+                            },
+                            {
+                                "key": "task-three",
+                                "engine": "mock",
+                                "spec": (
+                                    "You are the deterministic mock worker. Write only the file "
+                                    "described in this MOCK_FILE block.\n"
+                                    "MOCK_FILE: hello.txt\n"
+                                    "hello from mock\n"
+                                    "MOCK_END"
+                                ),
+                                "check": "grep -q hello hello.txt || { echo FAIL: missing; exit 1; }",
+                                "expect_files": ["hello.txt"],
+                            },
+                        ],
+                    },
+                    indent=2,
+                ),
+                encoding="utf-8",
+            )
+
+            env = os.environ.copy()
+            env["HOME"] = str(home)
+            env["RINGER_HOME"] = str(ringer_home)
+            env["XDG_CONFIG_HOME"] = str(root / "xdg-config")
+
+            proc = subprocess.run(
+                [
+                    sys.executable,
+                    "ringer.py",
+                    "run",
+                    str(manifest_path),
+                    "--config",
+                    str(config_path),
+                    "--no-dashboard",
+                    "--identity",
+                    "engine-down-test",
+                ],
+                cwd=ROOT,
+                env=env,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=False,
+                timeout=30,
+            )
+
+            combined_output = proc.stdout + proc.stderr
+            self.assertEqual(1, proc.returncode, combined_output)
+
+            # All three tasks end in the distinct engine-down status, none of
+            # them marked "fail" (which would count against the model).
+            for key in ("task-one", "task-two", "task-three"):
+                self.assertRegex(
+                    combined_output,
+                    re.compile(
+                        rf"^{re.escape(key)}\s+engine-down\s+ENGINE_DOWN\s+1\s+",
+                        re.MULTILINE,
+                    ),
+                    combined_output,
+                )
+
+            # task-one actually ran the mock worker and hit the 402.
+            task_one_log = workdir / "task-one" / "worker.log"
+            self.assertTrue(task_one_log.exists(), combined_output)
+            self.assertIn("402 Payment Required", task_one_log.read_text(encoding="utf-8"))
+            attempt_starts = re.findall(
+                r"^\[ringer\.py\] attempt (\d) started \d{4}-",
+                task_one_log.read_text(encoding="utf-8"),
+                flags=re.MULTILINE,
+            )
+            self.assertEqual(["1"], attempt_starts, "task-one must not retry a dead engine")
+
+            # task-two and task-three must never spawn a worker at all: no
+            # taskdir, no log, no wasted attempt.
+            self.assertFalse((workdir / "task-two").exists(), combined_output)
+            self.assertFalse((workdir / "task-three").exists(), combined_output)
+
+            # The model log must carry ENGINE_DOWN verdicts, not FAIL, so the
+            # scoreboard doesn't count this as the model failing three tasks.
+            log_rows = [
+                json.loads(line)
+                for line in (root / "runs.jsonl").read_text(encoding="utf-8").splitlines()
+                if line.strip()
+            ]
+            self.assertEqual(3, len(log_rows))
+            for row in log_rows:
+                self.assertEqual("ENGINE_DOWN", row["verdict"])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary
- **Model identity registry**: register all model slugs the scoreboard flagged unregistered — 16 total, including `grok-4.5` (the actual manifest slug grok-engine tasks log, distinct from the existing `grok-build` key), 13 OpenCode/OpenRouter slugs cross-checked against each lab's own page or OpenRouter catalog history, and 2 slugs that turned out to be legitimately delisted (not typos) — `poolside/laguna-m.1:free` (delisted 2026-08-01) and `nousresearch/hermes-3-llama-3.1-405b:free` (free tier delisted 2026-07-19), traced via `openrouter-catalog.changes.jsonl` added/removed events.
- **Engine-down fast-fail**: classify terminal billing/auth worker errors (402, expired token, insufficient credits) so a billing outage fails remaining queued tasks on that engine immediately instead of burning both retry attempts per task, and excludes those attempts from scoreboard pass-rate aggregation.
- **fix-swarm owned-files fix**: `git add -A` was sweeping sandbox/tempfile debris into the owned-files gate and failing checks that had actually passed verify; switched to `git add -u` + explicit owned paths.
- **opencode-sandboxed XDG_DATA_HOME isolation**: each worker now gets a private session-store directory instead of sharing one growing SQLite DB, fixing "database is locked" failures under concurrency.

## Test plan
- [x] `pytest tests/test_identity_evidence.py tests/test_taxonomy.py tests/test_signal_contract.py` — 18 passed
- [x] `./ringer.py models --notes-file ~/.ringer/MODEL-NOTES.md` — unregistered-slug warning cleared (was 16, now 0)
- [x] fix-swarm and engine-down changes each carry their own dedicated test coverage (`tests/test_engine_down.py`, existing fix-swarm suite)