### PR TITLE
registry: verified identities for Ollama Cloud model slugs

### DIFF
--- a/registry/model-identity.toml
+++ b/registry/model-identity.toml
@@ -98,3 +98,24 @@ lab = "Meta"
 confidence = "verified"
 source = "manifest model field; OpenRouter slug meta-llama/llama-3.3-70b-instruct:free"
 last_verified = 2026-07-10
+
+[engines.opencode.models."ollama-cloud/kimi-k2.7-code"]
+display = "Kimi K2.7 Code (Ollama Cloud)"
+lab = "Moonshot AI"
+confidence = "verified"
+source = "Ollama Cloud slug kimi-k2.7-code; same Moonshot AI model as OpenRouter moonshotai/kimi-k2.7-code (moonshot.ai)"
+last_verified = 2026-07-12
+
+[engines.opencode.models."ollama-cloud/qwen3-coder:480b"]
+display = "Qwen3 Coder 480B (Ollama Cloud)"
+lab = "Alibaba (Qwen)"
+confidence = "verified"
+source = "Ollama Cloud slug qwen3-coder:480b = Qwen3-Coder-480B-A35B (github.com/QwenLM/Qwen3-Coder)"
+last_verified = 2026-07-12
+
+[engines.opencode.models."ollama/qwen3-coder:480b"]
+display = "Qwen3 Coder 480B (Ollama Cloud)"
+lab = "Alibaba (Qwen)"
+confidence = "verified"
+source = "Retired slug from a misconfigured provider id (401 run, 2026-07-12); same model as ollama-cloud/qwen3-coder:480b"
+last_verified = 2026-07-12


### PR DESCRIPTION
## What changed

Three `opencode` model-identity entries in `registry/model-identity.toml`, recorded during the 2026-07-12 lane-proof runs:

- `ollama-cloud/kimi-k2.7-code` → Kimi K2.7 Code (Moonshot AI)
- `ollama-cloud/qwen3-coder:480b` → Qwen3 Coder 480B (Alibaba/Qwen)
- `ollama/qwen3-coder:480b` → retired slug from a misconfigured provider id (the 401 run), mapped to the same Qwen3 Coder 480B so historical scoreboard rows attribute correctly

## Why

Without these entries the scoreboard shows raw slugs (or splits one model's evidence across two identities via the retired slug). All three are `confidence=verified` with sources, per the registry's evidence rule.

## Reviewer notes

- Draft on purpose: the entries were authored in a July 12 session and sat uncommitted; worth a maintainer's glance at the `last_verified` dates before merging.
- Independent of #93 (MODEL-NOTES evidence rows) — no overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)