### PR TITLE
fix: Strip ANSI escapes before parsing token counts and reported models

### DIFF
--- a/ringer.py
+++ b/ringer.py
@@ -9430,6 +9430,10 @@ def parse_env_file(path: Path) -> dict[str, str]:
 
 
 def parse_token_count(text: str, token_regex: str | None = DEFAULT_TOKEN_REGEX) -> int | None:
+    # Engines colorize stdout when FORCE_COLOR is set (Claude Code, most CI),
+    # leaving escape bytes between the label and the number that no practical
+    # regex bridges — strip them once here so every regex sees plain text.
+    text = ANSI_RE.sub("", text)
     if token_regex:
         matches = list(re.finditer(token_regex, text, flags=re.IGNORECASE))
         for match in reversed(matches):
@@ -9454,6 +9458,9 @@ def parse_token_count(text: str, token_regex: str | None = DEFAULT_TOKEN_REGEX) 
 def parse_reported_model(text: str, model_report_regex: str | None) -> str | None:
     if not model_report_regex:
         return None
+    # Same reason as parse_token_count: a colorized "model:" header breaks
+    # the ^model: anchor unless the ANSI escapes are stripped first.
+    text = ANSI_RE.sub("", text)
     match = re.search(model_report_regex, text, flags=re.IGNORECASE)
     if match is None or match.lastindex is None:
         return None

--- a/tests/test_identity_evidence.py
+++ b/tests/test_identity_evidence.py
@@ -105,6 +105,14 @@ access = "OpenRouter API"
         output = "OpenAI Codex v0.144.0\n--------\nmodel: gpt-5.6-sol\nprovider: openai\n"
         self.assertEqual("gpt-5.6-sol", parse_reported_model(output, engine.model_report_regex))
 
+    def test_codex_report_regex_captures_ansi_colorized_header(self) -> None:
+        # Real bytes from codex exec run with FORCE_COLOR set (as Claude Code
+        # and most CI systems do): the header is bold-wrapped, so the ^model:
+        # anchor never matches without stripping ANSI first.
+        engine = load_engines(None)["codex"]
+        output = "OpenAI Codex v0.146.0\n--------\n\x1b[1mmodel:\x1b[0m gpt-5.6-sol\nprovider: openai\n"
+        self.assertEqual("gpt-5.6-sol", parse_reported_model(output, engine.model_report_regex))
+
     def test_reported_model_wins_and_resolved_model_is_fallback(self) -> None:
         rows = self.log_attempts(
             WorkerResult(0, False, 12, reported_model="gpt-5.7"),

--- a/tests/test_ringer.py
+++ b/tests/test_ringer.py
@@ -595,6 +595,19 @@ class RingerCliTests(unittest.TestCase):
         self.assertEqual(ringer.parse_token_count("tokens used: 1,234", r"tokens\s+used\s*:?\s*([0-9][0-9,]*)"), 1234)
         self.assertEqual(ringer.parse_token_count("tokens used\n5,678", r"tokens\s+used\s*:?\s*([0-9][0-9,]*)"), 5678)
 
+    def test_token_count_parser_sees_through_ansi_colorized_output(self) -> None:
+        # Real bytes from codex exec run with FORCE_COLOR set (as Claude Code
+        # and most CI systems do): the label is dim-wrapped and the number is
+        # on the following line, so the escape sequences sit between "used"
+        # and the digits and an ANSI-blind \s* cannot bridge them.
+        colorized = "\x1b[2mtokens used\x1b[0m\n17,270\n"
+        self.assertEqual(ringer.parse_token_count(colorized, ringer.DEFAULT_TOKEN_REGEX), 17270)
+        # User-supplied custom regexes get the same stripping — the fix is in
+        # the parser, not the shipped pattern.
+        self.assertEqual(ringer.parse_token_count(colorized, r"tokens\s+used\s*:?\s*([0-9][0-9,]*)"), 17270)
+        # Uncolorized output keeps parsing exactly as before.
+        self.assertEqual(ringer.parse_token_count("tokens used: 1,234", ringer.DEFAULT_TOKEN_REGEX), 1234)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
# Strip ANSI escapes before parsing token counts and reported models

## The observed failure

Every codex run launched from Claude Code on my machine recorded **no model and no tokens** — the scoreboard attributed nothing while the raw worker log plainly showed both. Wrong model attribution is the bug class this repo's CONTRIBUTING calls unforgivable, which is why I'm sending this one upstream.

Root cause: environments like Claude Code and most CI systems set `FORCE_COLOR` for every child process, ringer passes its environment to workers unchanged, and codex honors the variable — it colorizes stdout **even through a pipe**. The captured bytes become:

```
\x1b[1mmodel:\x1b[0m gpt-5.6-sol
\x1b[2mtokens used\x1b[0m
17,270
```

`DEFAULT_CODEX_MODEL_REPORT_REGEX` anchors on `^model:` and never matches the bold-wrapped header. `DEFAULT_TOKEN_REGEX`'s `\s*` cannot bridge the escape bytes between "used" and the number. Both parse to `None`, silently.

## Executed proof

Controlled A/B under ringer itself — identical one-task manifest, stock `[engines.codex]` from config.sample.toml, codex-cli 0.146.0, one variable flipped:

| Env | Raw log | Eval row |
|---|---|---|
| `FORCE_COLOR=3` (Claude Code default) | colorized as above | `worker_tokens: null`, `reported_model: null` |
| `env -u FORCE_COLOR`, all else identical | plain text | `worker_tokens: 17238`, `reported_model: "gpt-5.6-sol"` |

Version is not the trigger: captured worker logs show codex 0.144.1 and 0.146.0 colorizing byte-identically under `FORCE_COLOR`, and 0.145.0 parsing fine without it. Any engine CLI that honors `FORCE_COLOR`/`--color=always` conventions will reproduce this; uncolorized environments are unaffected (stripping is a no-op on plain text).

## The fix

Fix the class, not the instances: `parse_token_count` and `parse_reported_model` strip ANSI once with the module's existing `ANSI_RE` — already the accepted remedy in this codebase (`clean_log_text` uses it for log display) — before matching. Both shipped regex constants are untouched, and **user-written custom `token_regex`/`model_report_regex` overrides benefit equally**, which patching the two constants would not achieve.

7 lines in `ringer.py` (2 functional + comments), no new constants, stdlib only.

## Tests

- `tests/test_ringer.py`: colorized token output (real captured bytes) parses via the shipped default **and** via a user-style custom regex; uncolorized input still parses (no regression).
- `tests/test_identity_evidence.py`: bold-wrapped `model:` header parses via the default codex engine regex, alongside the existing plain-header test.

Both new tests fail on unpatched `ringer.py` (`None`), pass with the fix. Full suite: 255 tests, all green, macOS / Python 3.14 and 3.12.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RNCh1cr6wJHXj52Hwwi5KW
