### PR TITLE
Quote the interpreter path in the deliverables check command

### DIFF
--- a/tests/test_deliverables.py
+++ b/tests/test_deliverables.py
@@ -5,6 +5,7 @@ import asyncio
 import json
 import os
 import posixpath
+import shlex
 import shutil
 import sys
 import tempfile
@@ -241,7 +242,7 @@ class DeliverableTests(unittest.TestCase):
         task = TaskSpec(
             key="task-one",
             spec="from pathlib import Path; Path('site-final.html').write_text('<h1>done</h1>\\n')",
-            check=f"{sys.executable!s} -c {json.dumps(check_code)}",
+            check=f"{shlex.quote(sys.executable)} -c {json.dumps(check_code)}",
             engine="mock",
             expect_files=("site-final.html",),
         )


### PR DESCRIPTION
`test_runner_harvests_when_task_passes` fails on any machine whose Python lives under a path containing a space.

The check command is built by interpolating `sys.executable` into a **shell string**:

```python
check=f"{sys.executable!s} -c {json.dumps(check_code)}"
```

That check is then run through the shell, which splits the unquoted path. On my machine `sys.executable` is

```
/Users/.../Library/Application Support/.../.venv/bin/python3
```

so the check dies before it starts:

```
/bin/sh: /Users/.../Library/Application: No such file or directory
```

## Why it reads as a harvesting bug and isn't

The worker is fine — it writes `site-final.html` exactly as the spec asks, and the taskdir contains it. But a check that cannot run can never exit 0, so the task fails, both attempts are spent, and `run()` returns 1 against the expected 0. The assertion that fires is `assertEqual(0, exit_code)`, which points at harvesting rather than at the check's own command line.

## Why CI is green

Hosted runners put Python at `/opt/hostedtoolcache/...` or `/usr/bin`, neither of which contains a space, so the suite passes there. It reproduces for contributors whose interpreter sits under `Application Support`, `Program Files`, or any venv beneath a directory with a space in the name.

## The fix

`shlex.quote(sys.executable)`, plus the import. Two insertions, one deletion.

I checked every other `sys.executable` in `tests/`: they are all argv lists handed to `subprocess` without a shell, so this is the only affected site — no other call needs quoting.

## Proof

| | result |
|---|---|
| `tests.test_deliverables` before | `Ran 8 tests` — `FAILED (failures=1)` |
| `tests.test_deliverables` after | `Ran 8 tests` — `OK` |
| full suite after | `Ran 253 tests` — `OK`, no failures |

Independent of #95 — both branches are cut from `upstream/main`, neither is stacked on the other.

A possible follow-up, deliberately not in this PR: a CI matrix entry that installs Python under a path with a space would keep this class from recurring.
