### PR TITLE
Lint: reject a manifest naming an engine that is not configured

### DIFF
--- a/ringer.py
+++ b/ringer.py
@@ -1814,6 +1814,22 @@ def lint_manifest(
     if manifest.run_name == MODEL_SCOREBOARD_RUN_NAME:
         findings.append("manifest: run_name model-scoreboard is reserved for the scoreboard page.")
 
+    # An engine name that resolves to nothing is the one manifest error that
+    # costs a whole dispatch to discover: `run` fails at spawn time, once the
+    # run row, the worktree and the dashboard entry already exist. Lint used to
+    # call a manifest naming `no-such-engine-xyz` clean, because nothing here
+    # ever looked the name up: the only code that touched it,
+    # noncanonical_route_findings, does a `.get()` that returns None and then
+    # `continue`s, so an unknown engine took the quiet path out.
+    if config is not None:
+        known = ", ".join(sorted(config.engines))
+        for task in manifest.tasks:
+            if task.engine not in config.engines:
+                findings.append(
+                    f"ERROR: {task.key}: engine {task.engine!r} is not configured; "
+                    f"engines available here: {known}."
+                )
+
     for task in manifest.tasks:
         if check_cannot_fail(task.check):
             findings.append(f"{task.key}: check cannot fail, so the task cannot be verified.")
@@ -10925,6 +10941,9 @@ def build_parser() -> argparse.ArgumentParser:
 
     lint_parser = subparsers.add_parser("lint", help="lint a ringer manifest")
     lint_parser.add_argument("manifest", type=Path, help="path to ringer.json")
+    # Lint reads the config now (engine names, model routes), so it takes the
+    # same suppressed --config every other config-consuming command takes.
+    lint_parser.add_argument("--config", type=Path, default=argparse.SUPPRESS, help=argparse.SUPPRESS)
     lint_parser.add_argument(
         "--allow-noncanonical-route",
         action="store_true",
@@ -11039,10 +11058,33 @@ def main(argv: list[str] | None = None) -> int:
 
         if args.command == "lint":
             manifest = Manifest.from_path(args.manifest)
+            # Lint ran with config=None until 2026-08-15 - the shared
+            # `AppConfig.load` below sits AFTER this branch returns. That made
+            # two checks vacuous at once: engine names were never resolvable,
+            # and noncanonical_route_findings fell back to the identity
+            # registry's defaults instead of the engine's real model_default
+            # for every task that does not name a model. Load it here.
+            lint_config: AppConfig | None
+            config_error = ""
+            try:
+                lint_config = AppConfig.load(args.config)
+            except Exception as exc:  # noqa: BLE001 - reported, not swallowed
+                lint_config = None
+                config_error = str(exc)
             findings = lint_manifest(
                 manifest,
+                config=lint_config,
                 allow_noncanonical_route=args.allow_noncanonical_route,
             )
+            if config_error:
+                # Say so rather than degrade quietly: without a config the
+                # engine and route checks did not run, and a bare "clean" would
+                # claim more than was actually checked.
+                findings.insert(
+                    0,
+                    f"ERROR: manifest: ringer config could not be loaded ({config_error}); "
+                    "engine names and model routes were NOT checked.",
+                )
             if findings:
                 print_lint_findings(findings)
                 return 1

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -2,6 +2,9 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
+import io
+import json
 import os
 import sys
 import tempfile
@@ -11,7 +14,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
-from ringer import Manifest, TaskSpec, Verifier, lint_manifest  # noqa: E402
+from ringer import AppConfig, Manifest, TaskSpec, Verifier, lint_manifest, main  # noqa: E402
 
 
 LONG_SPEC = (
@@ -309,6 +312,127 @@ class LintManifestTests(unittest.TestCase):
                 manifest = Manifest.from_path(path)
                 findings = lint_manifest(manifest)
                 self.assertEqual([], findings, f"{path} should lint clean, got: {findings}")
+
+
+class UnknownEngineLintTests(unittest.TestCase):
+    """`ringer lint` called a manifest naming a nonexistent engine clean.
+
+    Two separate holes, and the second is the one that made the first
+    invisible: `lint_manifest` never resolved the engine name at all, AND the
+    `lint` CLI branch returned before the shared `AppConfig.load`, so even a
+    correct check would have run with `config=None` and found nothing.
+    Both halves are pinned here, and each guard is exercised in BOTH
+    directions - a guard only proven to block is indistinguishable from one
+    welded shut.
+    """
+
+    def config_with(self, *engines: str) -> AppConfig:
+        path = self.write_config(*engines)
+        return AppConfig.load(path)
+
+    def write_config(self, *engines: str) -> Path:
+        temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(temp_dir.cleanup)
+        path = Path(temp_dir.name) / "config.toml"
+        body = "".join(
+            f'[engines.{name}]\nbin = "{name}"\nargs_template = ["{{spec}}"]\n\n' for name in engines
+        )
+        path.write_text(body, encoding="utf-8")
+        return path
+
+    def manifest_using(self, engine: str) -> Manifest:
+        temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(temp_dir.cleanup)
+        return Manifest.from_obj(
+            {
+                "run_name": "engine-lint-test",
+                "workdir": str(Path(temp_dir.name) / "work"),
+                "max_parallel": 1,
+                "tasks": [
+                    {
+                        "key": "one",
+                        "engine": engine,
+                        "spec": LONG_SPEC,
+                        "check": GOOD_CHECK,
+                        "expect_files": ["output.txt"],
+                        "verified": "the output file exists and contains the expected content",
+                    }
+                ],
+            }
+        )
+
+    def engine_findings(self, findings: list[str]) -> list[str]:
+        return [f for f in findings if "is not configured" in f]
+
+    def test_unknown_engine_is_reported(self) -> None:
+        findings = lint_manifest(self.manifest_using("no-such-engine-xyz"), config=self.config_with("cline"))
+        self.assertEqual(1, len(self.engine_findings(findings)), findings)
+        self.assertIn("no-such-engine-xyz", self.engine_findings(findings)[0])
+        # The message must name what IS available, so a config that failed to
+        # load is diagnosable from the finding alone.
+        self.assertIn("cline", self.engine_findings(findings)[0])
+
+    def test_configured_engine_is_not_reported(self) -> None:
+        # The half that proves the guard is not welded shut.
+        findings = lint_manifest(self.manifest_using("cline"), config=self.config_with("cline"))
+        self.assertEqual([], self.engine_findings(findings), findings)
+
+    def test_check_is_vacuous_without_config(self) -> None:
+        # Documents WHY the CLI must load the config: with config=None the
+        # check cannot fire at all, which is exactly how the bug survived.
+        findings = lint_manifest(self.manifest_using("no-such-engine-xyz"))
+        self.assertEqual([], self.engine_findings(findings), findings)
+
+    def run_lint_cli(self, engine: str, config_path: Path) -> tuple[int, str]:
+        manifest_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(manifest_dir.cleanup)
+        manifest_path = Path(manifest_dir.name) / "manifest.json"
+        manifest_path.write_text(
+            json.dumps(
+                {
+                    "run_name": "engine-lint-cli",
+                    "workdir": str(Path(manifest_dir.name) / "work"),
+                    "max_parallel": 1,
+                    "tasks": [
+                        {
+                            "key": "one",
+                            "engine": engine,
+                            "spec": LONG_SPEC,
+                            "check": GOOD_CHECK,
+                            "expect_files": ["output.txt"],
+                            "verified": "the output file exists and contains the expected content",
+                        }
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+        previous = os.environ.get("RINGER_NO_SELF_UPDATE")
+        os.environ["RINGER_NO_SELF_UPDATE"] = "1"
+        buffer = io.StringIO()
+        try:
+            with contextlib.redirect_stdout(buffer):
+                code = main(["lint", str(manifest_path), "--config", str(config_path)])
+        finally:
+            if previous is None:
+                os.environ.pop("RINGER_NO_SELF_UPDATE", None)
+            else:
+                os.environ["RINGER_NO_SELF_UPDATE"] = previous
+        return code, buffer.getvalue()
+
+    def test_cli_lint_loads_the_config(self) -> None:
+        # The wiring test. lint_manifest can be perfectly correct while the CLI
+        # keeps passing config=None, which is the state this fix found.
+        config_path = self.write_config("cline")
+        code, output = self.run_lint_cli("no-such-engine-xyz", config_path)
+        self.assertEqual(1, code, output)
+        self.assertIn("is not configured", output)
+
+    def test_cli_lint_stays_clean_on_a_configured_engine(self) -> None:
+        config_path = self.write_config("cline")
+        code, output = self.run_lint_cli("cline", config_path)
+        self.assertEqual(0, code, output)
+        self.assertIn("lint: clean", output)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Burned a whole dispatch discovering a typo in an engine name. `lint` said
`clean`, `run` then failed at spawn time — after the run row, the worktree and
the dashboard entry already existed. The manifest was generated by a tool of
mine, so the same wrong name would have come back every time until I read the
spawn error closely enough to recognise it as a name problem rather than a
missing binary.

`lint` is the cheap gate that exists to catch exactly this before a dispatch is
paid for, and on this input it certified nothing:

```
$ ./ringer.py lint probe.json          # main @ a1a91b8
lint: clean (1 tasks)
$ echo $?
0
```

That manifest names `no-such-engine-xyz`. It cannot run.

## Two holes, and the second is what made the first invisible

**1. `lint_manifest` never resolved `task.engine` against the config.** The only
code that touches the name is `noncanonical_route_findings`, and an unknown name
takes the quiet path out of it — `config.engines.get(task.engine)` returns
`None`, `model_key` falls through to `identity_registry.defaults.get(...)` → `""`,
`noncanonical_routes.get((engine, ""))` → `None` → `continue` (ringer.py
6376-6382). No finding, by construction.

**2. The `lint` CLI branch returned before the shared `AppConfig.load`.** The
branch ends at 11090/11092; the shared load is at 11097. So `lint_manifest` was
always called with `config=None` — the parameter was already in its signature
and was simply never fed from the CLI. A correct check added in (1) alone would
still have found nothing.

That second hole also silently degraded a check that already shipped: with
`config=None`, `noncanonical_route_findings` falls back to the identity
registry's defaults instead of the engine's real `model_default`, for every task
that does not name a model explicitly.

## What this does

- Resolves each task's engine against `config.engines`, and reports an unknown
  one naming the engines that *are* available — so the finding is diagnosable on
  its own, without a second round-trip to the config.
- Loads the config in the `lint` branch, via the same suppressed `--config`
  argument `run`, `hud`, `db`, `models` and `demo` already take (the main parser
  supplies the default; `argparse.SUPPRESS` on the subparser keeps it from being
  clobbered). No new flag surface.
- If the config cannot be loaded, says so as the first finding rather than
  degrading quietly — a bare `clean` would otherwise claim more than was
  actually checked.

Same manifest, with this change:

```
$ ./ringer.py lint probe.json
lint: ERROR: one: engine 'no-such-engine-xyz' is not configured; engines available here: claude, cline, codex, copilot.
$ echo $?
1
```

## On "one fix per PR" — this has an `and`, deliberately

The check and the config wiring cannot be split into two mergeable PRs: the
check without the wiring is dead code that can never fire, and the wiring
without the check has no observable effect on its own. They are one defect —
`lint` runs configless — seen from two ends. Splitting would mean landing a
provably vacuous guard first, which is the failure mode the second half exists
to prevent.

## Proof

`tests/test_lint.py` gains five tests, each guard exercised in **both**
directions, because a guard only shown to block is indistinguishable from one
welded shut:

| Test | Pins |
|---|---|
| `test_unknown_engine_is_reported` | the finding fires and names what is available |
| `test_configured_engine_is_not_reported` | a valid engine is **not** flagged |
| `test_check_is_vacuous_without_config` | documents *why* the wiring is required — with `config=None` the check cannot fire at all |
| `test_cli_lint_loads_the_config` | the wiring itself: fails if the CLI goes back to `config=None` |
| `test_cli_lint_stays_clean_on_a_configured_engine` | the CLI path exits 0 on a good manifest |

Mutation-proved in both halves: neutering the check reddens two tests, dropping
the config load reddens one, restoring both goes green. The before/after above
is the real CLI against a real config, not a fixture.

## Notes for review

- **Rebased on `a1a91b8`**, current `main`.
- **Overlap with #95.** That PR touches the same two files for a different
  concern (check parseability vs. engine identity). A textual conflict in
  `lint_manifest`'s findings block and in `test_lint.py`'s import line is
  likely. Happy to rebase whichever lands second — no objection to #95 going
  first.
- **Related to #43** ("warn at config load when an engine bin is not
  resolvable") but at a different layer: #43 is a configured engine whose binary
  will not resolve, this is a name that is not a configured engine at all. They
  are complementary; neither catches the other's case.
- **Platform honesty.** Developed and run on Windows. `tests/test_lint.py` has
  two failures on this box — `test_verifier_expands_user_expect_files` and
  `test_w6_write_collision` — which reproduce **identically on pristine
  `a1a91b8`** (14 tests / 2 failures before, 19 tests / the same 2 after), so
  they are pre-existing and path-shaped rather than anything this change did. I
  make no POSIX claim beyond what the macOS and Linux jobs prove; the new tests
  are stdlib-only, spawn no shell, and call `main()` in-process with
  `RINGER_NO_SELF_UPDATE=1` set.
- Scope is one concern, two files, additions only. It inspects the manifest the
  operator wrote, not the worker — squarely "verify outputs", not confinement.
