### PR TITLE
Manifest: worktrees:true without a manifest-level repo fails at parse instead of silently no-opping

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,6 +392,7 @@ Every community PR that lands in main is credited here — that's a project rule
 - [@davekopecek](https://github.com/davekopecek) (Dave Kopecek) — committed the design-reference fixture so the design-token guard runs on every machine (#30)
 - [@snapsynapse](https://github.com/snapsynapse) (Sam Rogers) — graceful shutdown on SIGINT/SIGTERM with worker-tree cleanup and finished state, plus the 14-test end-to-end CLI regression suite (#4)
 - [@mlava](https://github.com/mlava) (Mark Lavercombe) — named setup failures across every diagnostic surface (#37) and `run --baseline`, the no-workers check preflight (#38)
+- [@radandmark](https://github.com/radandmark) (Mark Chadwick) — refuse `worktrees: true` without a manifest-level `repo` at parse time, instead of silently creating no worktrees (#110)
 
 Contributions are welcome — see [CONTRIBUTING.md](CONTRIBUTING.md) for the philosophy and what gets a PR merged fast. The short version: small and scoped, rebased on current main, every claim backed by an executed test. Authorship is always preserved — where a maintainer pushes a mechanical fix to your branch, you remain the commit author.
 

--- a/ringer.py
+++ b/ringer.py
@@ -1762,6 +1762,12 @@ class Manifest:
         if duplicates:
             raise ValueError(f"duplicate task keys: {', '.join(duplicates)}")
         worktrees = bool(obj.get("worktrees", False))
+        if worktrees and repo is None:
+            raise ValueError(
+                "worktrees: true requires a manifest-level 'repo' - without it no "
+                "worktrees are created and every worker starts in an empty taskdir "
+                "(the checks then fail with 'Not a git repository')"
+            )
         if worktrees:
             reserved_logs_dir = (workdir / "logs").resolve()
             collisions = []

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -313,3 +313,38 @@ class LintManifestTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)
+
+
+class TestWorktreesRequireRepo(unittest.TestCase):
+    """worktrees: true without a manifest-level repo used to silently no-op:
+    no worktrees were created, every worker started in an empty taskdir, and
+    the failure surfaced as check errors that looked like worker faults
+    (2026-08-19, two runs lost to it). It must refuse at parse time."""
+
+    def _obj(self, **overrides):
+        obj = {
+            "run_name": "wt-guard",
+            "workdir": "/tmp/wt-guard",
+            "worktrees": True,
+            "repo": "/tmp/some-repo",
+            "tasks": [{
+                "key": "t1",
+                "spec": "do the thing",
+                "check": "true",
+                "verified": "it happened",
+            }],
+        }
+        obj.update(overrides)
+        return obj
+
+    def test_worktrees_without_repo_is_a_parse_error(self):
+        obj = self._obj()
+        del obj["repo"]
+        with self.assertRaises(ValueError) as ctx:
+            Manifest.from_obj(obj)
+        self.assertIn("repo", str(ctx.exception))
+
+    def test_worktrees_with_repo_parses(self):
+        manifest = Manifest.from_obj(self._obj())
+        self.assertTrue(manifest.worktrees)
+        self.assertIsNotNone(manifest.repo)


### PR DESCRIPTION
**Observed failure** (two burned runs before we found it): a manifest with `"worktrees": true` and an invented per-task `worktree_of` field — but no manifest-level `repo` — lints clean and runs. The worktree gate is `manifest.worktrees and manifest.repo is not None`, so no worktrees are created, every worker starts in an empty taskdir, and the checks fail with `Not a git repository`.

What made it expensive to diagnose: capable workers **self-rescue** — they init or clone their own tree inside the empty taskdir, pass some checks, and the schema mistake presents as flaky worker behaviour instead of a manifest error. We misdiagnosed it twice (engine cwd handling, then a worktree-add race) before reading the gate.

**Fix:** `Manifest.from_obj` raises `ValueError` when `worktrees: true` arrives without `repo`, with a message that says exactly what would otherwise happen. Both `lint` and `run` surface it before anything spawns.

**Proof:** two tests in `tests/test_lint.py` (`TestWorktreesRequireRepo`) — accepted with `repo`, refused without. Full suite green locally on Linux (`python3 -m unittest discover -s tests`), branch is upstream `main` + this one commit. A follow-up commit on this branch adds the README Contributors line once this PR has its number, so `test_contributors` stays green.