### PR TITLE
Add optional staged task dependencies

### DIFF
--- a/.claude/skills/ringer/SKILL.md
+++ b/.claude/skills/ringer/SKILL.md
@@ -202,7 +202,9 @@ Pattern-selection judgment:
   your own having seen the prior art.
 - **Review before fix.** Run a read-only review swarm, read the reports
   yourself, then compile the confirmed findings into a fix-swarm manifest.
-  Don't let the same worker find and fix.
+  Don't let the same worker find and fix. When the reviewer can be decided up
+  front, `depends_on` (below) puts both stages in ONE manifest so you aren't
+  sitting between them waiting to launch the second.
 - **Personas must be separate workers.** Parallel personas in one context
   bleed into each other. One persona per task, one session dir per task.
 - **Iterating on a prompt/product? Re-run the same panel.** A fixed persona
@@ -213,6 +215,40 @@ Pattern-selection judgment:
   and a validator as the check. Diagnosing a failed worker's output is a
   read-only scout task. If it calls a model, it runs under Ringer — that is
   what makes it visible, verified, and logged.
+
+## Staged tasks: `depends_on`
+
+A task can name prerequisites that must all PASS before it becomes eligible:
+
+```json
+{"key": "schema-qc", "depends_on": ["schema-producer"], "engine": "opencode"}
+```
+
+Use it when the second stage is decidable up front — producer then QC, build
+then audit, draft then persona panel. It buys you one thing: you stop being the
+thing that notices stage one finished and launches stage two.
+
+- **A failed prerequisite SKIPS its dependent.** No worker is launched, no
+  attempt is consumed, and no eval row is written — the reviewer never runs
+  against work that didn't build, and the scoreboard doesn't get a row for a
+  model that never saw the task. `blocked_by` names what stopped it, and
+  skips propagate down the chain.
+- **Waiting happens before the concurrency slot**, so a two-stage manifest at
+  `max_parallel: 1` runs stage one then stage two instead of deadlocking.
+- **A prerequisite isn't terminal until its retries finish.** Fails attempt 1,
+  passes attempt 2 — the dependent runs.
+- **It is a CONTROL dependency, not a data one.** Nothing flows between tasks
+  automatically. In worktrees mode a passing task's worktree is DELETED before
+  its dependent starts, so anything the dependent needs must be exported by the
+  producer's *check* to a durable path outside the worktree, and the dependent's
+  spec must name that exact path. This is the mistake to expect: a QC task that
+  says "review the patch" without saying where the patch is will review nothing.
+- **Don't stage what doesn't need it.** Independent tasks should stay
+  independent — dependencies serialize work that could have run in parallel.
+
+Cycles, self-dependencies, unknown keys, duplicates and malformed values are
+rejected when the manifest is parsed, so `lint` catches a bad graph before any
+worker spawns.
 
 ## Engine selection
 

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Each task gets its own directory, its own worker, its own log, and its own verdi
 | `engine` | Which configured engine runs this task (default `codex`) |
 | `model` | Which model a harness engine runs for this task — fills the engine's `{model}` placeholder (e.g. `"openrouter/moonshotai/kimi-k2.7"`); empty uses the engine's `model_default` |
 | `task_type` | Optional free-form string naming the kind of work this task is, so the model-performance log can slice pass rates by task shape rather than only by model. Suggested vocabulary: `code-feature`, `code-fix`, `code-review`, `test-hardening`, `docs`, `research`, `persona-review`, `copywriting`, `site-build`, `motion-design`, `image-gen`, `data-pipeline`, `format-conversion`, `probe`, `bakeoff`. Empty is allowed; the log just reports it under `(none)`. |
+| `depends_on` | Optional list of task keys that must **all pass** before this task starts (default: none — the task is eligible immediately). A dependent waits for every prerequisite to finish its final attempt before it takes a `max_parallel` slot, so it never holds a slot while blocked. If any prerequisite ends in a non-pass state, the dependent is marked `skipped`: no worker is launched, no attempt is consumed, no eval row is written, and anything depending on it is skipped in turn. This is a *control* dependency only — no files flow between tasks. Because a passing task's worktree (if any) is deleted, anything a dependent needs must be exported by the producer's `check` to a durable path outside the worktree. |
 | `timeout_s` | Per-task kill timer (default 900) |
 | `max_attempts` | How many times this task may run (default 2 — one try plus one retry with the check's failure output injected). Set `1` for a hard no-retry lane |
 | `redact_spec` | Replace this task's spec with `[redacted request packet]` in the run state, the logged command line, and the eval row, for specs carrying sensitive material. Redacts Ringer's own records only — captured worker output is never rewritten (invariant), so a worker that echoes its request still puts that text in `worker.log` |
@@ -110,6 +111,17 @@ Each task gets its own directory, its own worker, its own log, and its own verdi
 | `worktrees` (run-level) | Give each task an isolated git worktree of `repo` so parallel workers can't collide |
 
 > **Worktree footgun:** on PASS the task's worktree is removed — including anything written inside it. In worktrees mode, worker logs live outside task worktrees in `workdir/logs/`; have workers write deliverables outside the worktree too, or have your `check` copy artifacts out before it exits 0.
+
+Example: run quality control only after the producer has been verified. If `schema-producer` fails or is skipped, `schema-qc` is marked `skipped` — no worker runs for it.
+
+```json
+{
+  "key": "schema-qc",
+  "depends_on": ["schema-producer"],
+  "spec": "Review the exported schema at /tmp/shared/schema.json against the DDL...",
+  "check": "test -s /tmp/shared/schema.json && ... "
+}
+```
 
 Not sure what your tasks even are yet? [`docs/interview-prompt.md`](docs/interview-prompt.md) is a prompt you paste into any chatbot; it interviews you about the job and hands back a brief your orchestrating agent can turn into a manifest. Ready-made skeletons for the patterns that work live in [`templates/`](templates/).
 
@@ -392,6 +404,7 @@ Every community PR that lands in main is credited here — that's a project rule
 - [@davekopecek](https://github.com/davekopecek) (Dave Kopecek) — committed the design-reference fixture so the design-token guard runs on every machine (#30)
 - [@snapsynapse](https://github.com/snapsynapse) (Sam Rogers) — graceful shutdown on SIGINT/SIGTERM with worker-tree cleanup and finished state, plus the 14-test end-to-end CLI regression suite (#4)
 - [@mlava](https://github.com/mlava) (Mark Lavercombe) — named setup failures across every diagnostic surface (#37) and `run --baseline`, the no-workers check preflight (#38)
+- [@Guidance78](https://github.com/Guidance78) (John W) — optional staged task dependencies: `depends_on` gates a task on its prerequisites and skips it, without invoking a worker, when one fails
 
 Contributions are welcome — see [CONTRIBUTING.md](CONTRIBUTING.md) for the philosophy and what gets a PR merged fast. The short version: small and scoped, rebased on current main, every claim backed by an executed test. Authorship is always preserved — where a maintainer pushes a mechanical fix to your branch, you remain the commit author.
 

--- a/ringer.py
+++ b/ringer.py
@@ -1642,6 +1642,10 @@ class TaskSpec:
     # engine's {model} placeholder); empty means the engine's model_default.
     model: str = ""
     task_type: str = ""
+    # Task keys that must all PASS before this task starts (a control
+    # dependency only — no artifacts flow between tasks). Empty means the
+    # task is eligible immediately, exactly as before.
+    depends_on: tuple[str, ...] = ()
 
     @classmethod
     def from_obj(cls, obj: dict[str, Any]) -> "TaskSpec":
@@ -1694,6 +1698,27 @@ class TaskSpec:
         task_type = obj.get("task_type", "")
         if not isinstance(task_type, str):
             raise ValueError(f"task {key}: task_type must be a string")
+        depends_on_raw = obj.get("depends_on", [])
+        if not isinstance(depends_on_raw, list):
+            raise ValueError(
+                f"task {key}: depends_on must be a JSON list of task keys, "
+                f"got {type(depends_on_raw).__name__}"
+            )
+        depends_on: list[str] = []
+        for dep in depends_on_raw:
+            if not isinstance(dep, str):
+                raise ValueError(
+                    f"task {key}: depends_on entries must be strings, "
+                    f"got {type(dep).__name__}"
+                )
+            dep_key = dep.strip()
+            if not dep_key:
+                raise ValueError(f"task {key}: depends_on entries must not be empty")
+            if dep_key in depends_on:
+                raise ValueError(
+                    f"task {key}: depends_on lists {dep_key!r} more than once"
+                )
+            depends_on.append(dep_key)
         return cls(
             key=key,
             spec=spec,
@@ -1708,7 +1733,37 @@ class TaskSpec:
             verified=verified.strip(),
             model=model.strip(),
             task_type=task_type.strip(),
+            depends_on=tuple(depends_on),
         )
+
+
+def dependency_cycle(tasks: tuple[TaskSpec, ...]) -> list[str] | None:
+    """Return the keys of one cycle (first == last), or None if the graph is acyclic."""
+    edges: dict[str, tuple[str, ...]] = {task.key: task.depends_on for task in tasks}
+    visited: dict[str, bool] = {}
+    stack: list[str] = []
+
+    def visit(node: str) -> list[str] | None:
+        visited[node] = True
+        stack.append(node)
+        for dep in edges.get(node, ()):
+            if visited.get(dep, False):
+                start = stack.index(dep)
+                return stack[start:] + [dep]
+            if dep not in visited:
+                cycle = visit(dep)
+                if cycle is not None:
+                    return cycle
+        stack.pop()
+        visited[node] = False
+        return None
+
+    for node in edges:
+        if node not in visited:
+            cycle = visit(node)
+            if cycle is not None:
+                return cycle
+    return None
 
 
 @dataclass(frozen=True)
@@ -1761,6 +1816,18 @@ class Manifest:
         duplicates = sorted({key for key in keys if keys.count(key) > 1})
         if duplicates:
             raise ValueError(f"duplicate task keys: {', '.join(duplicates)}")
+        task_keys = set(keys)
+        for task in tasks:
+            for dep in task.depends_on:
+                if dep == task.key:
+                    raise ValueError(f"task {task.key}: cannot depend on itself")
+                if dep not in task_keys:
+                    raise ValueError(
+                        f"task {task.key}: depends_on references unknown task {dep!r}"
+                    )
+        cycle = dependency_cycle(tasks)
+        if cycle is not None:
+            raise ValueError(f"dependency cycle: {' -> '.join(cycle)}")
         worktrees = bool(obj.get("worktrees", False))
         if worktrees:
             reserved_logs_dir = (workdir / "logs").resolve()
@@ -2094,6 +2161,9 @@ class TaskRuntime:
     setup_error: str | None = None
     last_worker_command: list[str] = field(default_factory=list)
     steering: dict[str, Any] | None = None
+    # Prerequisite keys this task is still waiting on, or the prerequisites
+    # that did not pass when the task ended skipped. Empty once unblocked.
+    blocked_by: tuple[str, ...] = ()
 
     def elapsed_s(self, now: float) -> float:
         if self.started_at_monotonic is None:
@@ -2275,6 +2345,8 @@ class StateWriter:
                     "key": runtime.task.key,
                     "status": runtime.status,
                     "verdict": runtime.final_verdict,
+                    "depends_on": list(runtime.task.depends_on),
+                    "blocked_by": list(runtime.blocked_by),
                     "engine": runtime.task.engine,
                     "model": (
                         runtime.task.model
@@ -2321,14 +2393,16 @@ class StateWriter:
                 tasks.append(task_state)
             pass_count = sum(1 for item in tasks if item["status"] == "pass")
             fail_count = sum(1 for item in tasks if item["status"] == "fail")
+            skipped_count = sum(1 for item in tasks if item["status"] == "skipped")
             running_count = sum(
                 1 for item in tasks if item["status"] in {"running", "verifying", "retrying"}
             )
             totals = {
                 "running": running_count,
-                "done": pass_count + fail_count,
+                "done": pass_count + fail_count + skipped_count,
                 "pass": pass_count,
                 "fail": fail_count,
+                "skipped": skipped_count,
                 "tokens": sum(int(item["tokens"] or 0) for item in tasks),
             }
             return {
@@ -2360,6 +2434,7 @@ class StateWriter:
             return {
                 "pass": sum(1 for runtime in self.runtimes if runtime.status == "pass"),
                 "fail": sum(1 for runtime in self.runtimes if runtime.status == "fail"),
+                "skipped": sum(1 for runtime in self.runtimes if runtime.status == "skipped"),
                 "tokens": sum(int(runtime.tokens or 0) for runtime in self.runtimes),
             }
 
@@ -4285,6 +4360,7 @@ def task_status_counts(state: dict[str, Any]) -> dict[str, int]:
     running_n = sum(1 for bucket in buckets if bucket == "working")
     retry_n = sum(1 for bucket in buckets if bucket == "retry")
     waiting_n = sum(1 for bucket in buckets if bucket == "waiting")
+    skip_n = sum(1 for bucket in buckets if bucket == "skip")
     return {
         "total": len(tasks),
         "pass": pass_n,
@@ -4292,6 +4368,7 @@ def task_status_counts(state: dict[str, Any]) -> dict[str, int]:
         "running": running_n,
         "retry": retry_n,
         "waiting": waiting_n,
+        "skip": skip_n,
     }
 
 
@@ -4329,6 +4406,12 @@ def waiting_phrase(count: int) -> str:
     return f"{count} are waiting"
 
 
+def skipped_phrase(count: int) -> str:
+    if count == 1:
+        return "1 skipped"
+    return f"{count} skipped"
+
+
 def live_briefing_sentence(state: dict[str, Any]) -> str:
     return html_to_text(live_briefing_html(state))
 
@@ -4348,6 +4431,8 @@ def live_briefing_html(state: dict[str, Any]) -> str:
         parts.append(f'<span class="n-fail">{html_escape(retry_phrase(counts["retry"]))}</span>')
     if counts["waiting"]:
         parts.append(html_escape(waiting_phrase(counts["waiting"])))
+    if counts["skip"]:
+        parts.append(html_escape(skipped_phrase(counts["skip"])))
     if counts["fail"]:
         parts.append(f'<span class="n-fail">{html_escape(failed_phrase(counts["fail"]))}</span>')
     status_sentence = join_plain_html_parts(parts)
@@ -4366,13 +4451,25 @@ def final_briefing_html(state: dict[str, Any]) -> str:
     total = counts["total"]
     pass_n = counts["pass"]
     fail_n = counts["fail"]
+    skip_n = counts["skip"]
     elapsed = fmt_compact_duration(state.get("elapsed_s"))
     first = f"Ringer finished {total} {task_word(total)} in {elapsed}."
-    if fail_n == 0:
+    if fail_n == 0 and skip_n == 0:
         return f"{html_escape(first)} <span class=\"n-pass\">All {total} finished and checked.</span>"
+    if fail_n == 0:
+        return (
+            f"{html_escape(first)} <span class=\"n-pass\">{pass_n} finished and checked</span>, "
+            f"{skip_n} skipped."
+        )
+    if skip_n == 0:
+        return (
+            f"{html_escape(first)} <span class=\"n-pass\">{pass_n} finished and checked</span>, "
+            f"<span class=\"n-fail\">{fail_n} failed after retry.</span>"
+        )
     return (
         f"{html_escape(first)} <span class=\"n-pass\">{pass_n} finished and checked</span>, "
-        f"<span class=\"n-fail\">{fail_n} failed after retry.</span>"
+        f"<span class=\"n-fail\">{fail_n} failed after retry</span>, "
+        f"{skip_n} skipped."
     )
 
 
@@ -4436,6 +4533,8 @@ def plain_transition_event(
         return {"line": f"{task_key} failed"}
     if status == "timeout":
         return {"line": f"{task_key} timed out"}
+    if status == "skipped":
+        return {"line": f"{task_key} skipped — a prerequisite did not pass"}
     return None
 
 
@@ -4454,6 +4553,8 @@ def task_state_bucket(status: str) -> str:
         return "pass"
     if status in {"fail", "error", "timeout", "died"}:
         return "fail"
+    if status == "skipped":
+        return "skip"
     if status == "retrying":
         return "retry"
     if status in {"running", "verifying"}:
@@ -4465,6 +4566,8 @@ def task_state_word(status: str) -> str:
     bucket = task_state_bucket(status)
     if bucket == "pass":
         return "finished & checked"
+    if bucket == "skip":
+        return "skipped"
     if bucket == "working":
         return "working"
     if bucket == "retry":
@@ -4496,6 +4599,8 @@ def render_progress_bar(tasks: list[dict[str, Any]], counts: dict[str, int]) -> 
         legend_parts.append(f'{counts["running"]} working')
     if counts["retry"]:
         legend_parts.append(f'{counts["retry"]} sent back')
+    if counts["skip"]:
+        legend_parts.append(f'{counts["skip"]} skipped')
     if counts["fail"]:
         legend_parts.append(f'{counts["fail"]} failed')
     if counts["waiting"]:
@@ -4503,7 +4608,8 @@ def render_progress_bar(tasks: list[dict[str, Any]], counts: dict[str, int]) -> 
     legend = " · ".join(legend_parts) if legend_parts else "No tasks"
     aria = (
         f'{counts["total"]} tasks: {counts["pass"]} passed, {counts["running"]} working, '
-        f'{counts["retry"]} retrying, {counts["waiting"]} waiting, {counts["fail"]} failed'
+        f'{counts["retry"]} retrying, {counts["waiting"]} waiting, '
+        f'{counts["skip"]} skipped, {counts["fail"]} failed'
     )
     return f"""<div class="rounds" role="img" aria-label="{html_escape(aria)}">{bar}</div>
     <p class="legend">{html_escape(legend)}</p>"""
@@ -4528,7 +4634,7 @@ def render_work_section(
         tasks = [
             task
             for task in tasks
-            if task_state_bucket(str(task.get("status", "queued"))) in {"pass", "fail"}
+            if task_state_bucket(str(task.get("status", "queued"))) in {"pass", "fail", "skip"}
         ]
     section_class = "work is-primary" if primary else "work"
     if not tasks:
@@ -4593,6 +4699,8 @@ def render_work_group(
         items_html = '<p class="empty-note">Finished and checked — this worker filed nothing to the shelf.</p>'
     elif bucket == "fail":
         items_html = '<p class="empty-note">Failed its check — nothing was delivered.</p>'
+    elif bucket == "skip":
+        items_html = '<p class="empty-note">Skipped — a prerequisite did not pass, so no worker ran.</p>'
     elif bucket in {"working", "retry"}:
         items_html = '<p class="empty-note">Nothing delivered yet — still on it.</p>'
     else:
@@ -8714,10 +8822,18 @@ class RingerRunner:
         self.verifier = Verifier()
         self.semaphore = asyncio.Semaphore(manifest.max_parallel)
         self.active_processes: dict[int, asyncio.subprocess.Process] = {}
+        # Terminal outcome per task key ("pass", "fail", or "skipped"), so a
+        # dependent can wait on its prerequisites before taking a concurrency
+        # slot. Filled lazily so _run_task also works when called directly.
+        self._task_results: dict[str, asyncio.Future[str]] = {}
 
     async def run(self) -> int:
         self.manifest.workdir.mkdir(parents=True, exist_ok=True)
         final_state = False
+        loop = asyncio.get_running_loop()
+        self._task_results = {
+            runtime.task.key: loop.create_future() for runtime in self.runtimes
+        }
         try:
             self.state_writer.start()
             if self.dashboard is not None:
@@ -8730,10 +8846,11 @@ class RingerRunner:
             with self.lock:
                 now = time.monotonic()
                 for runtime in self.runtimes:
-                    if runtime.status not in {"pass", "fail"}:
+                    if runtime.status not in {"pass", "fail", "skipped"}:
                         runtime.status = "fail"
                         runtime.final_verdict = "ERROR"
                         runtime.ended_at_monotonic = runtime.ended_at_monotonic or now
+            self._resolve_pending_results()
             self.state_writer.flush()
             final_state = True
             raise
@@ -8765,6 +8882,60 @@ class RingerRunner:
                 kill_process_group(proc)
 
     async def _run_task(self, runtime: TaskRuntime) -> None:
+        try:
+            if runtime.task.depends_on:
+                blockers = await self._wait_for_prerequisites(runtime)
+                if blockers:
+                    await self._mark_skipped(runtime, blockers)
+                    return
+            await self._execute_task(runtime)
+        finally:
+            self._publish_task_result(runtime)
+
+    async def _wait_for_prerequisites(self, runtime: TaskRuntime) -> tuple[str, ...] | None:
+        """Wait (before any concurrency slot is taken) for every prerequisite
+        to reach a terminal state. Returns the prerequisites that did not
+        PASS, or None when every prerequisite passed."""
+        blockers: list[str] = []
+        still_waiting = list(runtime.task.depends_on)
+        for dep in runtime.task.depends_on:
+            result_future = self._task_results.get(dep)
+            if result_future is None:
+                result_future = asyncio.get_running_loop().create_future()
+                self._task_results[dep] = result_future
+            result = await result_future
+            still_waiting.remove(dep)
+            with self.lock:
+                runtime.blocked_by = tuple(still_waiting)
+            if result != "pass":
+                blockers.append(dep)
+        return tuple(blockers) if blockers else None
+
+    async def _mark_skipped(self, runtime: TaskRuntime, blockers: tuple[str, ...]) -> None:
+        # No worker process is launched, no attempt is consumed, and no eval
+        # row is written — skipped is a terminal status that the run state,
+        # the summary, and the result future all record without side effects.
+        with self.lock:
+            runtime.status = "skipped"
+            runtime.blocked_by = blockers
+            runtime.ended_at_monotonic = time.monotonic()
+
+    def _publish_task_result(self, runtime: TaskRuntime) -> None:
+        status = runtime.status
+        if status not in {"pass", "fail", "skipped"}:
+            status = "fail"
+        result_future = self._task_results.get(runtime.task.key)
+        if result_future is None:
+            result_future = asyncio.get_running_loop().create_future()
+            self._task_results[runtime.task.key] = result_future
+        if not result_future.done():
+            result_future.set_result(status)
+
+    def _resolve_pending_results(self) -> None:
+        for runtime in self.runtimes:
+            self._publish_task_result(runtime)
+
+    async def _execute_task(self, runtime: TaskRuntime) -> None:
         async with self.semaphore:
             with self.lock:
                 runtime.started_at_monotonic = time.monotonic()
@@ -9307,6 +9478,7 @@ class RingerRunner:
             taskdir=taskdir,
             log_path=log_path,
             spec_short=shorten(task.spec, 120),
+            blocked_by=task.depends_on,
         )
 
     def _taskdir(self, task: TaskSpec) -> Path:
@@ -10094,6 +10266,9 @@ def print_summary(run_id: str, runtimes: list[TaskRuntime]) -> None:
         print("\nsetup failures (no worker was spawned):")
         for runtime in setup_failures:
             print(f"  {runtime.task.key}: {runtime.setup_error}")
+    skipped = [r for r in runtimes if r.status == "skipped"]
+    if skipped:
+        print(f"skipped: {len(skipped)} task(s) did not run because a prerequisite did not pass")
 
 
 def create_demo_manifest() -> Path:

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -1,0 +1,644 @@
+#!/usr/bin/env python3
+"""depends_on: task ordering, skip propagation, and hard manifest validation.
+
+Covers the required semantics: parsing of the field (including every
+rejection), graph validation (unknown keys, self-dependency, cycles), the
+dependency wait happening before a max_parallel slot is taken, skip
+propagation through a chain and through fan-in, the retry boundary (a
+prerequisite is terminal only after its final attempt), and the guarantee
+that a skipped task launches no worker, consumes no attempt, and writes no
+eval row. Uses only deterministic, non-model workers.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import shlex
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+import ringer  # noqa: E402
+
+from ringer import (  # noqa: E402
+    AppConfig,
+    ArtifactConfig,
+    EngineConfig,
+    EvalConfig,
+    Manifest,
+    RingerRunner,
+    SteeringConfig,
+    TaskSpec,
+)
+
+
+PASS_SPEC = "MOCK_FILE: out.txt\ndone\nMOCK_END"
+PASS_CHECK = 'test "$(cat out.txt 2>/dev/null)" = done'
+FAIL_SPEC = "MOCK_FAIL"
+FAIL_CHECK = 'test "$(cat out.txt 2>/dev/null)" = done'
+
+
+def task_obj(key: str, **overrides: object) -> dict[str, object]:
+    data: dict[str, object] = {
+        "key": key,
+        "spec": "Do the work described here in full.",
+        "check": "true",
+    }
+    data.update(overrides)
+    return data
+
+
+def manifest_obj(
+    *tasks: dict[str, object],
+    run_name: str = "deps",
+    workdir: Path | None = None,
+    max_parallel: int = 2,
+) -> dict[str, object]:
+    return {
+        "run_name": run_name,
+        "workdir": str(workdir),
+        "max_parallel": max_parallel,
+        "tasks": list(tasks),
+    }
+
+
+def mock_engine() -> EngineConfig:
+    return EngineConfig(
+        name="mock",
+        bin=sys.executable,
+        args_template=(str(ROOT / "engines" / "mock_worker.py"), "{spec}"),
+        full_access_args=(),
+        sandbox_args=(),
+        token_regex=None,
+    )
+
+
+def make_config(root: Path) -> AppConfig:
+    return AppConfig(
+        path=None,
+        identity_default=None,
+        state_dir=root / "state",
+        dashboard_port_base=8787,
+        hud_port=8700,
+        hud_app_path=None,
+        allow_full_access=False,
+        eval=EvalConfig(backend="jsonl", jsonl_path=root / "eval.jsonl"),
+        engines={"mock": mock_engine()},
+        artifact=ArtifactConfig(
+            enabled=False,
+            out_template=str(root / "live.html"),
+            report_template=str(root / "report.html"),
+            index_out=root / "index.html",
+        ),
+        steering=SteeringConfig(dir=None),
+    )
+
+
+class TaskSpecDependsOnParsingTests(unittest.TestCase):
+    def base(self, **overrides: object) -> dict[str, object]:
+        data: dict[str, object] = {
+            "key": "a",
+            "spec": "Do the work.",
+            "check": "true",
+        }
+        data.update(overrides)
+        return data
+
+    def test_absent_depends_on_defaults_to_empty(self) -> None:
+        self.assertEqual((), TaskSpec.from_obj(self.base()).depends_on)
+
+    def test_depends_on_accepts_a_list_of_strings(self) -> None:
+        task = TaskSpec.from_obj(self.base(depends_on=["producer", "lint"]))
+        self.assertEqual(("producer", "lint"), task.depends_on)
+
+    def test_depends_on_trims_whitespace_around_keys(self) -> None:
+        task = TaskSpec.from_obj(self.base(depends_on=["  producer  "]))
+        self.assertEqual(("producer",), task.depends_on)
+
+    def test_bare_string_depends_on_is_rejected_never_coerced(self) -> None:
+        with self.assertRaisesRegex(ValueError, "depends_on must be a JSON list"):
+            TaskSpec.from_obj(self.base(depends_on="producer"))
+
+    def test_dict_depends_on_is_rejected(self) -> None:
+        with self.assertRaisesRegex(ValueError, "depends_on must be a JSON list"):
+            TaskSpec.from_obj(self.base(depends_on={"producer": "lint"}))
+
+    def test_non_string_entry_is_rejected(self) -> None:
+        with self.assertRaisesRegex(ValueError, "depends_on entries must be strings"):
+            TaskSpec.from_obj(self.base(depends_on=["producer", 7]))
+
+    def test_duplicate_entries_are_rejected(self) -> None:
+        with self.assertRaisesRegex(ValueError, "more than once"):
+            TaskSpec.from_obj(self.base(depends_on=["producer", "producer"]))
+
+    def test_empty_after_trim_is_rejected(self) -> None:
+        with self.assertRaisesRegex(ValueError, "must not be empty"):
+            TaskSpec.from_obj(self.base(depends_on=["producer", "   "]))
+
+
+class ManifestDependencyGraphTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory(prefix="ringer-deps-graph-")
+        self.addCleanup(self._tmp.cleanup)
+        self.workdir = Path(self._tmp.name) / "work"
+
+    def build(self, *tasks: dict[str, object]) -> Manifest:
+        return Manifest.from_obj(manifest_obj(*tasks, workdir=self.workdir))
+
+    def test_unknown_dependency_is_rejected(self) -> None:
+        with self.assertRaisesRegex(ValueError, "references unknown task 'ghost'"):
+            self.build(task_obj("a", depends_on=["ghost"]))
+
+    def test_self_dependency_is_rejected(self) -> None:
+        with self.assertRaisesRegex(ValueError, "cannot depend on itself"):
+            self.build(task_obj("a", depends_on=["a"]))
+
+    def test_direct_cycle_is_rejected_with_cycle_keys_named(self) -> None:
+        with self.assertRaisesRegex(ValueError, "dependency cycle: build -> qc -> build"):
+            self.build(
+                task_obj("build", depends_on=["qc"]),
+                task_obj("qc", depends_on=["build"]),
+            )
+
+    def test_indirect_cycle_is_rejected_with_cycle_keys_named(self) -> None:
+        with self.assertRaisesRegex(ValueError, "dependency cycle: a -> b -> c -> a"):
+            self.build(
+                task_obj("a", depends_on=["b"]),
+                task_obj("b", depends_on=["c"]),
+                task_obj("c", depends_on=["a"]),
+            )
+
+    def test_acyclic_diamond_is_accepted(self) -> None:
+        manifest = self.build(
+            task_obj("root"),
+            task_obj("left", depends_on=["root"]),
+            task_obj("right", depends_on=["root"]),
+            task_obj("merge", depends_on=["left", "right"]),
+        )
+        self.assertEqual(4, len(manifest.tasks))
+        self.assertEqual(("root",), manifest.tasks[1].depends_on)
+
+
+class DependencyRuntimeTests(unittest.IsolatedAsyncioTestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory(prefix="ringer-deps-run-")
+        self.addCleanup(self._tmp.cleanup)
+        self.root = Path(self._tmp.name)
+        self.config = make_config(self.root)
+
+    async def run_manifest(self, obj: dict[str, object], *, timeout: float = 30) -> RingerRunner:
+        runner = RingerRunner(Manifest.from_obj(obj), self.config, "test", dashboard_enabled=False)
+        await asyncio.wait_for(runner.run(), timeout=timeout)
+        return runner
+
+    def eval_rows(self) -> list[dict[str, object]]:
+        path = self.config.eval.jsonl_path
+        if not path.exists():
+            return []
+        return [
+            json.loads(line)
+            for line in path.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
+
+    async def test_dependent_waits_before_taking_a_concurrency_slot(self) -> None:
+        # max_parallel 1: if the dependent held the only slot while waiting,
+        # its prerequisite could never run and the run would deadlock.
+        runner = await self.run_manifest(            manifest_obj(
+                task_obj("producer", engine="mock", spec=PASS_SPEC, expect_files=["out.txt"], check=PASS_CHECK),
+                task_obj("consumer", depends_on=["producer"], engine="mock", spec=PASS_SPEC, expect_files=["out.txt"], check=PASS_CHECK),
+                run_name="two-stage", workdir=self.root / "work", max_parallel=1,
+            ),
+            timeout=30,
+        )
+        by_key = {runtime.task.key: runtime for runtime in runner.runtimes}
+        self.assertEqual("pass", by_key["producer"].status)
+        self.assertEqual("pass", by_key["consumer"].status)
+        self.assertEqual(1, by_key["consumer"].attempts)
+        self.assertTrue(all(future.done() for future in runner._task_results.values()))
+
+    async def test_skip_propagates_through_a_chain_with_no_worker_no_attempt_no_eval_row(self) -> None:
+        runner = await self.run_manifest(
+            manifest_obj(
+                task_obj("a", engine="mock", spec=FAIL_SPEC, expect_files=["out.txt"], check=FAIL_CHECK),
+                task_obj("b", depends_on=["a"], engine="mock", spec=PASS_SPEC, expect_files=["out.txt"], check=PASS_CHECK),
+                task_obj("c", depends_on=["b"], engine="mock", spec=PASS_SPEC, expect_files=["out.txt"], check=PASS_CHECK),
+                run_name="skip-chain", workdir=self.root / "work", max_parallel=1,
+            ),
+            timeout=30,
+        )
+        by_key = {runtime.task.key: runtime for runtime in runner.runtimes}
+        self.assertEqual("fail", by_key["a"].status)
+        self.assertEqual("skipped", by_key["b"].status)
+        self.assertEqual("skipped", by_key["c"].status)
+        self.assertEqual(0, by_key["b"].attempts)
+        self.assertEqual(0, by_key["c"].attempts)
+        self.assertIsNone(by_key["b"].worker_pid)
+        self.assertIsNone(by_key["c"].worker_pid)
+        self.assertEqual(("a",), by_key["b"].blocked_by)
+        self.assertEqual(("b",), by_key["c"].blocked_by)
+        rows = self.eval_rows()
+        self.assertEqual(["a", "a"], [row["task_key"] for row in rows])
+        self.assertEqual({"fail", "skipped"}, {future.result() for future in runner._task_results.values()})
+        self.assertTrue(all(future.done() for future in runner._task_results.values()))
+
+    async def test_fan_in_waits_for_every_prerequisite(self) -> None:
+        # Each prerequisite stamps a shared order log inside its check; the
+        # merge must start only after both have stamped, so its stamp is later
+        # than either's. p2's check sleeps so that, if the scheduler ignored
+        # depends_on and ran the merge concurrently, the merge would finish and
+        # stamp well before p2 — the ordering assertions below would then fail.
+        log = self.root / "order.log"
+
+        def stamp_check(key: str, *, delay: float = 0) -> str:
+            check = (
+                f"printf '%s %s\\n' '{key}' \"$(date +%s%N)\" >> {shlex.quote(str(log))}; "
+                'test "$(cat out.txt 2>/dev/null)" = done'
+            )
+            return f"sleep {delay}; {check}" if delay else check
+
+        runner = await self.run_manifest(
+            manifest_obj(
+                task_obj("p1", engine="mock", spec=PASS_SPEC, expect_files=["out.txt"], check=stamp_check("p1")),
+                task_obj("p2", engine="mock", spec=PASS_SPEC, expect_files=["out.txt"], check=stamp_check("p2", delay=1)),
+                task_obj("merge", depends_on=["p1", "p2"], engine="mock", spec=PASS_SPEC, expect_files=["out.txt"], check=stamp_check("merge")),
+                run_name="fan-in", workdir=self.root / "work", max_parallel=2,
+            ),
+            timeout=30,
+        )
+        self.assertTrue(all(runtime.status == "pass" for runtime in runner.runtimes))
+        self.assertTrue(all(future.done() for future in runner._task_results.values()))
+        stamps: dict[str, int] = {}
+        for line in log.read_text(encoding="utf-8").splitlines():
+            key, value = line.split(" ", 1)
+            stamps[key] = int(value)
+        self.assertEqual({"p1", "p2", "merge"}, set(stamps))
+        self.assertGreater(stamps["merge"], stamps["p1"])
+        self.assertGreater(stamps["merge"], stamps["p2"])
+
+    async def test_fan_in_skips_when_any_prerequisite_fails(self) -> None:
+        runner = await self.run_manifest(
+            manifest_obj(
+                task_obj("p1", engine="mock", spec=PASS_SPEC, expect_files=["out.txt"], check=PASS_CHECK),
+                task_obj("p2", engine="mock", spec=FAIL_SPEC, expect_files=["out.txt"], check=FAIL_CHECK),
+                task_obj("merge", depends_on=["p1", "p2"], engine="mock", spec=PASS_SPEC, expect_files=["out.txt"], check=PASS_CHECK),
+                run_name="fan-in-fail", workdir=self.root / "work", max_parallel=2,
+            ),
+            timeout=30,
+        )
+        by_key = {runtime.task.key: runtime for runtime in runner.runtimes}
+        self.assertEqual("pass", by_key["p1"].status)
+        self.assertEqual("fail", by_key["p2"].status)
+        self.assertEqual("skipped", by_key["merge"].status)
+        self.assertEqual(0, by_key["merge"].attempts)
+        self.assertEqual(("p2",), by_key["merge"].blocked_by)
+        rows = sorted(
+            (row["task_key"], row["verdict"]) for row in self.eval_rows()
+        )
+        self.assertEqual([("p1", "PASS"), ("p2", "FAIL"), ("p2", "FAIL")], rows)
+
+    async def test_dependent_runs_only_after_prerequisite_final_attempt(self) -> None:
+        # The producer fails attempt 1 and passes attempt 2; its dependent
+        # must not start until the retry resolves, then it runs.
+        runner = await self.run_manifest(
+            manifest_obj(
+                task_obj(
+                    "prod",
+                    engine="mock",
+                    spec=PASS_SPEC,
+                    expect_files=["out.txt"],
+                    check="if [ -f second ]; then exit 0; else touch second; exit 1; fi",
+                ),
+                task_obj("qc", depends_on=["prod"], engine="mock", spec=PASS_SPEC, expect_files=["out.txt"], check=PASS_CHECK),
+                run_name="retry-boundary", workdir=self.root / "work", max_parallel=1,
+            ),
+            timeout=30,
+        )
+        by_key = {runtime.task.key: runtime for runtime in runner.runtimes}
+        self.assertEqual("pass", by_key["prod"].status)
+        self.assertEqual(2, by_key["prod"].attempts)
+        self.assertEqual("pass", by_key["qc"].status)
+        self.assertEqual(1, by_key["qc"].attempts)
+        self.assertEqual(
+            ["prod", "prod", "qc"],
+            [row["task_key"] for row in self.eval_rows()],
+        )
+
+    async def test_task_without_depends_on_behaves_exactly_as_before(self) -> None:
+        runner = await self.run_manifest(
+            manifest_obj(
+                task_obj("solo", engine="mock", spec=PASS_SPEC, expect_files=["out.txt"], check=PASS_CHECK),
+                run_name="solo", workdir=self.root / "work", max_parallel=1,
+            ),
+            timeout=30,
+        )
+        self.assertEqual("pass", runner.runtimes[0].status)
+        self.assertEqual(1, runner.runtimes[0].attempts)
+        self.assertEqual((), runner.runtimes[0].blocked_by)
+
+    async def test_skipped_tasks_leave_no_taskdir_and_no_log(self) -> None:
+        runner = await self.run_manifest(
+            manifest_obj(
+                task_obj("a", engine="mock", spec=FAIL_SPEC, expect_files=["out.txt"], check=FAIL_CHECK),
+                task_obj("b", depends_on=["a"], engine="mock", spec=PASS_SPEC, expect_files=["out.txt"], check=PASS_CHECK),
+                run_name="no-artifacts", workdir=self.root / "work", max_parallel=1,
+            ),
+            timeout=30,
+        )
+        by_key = {runtime.task.key: runtime for runtime in runner.runtimes}
+        self.assertFalse(by_key["b"].taskdir.exists())
+        self.assertFalse(by_key["b"].log_path.exists())
+
+    async def test_exception_in_prerequisite_still_publishes_and_unblocks_dependent(self) -> None:
+        runner = RingerRunner(
+            Manifest.from_obj(
+                manifest_obj(
+                    task_obj("boom", engine="mock", spec=PASS_SPEC, expect_files=["out.txt"], check=PASS_CHECK),
+                    task_obj("dep", depends_on=["boom"], engine="mock", spec=PASS_SPEC, expect_files=["out.txt"], check=PASS_CHECK),
+                    run_name="boom", workdir=self.root / "work", max_parallel=1,
+                )
+            ),
+            self.config,
+            "test",
+            dashboard_enabled=False,
+        )
+
+        async def boom_prepare(runtime: object) -> tuple[bool, str | None]:
+            raise RuntimeError("simulated preparation explosion")
+
+        runner._prepare_taskdir = boom_prepare  # type: ignore[method-assign]
+        boom_task = asyncio.create_task(runner._run_task(runner.runtimes[0]))
+        dep_task = asyncio.create_task(runner._run_task(runner.runtimes[1]))
+        with self.assertRaises(RuntimeError):
+            await boom_task
+        await asyncio.wait_for(dep_task, timeout=10)
+        self.assertTrue(runner._task_results["boom"].done())
+        self.assertTrue(runner._task_results["dep"].done())
+        self.assertEqual("fail", runner._task_results["boom"].result())
+        self.assertEqual("skipped", runner.runtimes[1].status)
+
+    async def test_cancelled_waiter_still_publishes_its_result(self) -> None:
+        runner = RingerRunner(
+            Manifest.from_obj(
+                manifest_obj(
+                    task_obj("never", engine="mock", spec=PASS_SPEC, expect_files=["out.txt"], check=PASS_CHECK),
+                    task_obj("waiter", depends_on=["never"], engine="mock", spec=PASS_SPEC, expect_files=["out.txt"], check=PASS_CHECK),
+                    run_name="cancel", workdir=self.root / "work", max_parallel=1,
+                )
+            ),
+            self.config,
+            "test",
+            dashboard_enabled=False,
+        )
+        waiter_task = asyncio.create_task(runner._run_task(runner.runtimes[1]))
+        await asyncio.sleep(0.05)
+        waiter_task.cancel()
+        with self.assertRaises(asyncio.CancelledError):
+            await waiter_task
+        self.assertTrue(runner._task_results["waiter"].done())
+        self.assertEqual("fail", runner._task_results["waiter"].result())
+
+
+class FinalBriefingHtmlTests(unittest.TestCase):
+    def state(self, *statuses: str) -> dict[str, object]:
+        return {
+            "elapsed_s": 10,
+            "tasks": [
+                {"key": f"task-{index}", "status": status}
+                for index, status in enumerate(statuses)
+            ],
+        }
+
+    def test_final_briefing_names_pass_fail_and_skip_counts(self) -> None:
+        html = ringer.final_briefing_html(self.state("pass", "fail", "skipped"))
+        self.assertEqual(
+            "Ringer finished 3 tasks in 10s. "
+            '<span class="n-pass">1 finished and checked</span>, '
+            '<span class="n-fail">1 failed after retry</span>, '
+            "1 skipped.",
+            html,
+        )
+
+
+class DependencyCliTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory(prefix="ringer-deps-cli-")
+        self.addCleanup(self._tmp.cleanup)
+        self.root = Path(self._tmp.name)
+        self.config_path = self.root / "config.toml"
+        self.jsonl_path = self.root / "runs.jsonl"
+        self.state_dir = self.root / "state"
+        self.write_config()
+
+    def write_config(self) -> None:
+        engines = {
+            "write_done": ["-c", "printf done > out.txt"],
+            "write_wrong": ["-c", "printf wrong > out.txt"],
+        }
+        lines = [
+            f'state_dir = "{self.state_dir}"',
+            "dashboard_port_base = 18787",
+            "allow_full_access = false",
+            "",
+            "[eval]",
+            'backend = "jsonl"',
+            f'jsonl_path = "{self.jsonl_path}"',
+            "",
+        ]
+        for name, args_template in engines.items():
+            lines.extend(
+                [
+                    f"[engines.{name}]",
+                    'bin = "/bin/sh"',
+                    f"args_template = {json.dumps(args_template)}",
+                    "sandbox_args = []",
+                    "full_access_args = []",
+                    "token_regex = \"\"",
+                    "",
+                ]
+            )
+        self.config_path.write_text("\n".join(lines), encoding="utf-8")
+
+    def run_cli(self, manifest: Path) -> subprocess.CompletedProcess[str]:
+        cmd = [
+            sys.executable,
+            "-B",
+            str(ROOT / "ringer.py"),
+            "--config",
+            str(self.config_path),
+            "run",
+            str(manifest),
+            "--no-dashboard",
+            "--identity",
+            "test-runner",
+        ]
+        env = os.environ.copy()
+        env["PYTHONDONTWRITEBYTECODE"] = "1"
+        env["RINGER_NO_SELF_UPDATE"] = "1"
+        return subprocess.run(
+            cmd,
+            cwd=ROOT,
+            env=env,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            timeout=30,
+            check=False,
+        )
+
+    def write_manifest(self, name: str, data: dict[str, object]) -> Path:
+        path = self.root / f"{name}.json"
+        path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+        return path
+
+    def final_state(self) -> dict[str, object]:
+        state_files = sorted((self.state_dir / "runs").glob("*.json"))
+        self.assertEqual(1, len(state_files))
+        return json.loads(state_files[0].read_text(encoding="utf-8"))
+
+    def test_serialized_tasks_expose_depends_on_and_blocked_by(self) -> None:
+        path = self.write_manifest(
+            "two-stage",
+            {
+                "run_name": "two-stage",
+                "workdir": str(self.root / "work"),
+                "max_parallel": 1,
+                "tasks": [
+                    {
+                        "key": "producer",
+                        "engine": "write_done",
+                        "spec": "Produce the artifact.",
+                        "expect_files": ["out.txt"],
+                        "check": 'test "$(cat out.txt 2>/dev/null)" = done',
+                    },
+                    {
+                        "key": "qc",
+                        "depends_on": ["producer"],
+                        "engine": "write_done",
+                        "spec": "QC the artifact.",
+                        "expect_files": ["out.txt"],
+                        "check": 'test "$(cat out.txt 2>/dev/null)" = done',
+                    },
+                ],
+            },
+        )
+        result = self.run_cli(path)
+        self.assertEqual(0, result.returncode, result.stdout)
+        state = self.final_state()
+        tasks = {task["key"]: task for task in state["tasks"]}
+        self.assertEqual(["producer"], tasks["qc"]["depends_on"])
+        self.assertEqual([], tasks["qc"]["blocked_by"])
+        self.assertEqual([], tasks["producer"]["depends_on"])
+        self.assertEqual([], tasks["producer"]["blocked_by"])
+        self.assertEqual(2, state["totals"]["done"])
+        self.assertEqual(0, state["totals"]["skipped"])
+
+    def test_skipped_chain_is_counted_separately_in_summary_and_state(self) -> None:
+        path = self.write_manifest(
+            "skip-chain",
+            {
+                "run_name": "skip-chain",
+                "workdir": str(self.root / "work"),
+                "max_parallel": 1,
+                "tasks": [
+                    {
+                        "key": "a",
+                        "engine": "write_wrong",
+                        "spec": "Produce the wrong artifact.",
+                        "expect_files": ["out.txt"],
+                        "check": 'test "$(cat out.txt 2>/dev/null)" = done',
+                    },
+                    {
+                        "key": "b",
+                        "depends_on": ["a"],
+                        "engine": "write_done",
+                        "spec": "Depends on a.",
+                        "expect_files": ["out.txt"],
+                        "check": 'test "$(cat out.txt 2>/dev/null)" = done',
+                    },
+                    {
+                        "key": "c",
+                        "depends_on": ["b"],
+                        "engine": "write_done",
+                        "spec": "Depends on b.",
+                        "expect_files": ["out.txt"],
+                        "check": 'test "$(cat out.txt 2>/dev/null)" = done',
+                    },
+                ],
+            },
+        )
+        result = self.run_cli(path)
+        self.assertEqual(1, result.returncode, result.stdout)
+        self.assertIn("skipped: 2 task(s) did not run because a prerequisite did not pass", result.stdout)
+        state = self.final_state()
+        tasks = {task["key"]: task for task in state["tasks"]}
+        self.assertEqual("fail", tasks["a"]["status"])
+        self.assertEqual("skipped", tasks["b"]["status"])
+        self.assertEqual("skipped", tasks["c"]["status"])
+        self.assertEqual(["a"], tasks["b"]["depends_on"])
+        self.assertEqual(["a"], tasks["b"]["blocked_by"])
+        self.assertEqual(["b"], tasks["c"]["blocked_by"])
+        self.assertEqual(0, tasks["b"]["attempts"])
+        self.assertEqual(0, tasks["c"]["attempts"])
+        self.assertEqual(1, state["summary"]["fail"])
+        self.assertEqual(2, state["summary"]["skipped"])
+        self.assertEqual(2, state["totals"]["skipped"])
+        self.assertEqual(3, state["totals"]["done"])
+
+    def test_invalid_manifests_exit_with_usage_error(self) -> None:
+        cases = [
+            (
+                task_obj("a", depends_on="producer"),
+                "depends_on must be a JSON list",
+            ),
+            (
+                task_obj("a", depends_on=["ghost"]),
+                "references unknown task 'ghost'",
+            ),
+            (
+                task_obj("a", depends_on=["a"]),
+                "cannot depend on itself",
+            ),
+        ]
+        for index, (task, message) in enumerate(cases):
+            with self.subTest(message=message):
+                path = self.write_manifest(
+                    f"invalid-{index}",
+                    {
+                        "run_name": f"invalid-{index}",
+                        "workdir": str(self.root / "work"),
+                        "max_parallel": 1,
+                        "tasks": [task],
+                    },
+                )
+                result = self.run_cli(path)
+                self.assertEqual(2, result.returncode, result.stdout)
+                self.assertIn(message, result.stdout)
+
+    def test_cyclic_manifest_names_the_cycle_keys(self) -> None:
+        path = self.write_manifest(
+            "cycle",
+            {
+                "run_name": "cycle",
+                "workdir": str(self.root / "work"),
+                "max_parallel": 1,
+                "tasks": [
+                    {"key": "build", "spec": "Build.", "check": "true", "depends_on": ["qc"]},
+                    {"key": "qc", "spec": "QC.", "check": "true", "depends_on": ["build"]},
+                ],
+            },
+        )
+        result = self.run_cli(path)
+        self.assertEqual(2, result.returncode, result.stdout)
+        self.assertIn("dependency cycle: build -> qc -> build", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## The problem I hit

Ringer runs tasks as a flat set — everything is eligible at once. I run producer
tasks followed by an independent QC reviewer on a different model family, and
there's no way to say "review this one after it builds."

So every stage becomes two runs with me in the middle, doing nothing but
watching for the first one to finish and then launching the second. The
expensive part isn't the worker tokens, it's the directing model reloading
context to do dispatch work it could have declared up front.

## The change

An optional task field:

```json
{"key": "schema-qc", "depends_on": ["schema-producer"]}
```

- Tasks without `depends_on` behave exactly as they do today.
- A dependent waits **before** acquiring a `max_parallel` slot, never while
  holding one, so a two-stage manifest at `max_parallel: 1` can't deadlock.
- It runs only after every prerequisite reaches a final PASS — a producer that
  fails attempt 1 and passes attempt 2 has passed.
- If a prerequisite doesn't pass, the dependent is `skipped`: no worker
  launched, no attempt consumed, and **no eval row for a model that never ran**.
  Skips propagate down the chain.
- Waiting, `skipped` and `blocked_by` show up truthfully in run state, the
  progress bar, the briefings and the summary.
- Missing keys, self-dependencies, duplicates, non-string entries, bare strings,
  dicts and cycles are all rejected at parse time, with the cycle path named.

Every task publishes its terminal result exactly once from a `finally`, so
preparation failures, timeouts, exhausted attempts, cancellation and unexpected
exceptions release waiters instead of hanging the run.

## Deliberately not in this PR

No cross-run dependencies, no conditional workflow language, no dynamic task
generation, no automatic artifact routing or patch application. `depends_on` is
a control dependency only. Because a passing task's worktree can be removed
before its dependent starts, anything the dependent needs has to be exported by
the producer's check to a durable path outside the worktree — documented beside
the field.

## Proof

- 27 new tests in `tests/test_dependencies.py`, all observed failing before the
  implementation existed.
- Disabling the dependency wait turns 7 of them red, including the fan-in
  ordering test — they detect the feature's absence rather than asserting on end
  status.
- Full suite: `RINGER_NO_SELF_UPDATE=1 python3 -m unittest discover -s tests` —
  280 pass on Python 3.12.
- `git diff --check` clean.
- Also exercised end to end on a real run: a producer that failed left its
  dependent `skipped` with 0 attempts, 0 tokens and no eval row, while a
  separate passing producer released its reviewer normally.
