### PR TITLE
Add run --prove-fail: execute every check against a declared known-bad state

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Each task gets its own directory, its own worker, its own log, and its own verdi
 | `spec` | The prompt handed to the worker |
 | `check` | Shell command run after the worker exits; exit 0 = PASS |
 | `expect_files` | Files that must exist and be non-empty before the check runs |
+| `known_bad` | Optional shell command that mutates the task's scratch dir into a known-bad state; used only by `--prove-fail`; absent means the task has no prove-fail coverage |
 | `engine` | Which configured engine runs this task (default `codex`) |
 | `model` | Which model a harness engine runs for this task — fills the engine's `{model}` placeholder (e.g. `"openrouter/moonshotai/kimi-k2.7"`); empty uses the engine's `model_default` |
 | `task_type` | Optional free-form string naming the kind of work this task is, so the model-performance log can slice pass rates by task shape rather than only by model. Suggested vocabulary: `code-feature`, `code-fix`, `code-review`, `test-hardening`, `docs`, `research`, `persona-review`, `copywriting`, `site-build`, `motion-design`, `image-gen`, `data-pipeline`, `format-conversion`, `probe`, `bakeoff`. Empty is allowed; the log just reports it under `(none)`. |
@@ -168,6 +169,20 @@ Lint reads the manifest; `--baseline` executes it — every task's `check` runs 
 ```
 
 Each check runs in a fresh scratch dir (a detached worktree when the manifest uses worktrees) through the same verifier as a real run. Reading the results: an assertion that demands the NEW behavior workers will build is *expected* to FAIL baseline; an assertion about UNCHANGED behavior that fails baseline is a bug in the check itself, and at run time it would burn a worker's attempts against something no model can satisfy. Fix the check before spawning.
+
+### Prove-fail: prove your checks can catch a lie
+
+`--baseline` catches checks that false-FAIL on a good tree. `--prove-fail` catches the opposite — checks that false-PASS on a bad one. A check proven both ways is worth trusting.
+
+For each task that declares `known_bad`, prove-fail makes a fresh scratch dir (a detached worktree when the manifest uses worktrees), runs the `known_bad` command there to fake a broken deliverable, then runs the task's real `check` against that bad state. The mode spawns no workers and writes no eval rows:
+
+```bash
+./ringer.py run swarm.json --prove-fail
+```
+
+The check FAILING is the good outcome — reported as **proved**, with the check's failure output shown (that output is what a retry prompt would see). A check that PASSES on the known-bad state is **broken**: it cannot be trusted to verify the task. A check that passes while `expect_files` are missing is **inconclusive** — the `known_bad` command must fabricate the deliverables in bad form for the test to mean anything. A `known_bad` command that itself fails or times out is an **error**. Tasks without `known_bad` are **skipped**; coverage is opt-in per task.
+
+The summary reads `prove-fail: P proved, B broken, I inconclusive, E error, S skipped of T task(s).` Exit code is 0 only when broken, inconclusive, and error are all zero — unlike `--baseline` (always 0, judgment left to you), a check that passes on a known-bad state is objectively broken. The two flags cannot be combined in one invocation.
 
 ## Make your agent actually use this
 
@@ -392,6 +407,7 @@ Every community PR that lands in main is credited here — that's a project rule
 - [@davekopecek](https://github.com/davekopecek) (Dave Kopecek) — committed the design-reference fixture so the design-token guard runs on every machine (#30)
 - [@snapsynapse](https://github.com/snapsynapse) (Sam Rogers) — graceful shutdown on SIGINT/SIGTERM with worker-tree cleanup and finished state, plus the 14-test end-to-end CLI regression suite (#4)
 - [@mlava](https://github.com/mlava) (Mark Lavercombe) — named setup failures across every diagnostic surface (#37) and `run --baseline`, the no-workers check preflight (#38)
+- [@heyjawrsh](https://github.com/heyjawrsh) (Joshua Butner) — `run --prove-fail`, the known-bad mirror of `--baseline` (#104)
 
 Contributions are welcome — see [CONTRIBUTING.md](CONTRIBUTING.md) for the philosophy and what gets a PR merged fast. The short version: small and scoped, rebased on current main, every claim backed by an executed test. Authorship is always preserved — where a maintainer pushes a mechanical fix to your branch, you remain the commit author.
 

--- a/ringer.py
+++ b/ringer.py
@@ -1630,6 +1630,7 @@ class TaskSpec:
     key: str
     spec: str
     check: str
+    known_bad: str = ""
     engine: str = DEFAULT_ENGINE_NAME
     expect_files: tuple[str, ...] = ()
     timeout_s: int = DEFAULT_TIMEOUT_S
@@ -1661,6 +1662,9 @@ class TaskSpec:
             raise ValueError(f"task {key}: check must be a string")
         if not check:
             raise ValueError(f"task {key}: check is required")
+        known_bad = obj.get("known_bad", "")
+        if not isinstance(known_bad, str):
+            raise ValueError(f"task {key}: known_bad must be a string")
         expect_files = obj.get("expect_files", [])
         if not isinstance(expect_files, list):
             raise ValueError(f"task {key}: expect_files must be a list")
@@ -1698,6 +1702,7 @@ class TaskSpec:
             key=key,
             spec=spec,
             check=check,
+            known_bad=known_bad.strip(),
             engine=engine,
             expect_files=tuple(str(item) for item in expect_files),
             timeout_s=timeout_s,
@@ -9971,6 +9976,189 @@ async def run_baseline(manifest: Manifest, *, config: AppConfig) -> int:
     return 0
 
 
+async def run_prove_fail(manifest: Manifest, *, config: AppConfig) -> int:
+    """Execute each task's CHECK against its declared known-bad tree. Spawn nothing.
+
+    The point: a check that passes after known_bad establishes the failure it
+    claims to detect cannot be trusted at run time. Running that experiment
+    in a fresh scratch taskdir proves the check produces useful failure
+    evidence before any worker spends an attempt on the task.
+
+    Checks run for real through the same verifier as a live run. Each covered
+    task gets a fresh scratch taskdir (a detached worktree when the manifest
+    uses worktrees), removed afterwards, so no known-bad state leaks into a
+    later run.
+    """
+    del config  # engines are irrelevant: prove-fail spawns no workers
+    verifier = Verifier()
+    worktrees = manifest.worktrees and manifest.repo is not None
+    prove_fail_root = Path(tempfile.mkdtemp(prefix="ringer-provefail-"))
+    total = len(manifest.tasks)
+    print(f"Prove-fail: executing {total} known-bad check(s) with no workers spawned.")
+    proved = 0
+    broken = 0
+    inconclusive = 0
+    errors = 0
+    skipped = 0
+    leaked_worktrees: list[str] = []
+    try:
+        for task in manifest.tasks:
+            if not task.known_bad:
+                skipped += 1
+                print(f"{task.key:<24} prove-fail: skipped (no known_bad)")
+                continue
+            taskdir = (prove_fail_root / task.key).resolve()
+            # Same containment rule as the real run path: a key must not
+            # escape its scratch root.
+            if (
+                not taskdir.is_relative_to(prove_fail_root.resolve())
+                or taskdir == prove_fail_root.resolve()
+            ):
+                errors += 1
+                print(
+                    f"{task.key:<24} prove-fail: ERROR "
+                    "(task key escapes the prove-fail scratch root)"
+                )
+                continue
+            if worktrees:
+                proc = await asyncio.create_subprocess_exec(
+                    "git",
+                    "-C",
+                    str(manifest.repo),
+                    "worktree",
+                    "add",
+                    "--detach",
+                    str(taskdir),
+                    "HEAD",
+                    stdin=asyncio.subprocess.DEVNULL,
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.STDOUT,
+                )
+                stdout, _ = await proc.communicate()
+                if proc.returncode != 0:
+                    errors += 1
+                    print(f"{task.key:<24} prove-fail: ERROR (git worktree add failed)")
+                    message = stdout.decode("utf-8", errors="replace").strip()
+                    for line in message.splitlines()[:4]:
+                        print(f"    {line}")
+                    continue
+            else:
+                taskdir.mkdir(parents=True, exist_ok=True)
+            try:
+                proc = await asyncio.create_subprocess_shell(
+                    task.known_bad,
+                    cwd=str(taskdir),
+                    stdin=asyncio.subprocess.DEVNULL,
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.STDOUT,
+                    start_new_session=True,
+                )
+                known_bad_timed_out = False
+                try:
+                    stdout, _ = await asyncio.wait_for(
+                        proc.communicate(), timeout=task.timeout_s
+                    )
+                except asyncio.TimeoutError:
+                    known_bad_timed_out = True
+                    terminate_process_group(proc)
+                    try:
+                        stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=5)
+                    except asyncio.TimeoutError:
+                        kill_process_group(proc)
+                        stdout, _ = await proc.communicate()
+                known_bad_output = (
+                    stdout.decode("utf-8", errors="replace") if stdout else ""
+                )
+                if known_bad_timed_out:
+                    known_bad_output += (
+                        f"\n[ringer.py] known_bad timed out after {task.timeout_s}s\n"
+                    )
+                if known_bad_timed_out or proc.returncode != 0:
+                    errors += 1
+                    detail = "timed out" if known_bad_timed_out else f"rc={proc.returncode}"
+                    print(
+                        f"{task.key:<24} prove-fail: ERROR "
+                        f"(bad state could not be established; {detail})"
+                    )
+                    for line in known_bad_output.strip().splitlines()[:6]:
+                        print(f"    {line}")
+                    continue
+
+                verify = await verifier.verify(task, taskdir)
+                if verify.ok:
+                    broken += 1
+                    print(
+                        f"{task.key:<24} prove-fail: BROKEN "
+                        "(check passed on a known-bad state)"
+                    )
+                elif verify.check_timed_out:
+                    proved += 1
+                    print(
+                        f"{task.key:<24} prove-fail: proved "
+                        f"(rc={verify.check_returncode}, timed out)"
+                    )
+                    for line in verify.raw_output_excerpt.strip().splitlines()[:6]:
+                        print(f"    {line}")
+                    print("    WARNING: a timeout makes useless retry output.")
+                elif verify.check_returncode == 0:
+                    inconclusive += 1
+                    print(
+                        f"{task.key:<24} prove-fail: inconclusive "
+                        "(check never caught the bad state; known_bad must fabricate "
+                        "the deliverables in bad form)"
+                    )
+                else:
+                    proved += 1
+                    print(
+                        f"{task.key:<24} prove-fail: proved "
+                        f"(rc={verify.check_returncode})"
+                    )
+                    for line in verify.raw_output_excerpt.strip().splitlines()[:6]:
+                        print(f"    {line}")
+            finally:
+                if worktrees:
+                    proc = await asyncio.create_subprocess_exec(
+                        "git",
+                        "-C",
+                        str(manifest.repo),
+                        "worktree",
+                        "remove",
+                        "--force",
+                        str(taskdir),
+                        stdin=asyncio.subprocess.DEVNULL,
+                        stdout=asyncio.subprocess.PIPE,
+                        stderr=asyncio.subprocess.STDOUT,
+                    )
+                    stdout, _ = await proc.communicate()
+                    if proc.returncode != 0:
+                        # A clean summary must not hide leaked worktree state.
+                        leaked_worktrees.append(str(taskdir))
+                        message = stdout.decode("utf-8", errors="replace").strip()
+                        print(
+                            f"{task.key:<24} prove-fail: WARNING "
+                            f"(worktree remove failed, leaked {taskdir})"
+                        )
+                        for line in message.splitlines()[:2]:
+                            print(f"    {line}")
+    finally:
+        shutil.rmtree(prove_fail_root, ignore_errors=True)
+    print(
+        f"\nprove-fail: {proved} proved, {broken} broken, "
+        f"{inconclusive} inconclusive, {errors} error, {skipped} skipped "
+        f"of {total} task(s)."
+    )
+    if leaked_worktrees:
+        print(
+            f"WARNING: {len(leaked_worktrees)} prove-fail worktree(s) could not be removed; "
+            f"clean up with `git -C {shlex.quote(str(manifest.repo))} worktree prune` after "
+            "removing the directories above."
+        )
+    # Unlike baseline, there is no judgment to defer: a pass on a known-bad
+    # state is objectively broken. Setup errors and inconclusive coverage are
+    # also not successful proof.
+    return 0 if broken == inconclusive == errors == 0 else 1
+
+
 def append_text(path: Path, text: str) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     with path.open("a", encoding="utf-8") as fh:
@@ -10815,6 +11003,15 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
     run_parser.add_argument(
+        "--prove-fail",
+        action="store_true",
+        help=(
+            "execute every task's CHECK against its declared known-bad state and "
+            "report, spawning no workers — a check that passes on known-bad work "
+            "cannot be trusted"
+        ),
+    )
+    run_parser.add_argument(
         "--allow-noncanonical-route",
         action="store_true",
         help="allow a registry-marked noncanonical model route for a deliberate bakeoff",
@@ -11004,6 +11201,17 @@ def main(argv: list[str] | None = None) -> int:
     parse_argv = [value for value in invocation_argv[1:] if value != "--no-self-update"]
     args = parser.parse_args(parse_argv)
     try:
+        if (
+            args.command == "run"
+            and getattr(args, "baseline", False)
+            and getattr(args, "prove_fail", False)
+        ):
+            print(
+                "ringer.py: error: --baseline and --prove-fail answer different "
+                "questions; run them separately.",
+                file=sys.stderr,
+            )
+            return 2
         if args.command == "self-update":
             config = AppConfig.load(args.config)
             result = perform_self_update(
@@ -11108,6 +11316,10 @@ def main(argv: list[str] | None = None) -> int:
             # Deliberately before preflight_engine_bins: baseline spawns no
             # workers, so a missing engine binary must not block it.
             return asyncio.run(run_baseline(manifest, config=config))
+        if getattr(args, "prove_fail", False):
+            # Deliberately before preflight_engine_bins: prove-fail spawns no
+            # workers, so a missing engine binary must not block it.
+            return asyncio.run(run_prove_fail(manifest, config=config))
         preflight_engine_bins(manifest, config)
         if args.command == "run":
             start_catalog_auto_refresh()

--- a/tests/test_prove_fail_mode.py
+++ b/tests/test_prove_fail_mode.py
@@ -1,0 +1,369 @@
+#!/usr/bin/env python3
+"""`run --prove-fail` executes checks against declared known-bad states.
+
+Pinned here:
+  * a check that rejects known-bad work is proved and exits successfully
+  * a check that accepts known-bad work is BROKEN and exits nonzero
+  * missing coverage is skipped, while failed setup is an error
+  * no workers spawn — a deliberately broken engine binary must not matter
+  * baseline and prove-fail cannot run together
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def toml_string(value: object) -> str:
+    return json.dumps(str(value))
+
+
+def init_git_repo(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    (path / "README.md").write_text("hello prove-fail\n", encoding="utf-8")
+    env = os.environ.copy()
+    env.update(
+        {
+            "GIT_AUTHOR_NAME": "test",
+            "GIT_AUTHOR_EMAIL": "test@example.com",
+            "GIT_COMMITTER_NAME": "test",
+            "GIT_COMMITTER_EMAIL": "test@example.com",
+        }
+    )
+    for args in (
+        ["git", "-C", str(path), "init", "--quiet"],
+        ["git", "-C", str(path), "add", "README.md"],
+        [
+            "git",
+            "-C",
+            str(path),
+            "-c",
+            "commit.gpgsign=false",
+            "commit",
+            "--quiet",
+            "-m",
+            "init",
+        ],
+    ):
+        subprocess.run(args, check=True, env=env, capture_output=True)
+
+
+class ProveFailModeTests(unittest.TestCase):
+    def run_ringer(
+        self,
+        root: Path,
+        tasks: list[dict[str, object]],
+        *mode_args: str,
+        worktrees: bool = False,
+    ) -> tuple[subprocess.CompletedProcess[str], Path, Path, Path | None]:
+        home = root / "home"
+        ringer_home = root / "ringer-home"
+        state_dir = root / "state"
+        workdir = root / "work"
+        config_path = root / "config.toml"
+        manifest_path = root / "manifest.json"
+        model_log = root / "runs.jsonl"
+        repo = root / "repo" if worktrees else None
+
+        home.mkdir()
+        ringer_home.mkdir()
+        if repo is not None:
+            init_git_repo(repo)
+
+        # The engine binary does not exist. Prove-fail must neither spawn it
+        # nor be blocked by the startup engine preflight.
+        config_path.write_text(
+            "\n".join(
+                [
+                    f"state_dir = {toml_string(state_dir)}",
+                    "",
+                    "[eval]",
+                    'backend = "jsonl"',
+                    f"jsonl_path = {toml_string(model_log)}",
+                    "",
+                    "[artifact]",
+                    "enabled = false",
+                    "",
+                    "[engines.missing]",
+                    'bin = "/nonexistent/engine-binary"',
+                    "args_template = [",
+                    '  "{spec}",',
+                    "]",
+                    "sandbox_args = []",
+                    "full_access_args = []",
+                    "",
+                ]
+            ),
+            encoding="utf-8",
+        )
+        manifest: dict[str, object] = {
+            "run_name": "prove-fail-test",
+            "workdir": str(workdir),
+            "max_parallel": 2,
+            "worktrees": worktrees,
+            "tasks": tasks,
+        }
+        if repo is not None:
+            manifest["repo"] = str(repo)
+        manifest_path.write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+
+        env = os.environ.copy()
+        env["HOME"] = str(home)
+        env["RINGER_HOME"] = str(ringer_home)
+        env["XDG_CONFIG_HOME"] = str(root / "xdg-config")
+        env["RINGER_NO_SELF_UPDATE"] = "1"
+        proc = subprocess.run(
+            [
+                sys.executable,
+                "ringer.py",
+                "run",
+                str(manifest_path),
+                "--config",
+                str(config_path),
+                "--no-dashboard",
+                *mode_args,
+            ],
+            cwd=ROOT,
+            env=env,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+            timeout=30,
+        )
+        return proc, model_log, workdir, repo
+
+    def test_proved_check_exits_zero_without_spawning_workers(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_root:
+            root = Path(temp_root)
+            proc, model_log, workdir, repo = self.run_ringer(
+                root,
+                [
+                    {
+                        "key": "corrupt-file",
+                        "engine": "missing",
+                        "spec": "Replace the corrupt artifact with clean content.",
+                        "known_bad": "printf 'corrupt\\n' > artifact.txt",
+                        "check": (
+                            "grep -q '^clean$' artifact.txt || "
+                            "{ echo FAIL: expected clean content; exit 1; }"
+                        ),
+                    }
+                ],
+                "--prove-fail",
+                worktrees=True,
+            )
+            output = proc.stdout + proc.stderr
+
+            self.assertEqual(0, proc.returncode, output)
+            self.assertRegex(
+                output,
+                re.compile(r"^corrupt-file\s+prove-fail: proved \(rc=1\)", re.MULTILINE),
+                output,
+            )
+            self.assertIn("FAIL: expected clean content", output)
+            self.assertIn(
+                "prove-fail: 1 proved, 0 broken, 0 inconclusive, 0 error, "
+                "0 skipped of 1 task(s).",
+                output,
+            )
+            self.assertFalse(model_log.exists(), "prove-fail wrote model-log rows")
+            self.assertFalse((root / "state").exists(), "prove-fail wrote run state")
+            self.assertFalse(
+                (workdir / "corrupt-file").exists(),
+                "prove-fail leaked a taskdir into the manifest workdir",
+            )
+            assert repo is not None
+            worktree_list = subprocess.run(
+                ["git", "-C", str(repo), "worktree", "list"],
+                capture_output=True,
+                text=True,
+                check=True,
+            ).stdout.strip()
+            self.assertEqual(
+                1,
+                len(worktree_list.splitlines()),
+                f"prove-fail leaked worktrees:\n{worktree_list}",
+            )
+
+    def test_check_that_cannot_fail_is_broken(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_root:
+            proc, model_log, _, _ = self.run_ringer(
+                Path(temp_root),
+                [
+                    {
+                        "key": "false-pass",
+                        "engine": "missing",
+                        "spec": "A worker would repair the bad state.",
+                        "known_bad": "printf 'bad\\n' > artifact.txt",
+                        "check": "true",
+                    }
+                ],
+                "--prove-fail",
+            )
+            output = proc.stdout + proc.stderr
+
+            self.assertNotEqual(0, proc.returncode, output)
+            self.assertRegex(
+                output,
+                re.compile(r"^false-pass\s+prove-fail: BROKEN", re.MULTILINE),
+                output,
+            )
+            self.assertIn("check passed on a known-bad state", output)
+            self.assertIn("0 proved, 1 broken", output)
+            self.assertFalse(model_log.exists(), "prove-fail wrote model-log rows")
+
+    def test_task_without_known_bad_is_skipped(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_root:
+            proc, _, _, _ = self.run_ringer(
+                Path(temp_root),
+                [
+                    {
+                        "key": "uncovered",
+                        "engine": "missing",
+                        "spec": "This task has no prove-fail coverage yet.",
+                        "check": "true",
+                    }
+                ],
+                "--prove-fail",
+            )
+            output = proc.stdout + proc.stderr
+
+            self.assertEqual(0, proc.returncode, output)
+            self.assertRegex(
+                output,
+                re.compile(
+                    r"^uncovered\s+prove-fail: skipped \(no known_bad\)",
+                    re.MULTILINE,
+                ),
+                output,
+            )
+            self.assertIn("0 error, 1 skipped of 1 task(s).", output)
+
+    def test_failing_known_bad_is_an_error(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_root:
+            proc, _, _, _ = self.run_ringer(
+                Path(temp_root),
+                [
+                    {
+                        "key": "bad-setup",
+                        "engine": "missing",
+                        "spec": "A worker would repair the bad state.",
+                        "known_bad": "echo could-not-create-bad-state; exit 7",
+                        "check": "false",
+                    }
+                ],
+                "--prove-fail",
+            )
+            output = proc.stdout + proc.stderr
+
+            self.assertNotEqual(0, proc.returncode, output)
+            self.assertRegex(
+                output,
+                re.compile(
+                    r"^bad-setup\s+prove-fail: ERROR "
+                    r"\(bad state could not be established; rc=7\)",
+                    re.MULTILINE,
+                ),
+                output,
+            )
+            self.assertIn("could-not-create-bad-state", output)
+            self.assertIn("0 inconclusive, 1 error, 0 skipped", output)
+
+    def test_missing_deliverable_with_successful_check_is_inconclusive(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_root:
+            proc, _, _, _ = self.run_ringer(
+                Path(temp_root),
+                [
+                    {
+                        "key": "missing-bad-deliverable",
+                        "engine": "missing",
+                        "spec": "A worker would create a valid deliverable.",
+                        "known_bad": "true",
+                        "check": "true",
+                        "expect_files": ["artifact.txt"],
+                    }
+                ],
+                "--prove-fail",
+            )
+            output = proc.stdout + proc.stderr
+
+            self.assertNotEqual(0, proc.returncode, output)
+            self.assertRegex(
+                output,
+                re.compile(
+                    r"^missing-bad-deliverable\s+prove-fail: inconclusive",
+                    re.MULTILINE,
+                ),
+                output,
+            )
+            self.assertIn("check never caught the bad state", output)
+            self.assertIn(
+                "known_bad must fabricate the deliverables in bad form", output
+            )
+            self.assertIn("0 broken, 1 inconclusive", output)
+
+    def test_known_bad_must_be_a_string(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_root:
+            proc, _, _, _ = self.run_ringer(
+                Path(temp_root),
+                [
+                    {
+                        "key": "invalid-known-bad",
+                        "engine": "missing",
+                        "spec": "This manifest field is malformed.",
+                        "known_bad": ["false"],
+                        "check": "false",
+                    }
+                ],
+                "--prove-fail",
+            )
+            output = proc.stdout + proc.stderr
+
+            self.assertNotEqual(0, proc.returncode, output)
+            self.assertIn(
+                "task invalid-known-bad: known_bad must be a string", output
+            )
+
+    def test_baseline_and_prove_fail_must_run_separately(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_root:
+            root = Path(temp_root)
+            bad_marker = root / "known-bad-ran"
+            check_marker = root / "check-ran"
+            proc, _, _, _ = self.run_ringer(
+                root,
+                [
+                    {
+                        "key": "conflict",
+                        "engine": "missing",
+                        "spec": "Neither mode should execute this task.",
+                        "known_bad": f"touch {bad_marker}",
+                        "check": f"touch {check_marker}",
+                    }
+                ],
+                "--baseline",
+                "--prove-fail",
+            )
+            output = proc.stdout + proc.stderr
+
+            self.assertNotEqual(0, proc.returncode, output)
+            self.assertEqual(1, len(output.strip().splitlines()), output)
+            self.assertIn(
+                "--baseline and --prove-fail answer different questions; "
+                "run them separately",
+                output,
+            )
+            self.assertFalse(bad_marker.exists(), "prove-fail ran despite flag conflict")
+            self.assertFalse(check_marker.exists(), "baseline ran despite flag conflict")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
A check of mine passed against a state I had deliberately broken — it grepped a README that already contained the words from earlier work, so it could not tell new material from old. --baseline had nothing to say about it: baseline proves a check does not false-FAIL on an unmodified tree, and nothing proved the mirror. 

--prove-fail is that mirror. Each task may declare known_bad, a shell command that mutates its scratch dir into the failure the check claims to detect. The mode runs it, then runs the task's real check against that state, in a fresh scratch dir (a detached worktree when the manifest uses worktrees). The check failing is the good outcome — reported as proved, with the failure output shown, since that output is what a retry prompt receives. A check that passes on known-bad work is reported BROKEN. 

Unlike --baseline, exit is nonzero when anything is broken, inconclusive, or errored: a pass on a known-bad state is not a judgment call to defer. The two flags refuse to run together — they answer different questions. Spawns no workers, writes no eval rows. 

Tests: tests/test_prove_fail_mode.py, seven hermetic cases (proved, broken, skipped, failing known_bad, inconclusive, field validation, flag conflict), modeled on test_baseline_mode.py —nonexistent engine binary so nothing can spawn, RINGER_NO_SELF_UPDATE=1. Full suite green on macOS. Rebased on current main.