### PR TITLE
engines: Claude Code CLI worker lane (subscription-backed, no OS sandbox)

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ For CI and evals, `config.sample.toml` includes `[engines.mock]` so the enforcem
 
 ![Identical workers, each under its own light](docs/engines.png)
 
-Ringer ships with three worker lanes: **Codex CLI** is the built-in default, and `config.sample.toml` carries verified engine blocks for **Grok Build CLI** (works as-is once you `grok login`) and **OpenCode + OpenRouter** (one edit: point `bin` at the sandbox wrapper in your clone). Anything else with a headless CLI is a config block away:
+Ringer ships with four worker lanes: **Codex CLI** is the built-in default, and `config.sample.toml` carries verified engine blocks for **Grok Build CLI** (works as-is once you `grok login`), **Claude Code CLI** (a Claude Pro/Max subscription; one edit: point `bin` at `engines/claude-worker.sh` in your clone — note it has no OS sandbox, so the task dir is the only isolation) and **OpenCode + OpenRouter** (one edit: point `bin` at the sandbox wrapper in your clone). Anything else with a headless CLI is a config block away:
 
 ```toml
 [engines.mymodel]

--- a/config.sample.toml
+++ b/config.sample.toml
@@ -91,6 +91,44 @@ token_regex = "tokens\\s+used\\s*:?\\s*([0-9][0-9,]*)"
 # default reads the `model:` header; override it here only if that format changes.
 model_report_regex = "(?m)^model:[ \\t]*([^ \\t\\r\\n]+)[ \\t]*\\r?$"
 
+# Claude Code CLI (Anthropic) — a Claude Pro/Max subscription as a worker lane.
+# Install: npm install -g @anthropic-ai/claude-code (or the native installer),
+# then `claude` once to sign in. Headless mode (-p) runs a full agentic loop with
+# tools and exits, so it drives a swarm the same way codex exec does. Models are
+# the CLI's own aliases: sonnet, opus, haiku (route with the per-task "model"
+# field); plan CLIs report cost as "included in plan". Verified against Claude
+# Code v2.1.221 (2026-08-05) across ~50 verified tasks in one session.
+#
+# CONFINEMENT: unlike codex (--sandbox) and the opencode wrapper (Seatbelt),
+# Claude Code has no OS-level sandbox of its own, and -p requires
+# --dangerously-skip-permissions to run unattended. The ONLY isolation is the
+# per-task directory ringer assigns. Keep swarm workdirs OUTSIDE any repo you
+# care about and review artifacts before integrating; an operator who needs real
+# confinement should run the lane in a container or VM.
+#
+# The wrapper exists because Claude Code has no -C/--dir flag: it cds into the
+# task dir so the agent's cwd is the write target. Set bin to the ABSOLUTE path
+# of engines/claude-worker.sh in your clone (ringer does not resolve engine bins
+# relative to the repo). Uncomment to enable.
+# [engines.claude]
+# bin = "/absolute/path/to/ringer/engines/claude-worker.sh"
+# model_default = "sonnet"
+# args_template = [
+#   "{taskdir}",
+#   "-p",
+#   "{access_args}",
+#   "--model",
+#   "{model}",
+#   "{engine_args}",
+#   "{spec}",
+# ]
+# sandbox_args = ["--dangerously-skip-permissions"]
+# full_access_args = ["--dangerously-skip-permissions"]
+# Claude Code's default text output carries no usage/token line, so no
+# token_regex is configured (a plan lane bills as "included in plan"); the
+# scoreboard records the run with an empty token count rather than a wrong one.
+# It also does not self-report a model in text mode, so no model_report_regex.
+
 # Grok Build CLI (xAI). Install: curl -fsSL https://x.ai/cli/install.sh | bash
 # (or: npm install -g @xai-official/grok), then `grok login` — OAuth on a
 # SuperGrok or X Premium Plus plan. Headless mode (-p) runs a full agentic

--- a/engines/claude-worker.sh
+++ b/engines/claude-worker.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Ringer engine wrapper: run Claude Code headless (-p) as a worker, inside the task dir.
+#
+# Uses Anthropic's own Claude Code CLI on the user's Claude subscription — no OpenCode
+# and no separate OAuth. Claude Code has no -C/--dir flag, so we cd into the task dir
+# (its cwd becomes the write target), then exec claude with whatever args ringer passes.
+#
+# CONFINEMENT NOTE: --dangerously-skip-permissions gives Claude no OS-level sandbox
+# (unlike codex --sandbox or the opencode Seatbelt wrapper). The only isolation is the
+# per-task directory ringer assigns. KEEP SWARM workdirs OUTSIDE any repo you care about,
+# and review artifacts before integrating. macOS/Linux.
+set -euo pipefail
+TASKDIR="${1:?usage: claude-worker.sh <taskdir> <claude args...>}"; shift
+cd "$TASKDIR"
+exec claude "$@" < /dev/null

--- a/tests/test_claude_engine.py
+++ b/tests/test_claude_engine.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""engines/claude-worker.sh — the Claude Code worker lane wrapper.
+
+Claude Code has no -C/--dir flag, so the wrapper's whole job is to cd into the task directory
+(making the agent's cwd the write target) and hand every remaining argument to `claude` unchanged.
+These tests prove that with a stub `claude` on PATH, so they run in CI on a machine that has never
+installed Claude Code.
+"""
+from __future__ import annotations
+
+import json
+import os
+import stat
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+WRAPPER = ROOT / "engines" / "claude-worker.sh"
+
+STUB = """#!/bin/sh
+# Stub `claude`: record cwd, argv and whether stdin is at EOF, then exit 0.
+python3 - "$@" <<'PY'
+import json, os, sys
+stdin_eof = sys.stdin.read() == ""
+with open(os.environ["STUB_OUT"], "w") as fh:
+    json.dump({"cwd": os.getcwd(), "argv": sys.argv[1:], "stdin_eof": stdin_eof}, fh)
+PY
+"""
+
+
+def _write_stub(bindir: Path, out_path: Path) -> None:
+    stub = bindir / "claude"
+    stub.write_text(STUB)
+    stub.chmod(stub.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+
+def _run(taskdir: Path, args, bindir: Path, out_path: Path):
+    env = dict(os.environ)
+    env["PATH"] = f"{bindir}{os.pathsep}{env.get('PATH', '')}"
+    env["STUB_OUT"] = str(out_path)
+    return subprocess.run(
+        [str(WRAPPER), str(taskdir), *args],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=60,
+    )
+
+
+class ClaudeWrapperTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        base = Path(self.tmp.name)
+        self.taskdir = base / "task"
+        self.taskdir.mkdir()
+        self.bindir = base / "bin"
+        self.bindir.mkdir()
+        self.out = base / "stub.json"
+        _write_stub(self.bindir, self.out)
+
+    def tearDown(self) -> None:
+        self.tmp.cleanup()
+
+    def test_wrapper_is_executable(self) -> None:
+        self.assertTrue(WRAPPER.exists(), f"{WRAPPER} is missing")
+        self.assertTrue(os.access(WRAPPER, os.X_OK), f"{WRAPPER} is not executable")
+
+    def test_runs_claude_inside_the_task_directory(self) -> None:
+        proc = _run(self.taskdir, ["-p", "--model", "sonnet", "do the thing"], self.bindir, self.out)
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        rec = json.loads(self.out.read_text())
+        self.assertEqual(
+            os.path.realpath(rec["cwd"]),
+            os.path.realpath(self.taskdir),
+            "the agent's cwd must be the task dir — that is what makes it the write target",
+        )
+
+    def test_passes_every_argument_through_unchanged(self) -> None:
+        args = ["-p", "--dangerously-skip-permissions", "--model", "opus", "spec with spaces"]
+        _run(self.taskdir, args, self.bindir, self.out)
+        self.assertEqual(json.loads(self.out.read_text())["argv"], args)
+
+    def test_closes_stdin(self) -> None:
+        # A worker that inherits an open stdin can hang a swarm waiting for input.
+        _run(self.taskdir, ["-p", "hello"], self.bindir, self.out)
+        self.assertTrue(json.loads(self.out.read_text())["stdin_eof"], "stdin must be closed")
+
+    def test_propagates_the_agent_exit_code(self) -> None:
+        failing = self.bindir / "claude"
+        failing.write_text("#!/bin/sh\nexit 3\n")
+        failing.chmod(failing.stat().st_mode | stat.S_IXUSR)
+        proc = _run(self.taskdir, ["-p", "x"], self.bindir, self.out)
+        self.assertEqual(proc.returncode, 3, "a failed worker must not look like a pass")
+
+    def test_missing_task_directory_fails_loudly(self) -> None:
+        proc = _run(Path(self.tmp.name) / "nope", ["-p", "x"], self.bindir, self.out)
+        self.assertNotEqual(proc.returncode, 0, "an unusable task dir must fail, not run in the wrong cwd")
+
+    def test_requires_a_task_directory_argument(self) -> None:
+        env = dict(os.environ)
+        env["PATH"] = f"{self.bindir}{os.pathsep}{env.get('PATH', '')}"
+        env["STUB_OUT"] = str(self.out)
+        proc = subprocess.run([str(WRAPPER)], capture_output=True, text=True, env=env, timeout=60)
+        self.assertNotEqual(proc.returncode, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds a fourth worker lane so a Claude Pro/Max subscription can drive a swarm, the way the Grok block already does for SuperGrok. One feature, four files.

## Why (an observed failure, not speculation)

I wanted a subscription-backed lane and tried the documented OpenCode route first. Its stored Anthropic OAuth credential had expired months earlier, and every run died on `Token refresh failed: 429` — the refresh endpoint rate-limits repeated attempts against a stale token, so it could not recover on its own. My other cheap lane was simultaneously sitting behind a hard spend cap.

Claude Code ships its own headless mode, so pointing ringer at that CLI directly sidesteps OpenCode's auth entirely. I then ran roughly **50 verified tasks** through this lane in one session — 27 parallel check implementations, a CLI runner, and a dozen parser modules, each gated by an executed check — with no lane-related failures.

## What's here

| file | |
|---|---|
| `engines/claude-worker.sh` | new — cds into the task dir, execs `claude` with the remaining args untouched |
| `config.sample.toml` | commented `[engines.claude]` block, matching the Grok block's shape |
| `README.md` | "three worker lanes" → four |
| `tests/test_claude_engine.py` | new — 7 tests |

The wrapper exists for exactly one reason: `claude` has no `-C`/`--dir` flag, so something has to make the task directory the agent's cwd.

## Honest scope — this lane has NO OS sandbox

Per the no-safety-theater rule, stated plainly rather than implied:

- `codex` has `--sandbox`; the opencode wrapper has Seatbelt. **Claude Code has neither**, and `-p` requires `--dangerously-skip-permissions` to run unattended.
- The **only** isolation is the per-task directory ringer assigns. Both the config comment and the README say so, and recommend keeping swarm workdirs outside any repo you care about. An operator who needs real confinement should run the lane in a container or VM.
- Consequently `sandbox_args` and `full_access_args` are identical. The flag is wired through `allow_full_access` rather than pretending it gates something it doesn't.

**Token capture is deliberately absent.** Claude Code's text output carries no usage line, so no `token_regex` is configured and the scoreboard records an empty token count rather than a wrong one — same posture as the Grok block, and it keeps the displayed data true. No `model_report_regex` either, for the same reason.

## Executed proof

`tests/test_claude_engine.py` proves the wrapper's contract using a stub `claude` on `PATH`, so **it runs in CI on a machine that has never installed Claude Code**:

- the agent's cwd is the task dir (what makes it the write target)
- every argument is passed through unchanged, including specs containing spaces
- stdin is closed (an inherited stdin can hang a swarm)
- the agent's exit code propagates — a failed worker must not look like a pass
- a missing task dir, or no task dir argument at all, fails loudly instead of running in the wrong place

```
python3 -m unittest discover -s tests -p test_claude_engine.py   # 7 tests, OK
RINGER_NO_SELF_UPDATE=1 python3 -m unittest discover -s tests    # 260 tests, OK (macOS)
```

Verified against Claude Code v2.1.221 (2026-08-05). Linux is unverified by me — I have only macOS here — so I'd rather CI's Linux job speak to it than assert it myself. The wrapper is POSIX `sh` with no macOS-specific calls.

## Not in this PR

While setting this up I also hit a real bug in the shipped `[engines.opencode]` block: it passes `--dangerously-skip-permissions`, which current OpenCode (1.2.20) rejects, so the lane prints its help and exits before calling a model. That's a separate fix and I'll send it as its own PR rather than bundle it here.