### PR TITLE
fix(engines): add XXXXXX suffix to mktemp calls in opencode sandboxed engine

### DIFF
--- a/engines/opencode-sandboxed.sh
+++ b/engines/opencode-sandboxed.sh
@@ -43,8 +43,8 @@ TASKDIR_REAL="$(cd "$TASKDIR" && pwd -P)"
 # we never have to open all of /private/tmp or ~/.cache to the sandboxed agent.
 # Resolve to the real path (/var/folders symlinks to /private/var/folders);
 # Seatbelt subpath matching needs the canonical path or writes EPERM-crash.
-SCRATCH="$(cd "$(mktemp -d -t ringer-opencode-scratch)" && pwd -P)"
-PROFILE="$(mktemp -t ringer-opencode-prof)"
+SCRATCH="$(cd "$(mktemp -d -t ringer-opencode-scratch.XXXXXX)" && pwd -P)"
+PROFILE="$(mktemp -t ringer-opencode-prof.XXXXXX)"
 cleanup() { rm -rf "$SCRATCH" "$PROFILE"; }
 trap cleanup EXIT
 


### PR DESCRIPTION
## Problem  The `mktemp` and `mktemp -d` calls in `engines/opencode-sandboxed.sh` use a bare prefix without trailing `X`s. On BSD/macOS, `mktemp` requires a template with trailing `X`s to generate unpredictable filenames. Without them, the temp path is more predictable and the utility may fail to guarantee uniqueness.  ## Fix  Append `.XXXXXX` to both temp templates so `mktemp` replaces them with random characters, producing ~56B possible unique names per the man page.  ## Files changed  - `engines/opencode-sandboxed.sh`: `mktemp -d -t ringer-opencode-scratch.XXXXXX` and `mktemp -t ringer-opencode-prof.XXXXXX`  ## Verification  - Only tracked shell file in the repo that uses `mktemp` — both calls now carry the suffix.