### PR TITLE
Refresh grok docs: CLI now serves grok-4.5, not grok-build/grok-composer-2.5-fast

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ grok login
 # 3) In ~/.config/ringer/config.toml, uncomment [engines.grok]
 ```
 
-Route with per-task `"engine": "grok"` and pick the model with `"model": "grok-build"` or `"model": "grok-composer-2.5-fast"` (the shipped default — the speed pick). Grok brings its own OS sandbox on macOS (profile `workspace`: read everywhere, writes confined to the task dir, temp, and `~/.grok`), and its JSON output exposes no token counts — plan-billed workers report cost as included in plan.
+Route with per-task `"engine": "grok"` and pick the model with `"model": "grok-4.5"` (run `grok models` to see what your installed CLI serves — older v0.2.x also exposed `grok-build` and `grok-composer-2.5-fast`, which current CLIs reject as "unknown model id"). Grok brings its own OS sandbox on macOS (profile `workspace`: read everywhere, writes confined to the task dir, temp, and `~/.grok`), and its JSON output exposes no token counts — plan-billed workers report cost as included in plan.
 
 `args_template` is an argv array, not a shell string. Ringer replaces `{taskdir}`, `{spec}`, and `{model}` inside each argv element. `{access_args}`, `{sandbox_args}`, `{full_access_args}`, `{model_args}` (becomes `-m <resolved model>` when the task or engine names one), and `{engine_args}` (the task's per-task `engine_args`) expand to multiple argv elements only when they appear as their own array item.
 

--- a/config.sample.toml
+++ b/config.sample.toml
@@ -96,15 +96,18 @@ model_report_regex = "(?m)^model:[ \\t]*([^ \\t\\r\\n]+)[ \\t]*\\r?$"
 # SuperGrok or X Premium Plus plan. Headless mode (-p) runs a full agentic
 # loop with tools and exits. Grok brings its own OS sandbox (Seatbelt on
 # macOS): profile "workspace" = read everywhere, write CWD + temp + ~/.grok,
-# network allowed. Models: grok-build, grok-composer-2.5-fast (route with the
-# per-task "model" field). Verified against Grok Build v0.2.81 (2026-07-06).
-# Note: --no-auto-update is accepted but absent from --help in v0.2.81 (grok
+# network allowed. Model: grok-4.5 (route with the per-task "model" field).
+# Verified against Grok Build v0.2.111 (2026-08-03). NOTE ON MODEL NAMES:
+# older v0.2.x exposed grok-build and grok-composer-2.5-fast; current CLIs
+# reject those with "unknown model id" — run `grok models` to see what your
+# installed CLI actually serves (v0.2.111 lists only grok-4.5).
+# Note: --no-auto-update is accepted but absent from --help (grok
 # rejects unknown flags, so this is a hidden flag, not a typo) — it stops the
 # CLI self-updating mid-swarm.
 # Uncomment to enable.
 # [engines.grok]
 # bin = "grok"
-# model_default = "grok-composer-2.5-fast"
+# model_default = "grok-4.5"
 # args_template = [
 #   "--cwd",
 #   "{taskdir}",
@@ -121,7 +124,7 @@ model_report_regex = "(?m)^model:[ \\t]*([^ \\t\\r\\n]+)[ \\t]*\\r?$"
 # ]
 # sandbox_args = ["--sandbox", "workspace"]
 # full_access_args = ["--sandbox", "off", "--permission-mode", "bypassPermissions"]
-# Grok's JSON output carries no usage/token fields (verified v0.2.81) — plan
+# Grok's JSON output carries no usage/token fields (verified v0.2.111) — plan
 # CLIs report cost as "included in plan"; regex is a harmless no-match. Its JSON
 # also does not self-report a model, so no model_report_regex is configured.
 # token_regex = "\"total_tokens\"\\s*:\\s*([0-9]+)"

--- a/registry/model-identity.toml
+++ b/registry/model-identity.toml
@@ -43,24 +43,36 @@ last_verified = 2026-07-10
 [engines.grok]
 harness = "Grok Build CLI"
 access = "OAuth plan"
-default_model_key = "grok-build"
+default_model_key = "grok-4.5"
 
-[engines.grok.models."grok-build"]
-# "Grok Build" is the HARNESS (the CLI product), never a model name. The CLI
-# serves exactly two models: Grok 4.5 (xAI) and Composer 2.5 (Cursor). The
-# 'grok-build' engine default resolves to Grok 4.5. An earlier entry here
-# wrongly recorded "Grok Build 0.1" as a model — do not reintroduce it.
+[engines.grok.models."grok-4.5"]
+# The live model id the Grok Build CLI serves. As of CLI v0.2.111 `grok models`
+# lists grok-4.5 as the only (and default) model; route with per-task
+# "model": "grok-4.5". "Grok Build" is the HARNESS (the CLI product), never a
+# model name — an earlier entry wrongly recorded "Grok Build 0.1" as a model; do
+# not reintroduce it.
 display = "Grok 4.5"
 lab = "xAI"
-confidence = "verified"     # operator-confirmed (Jon, 2026-07-10): Grok Build CLI serves Grok 4.5 + Composer 2.5
+confidence = "verified"     # `grok models` on CLI v0.2.111 (2026-08-03) lists grok-4.5; operator-confirmed the CLI serves Grok 4.5
+source = "https://docs.x.ai/developers/release-notes"
+last_verified = 2026-08-03
+noncanonical_slugs = ["opencode:openrouter/x-ai/grok-4.5"]
+
+# Retired CLI slugs, kept only so historical run rows still resolve to a display.
+# Older Grok Build v0.2.x accepted these as `-m` values; current CLIs reject
+# them with "unknown model id" (grok-composer-2.5-fast was Cursor's Composer 2.5,
+# no longer offered by the CLI on our plan). Do not route new work here — use grok-4.5.
+[engines.grok.models."grok-build"]
+display = "Grok 4.5"
+lab = "xAI"
+confidence = "verified"     # operator-confirmed (Jon, 2026-07-10): Grok Build CLI served Grok 4.5 + Composer 2.5
 source = "https://docs.x.ai/developers/release-notes"
 last_verified = 2026-07-10
-noncanonical_slugs = ["opencode:openrouter/x-ai/grok-4.5"]
 
 [engines.grok.models."grok-composer-2.5-fast"]
 display = "Composer 2.5 Fast"
 lab = "Cursor (Anysphere)"
-confidence = "verified"     # Cursor (Anysphere) model, served through xAI's Grok Build CLI in our setup
+confidence = "verified"     # Cursor (Anysphere) model, served through xAI's Grok Build CLI in our earlier (v0.2.81) setup
 source = "https://cursor.com/blog/composer-2-5"
 last_verified = 2026-07-10
 


### PR DESCRIPTION
## What

The Grok Build CLI collapsed its model lineup. As of **v0.2.111** (`grok models` on an OAuth plan) the CLI serves a single model id, `grok-4.5`. The old slugs `grok-build` and `grok-composer-2.5-fast` now return `Invalid params: "unknown model id"`.

Because `config.sample.toml` ships `model_default = "grok-composer-2.5-fast"` and the README's plan-lane example routes to `grok-build` / `grok-composer-2.5-fast`, anyone whose Grok CLI has auto-updated past ~v0.2.81 hits an "unknown model id" error the moment they enable the grok lane — the sample default is dead on arrival.

## Changes (docs, sample-config, and registry — no engine code)

- **`config.sample.toml`**: `model_default` → `grok-4.5`; comments now state the CLI serves `grok-4.5`, flag that the old slugs return "unknown model id", and point readers at `grok models` to see what their installed CLI actually offers. Version stamps bumped to v0.2.111 (`--no-auto-update` and the no-token-fields note re-verified on v0.2.111).
- **`README.md`**: plan-lane routing example → `"model": "grok-4.5"`, with the same `grok models` pointer and a note that older v0.2.x also exposed the retired slugs.
- **`registry/model-identity.toml`**: adds an `[engines.grok.models."grok-4.5"]` identity entry and makes it the grok engine default, so runs on the current CLI stop showing as `unregistered` in the scoreboard. The retired `grok-build` / `grok-composer-2.5-fast` entries stay for historical row identity; the noncanonical opencode→grok misroute mapping moves onto `grok-4.5`. All identity/taxonomy tests pass (29).

## How verified

- `grok --version` → `grok 0.2.111`; `grok models` lists only `grok-4.5` (default).
- Ran a one-task Ringer probe through `engine: "grok"`, `model: "grok-4.5"`: worker authored working code, the executed check ran it green (exit 0). First-attempt PASS. The same probe with `model: "grok-composer-2.5-fast"` failed with `unknown model id`.

## Not included

`registry/model-capabilities/grok-4.5.toml` (the detailed capability/evidence file) is not added — those files carry sourced auth/streaming/rate-limit claims that need a real research pass, and I didn't want to fabricate them. The existing `grok-build.toml` / `grok-composer-2.5-fast.toml` capability files are left as-is. Happy to add a properly-sourced `grok-4.5.toml` in a follow-up.
