### PR TITLE
registry: register 15 observed-but-unregistered opencode/openrouter model slugs

### DIFF
--- a/registry/model-identity.toml
+++ b/registry/model-identity.toml
@@ -98,3 +98,96 @@ lab = "Meta"
 confidence = "verified"
 source = "manifest model field; OpenRouter slug meta-llama/llama-3.3-70b-instruct:free"
 last_verified = 2026-07-10
+
+[engines.opencode.models."openrouter/anthropic/claude-sonnet-5"]
+display = "Claude Sonnet 5"
+lab = "Anthropic"
+confidence = "verified"
+source = "manifest model field; OpenRouter slug anthropic/claude-sonnet-5"
+last_verified = 2026-08-01
+
+[engines.opencode.models."openrouter/cohere/north-mini-code:free"]
+display = "North Mini Code (free)"
+lab = "Cohere"
+confidence = "verified"
+source = "manifest model field; OpenRouter slug cohere/north-mini-code:free"
+last_verified = 2026-08-01
+
+[engines.opencode.models."openrouter/deepseek/deepseek-v4-flash"]
+display = "DeepSeek V4 Flash"
+lab = "DeepSeek"
+confidence = "verified"
+source = "manifest model field; OpenRouter slug deepseek/deepseek-v4-flash"
+last_verified = 2026-08-01
+
+[engines.opencode.models."openrouter/deepseek/deepseek-v4-pro"]
+display = "DeepSeek V4 Pro"
+lab = "DeepSeek"
+confidence = "verified"
+source = "manifest model field; OpenRouter slug deepseek/deepseek-v4-pro"
+last_verified = 2026-08-01
+
+[engines.opencode.models."openrouter/inclusionai/ling-2.6-flash"]
+# InclusionAI is Ant Group's AGI/open-source publishing org (home of the Ant
+# Ling team) — see https://huggingface.co/inclusionAI.
+display = "Ling 2.6 Flash"
+lab = "InclusionAI (Ant Group)"
+confidence = "verified"
+source = "https://huggingface.co/inclusionAI"
+last_verified = 2026-08-01
+
+[engines.opencode.models."openrouter/inclusionai/ling-3.0-flash:free"]
+display = "Ling 3.0 Flash (free)"
+lab = "InclusionAI (Ant Group)"
+confidence = "verified"
+source = "https://huggingface.co/inclusionAI"
+last_verified = 2026-08-01
+
+[engines.opencode.models."openrouter/moonshotai/kimi-k2.5"]
+display = "Kimi K2.5"
+lab = "Moonshot AI"
+confidence = "verified"
+source = "manifest model field; OpenRouter slug moonshotai/kimi-k2.5"
+last_verified = 2026-08-01
+
+[engines.opencode.models."openrouter/moonshotai/kimi-k2.6"]
+display = "Kimi K2.6"
+lab = "Moonshot AI"
+confidence = "verified"
+source = "https://openrouter.ai/moonshotai/kimi-k2.6"
+last_verified = 2026-08-01
+
+[engines.opencode.models."openrouter/nvidia/nemotron-3-nano-30b-a3b:free"]
+display = "Nemotron 3 Nano 30B A3B (free)"
+lab = "NVIDIA"
+confidence = "verified"
+source = "manifest model field; OpenRouter slug nvidia/nemotron-3-nano-30b-a3b:free"
+last_verified = 2026-08-01
+
+[engines.opencode.models."openrouter/nvidia/nemotron-3-super-120b-a12b"]
+display = "Nemotron 3 Super 120B A12B"
+lab = "NVIDIA"
+confidence = "verified"
+source = "manifest model field; OpenRouter slug nvidia/nemotron-3-super-120b-a12b"
+last_verified = 2026-08-01
+
+[engines.opencode.models."openrouter/nvidia/nemotron-3-ultra-550b-a55b:free"]
+display = "Nemotron 3 Ultra 550B A55B (free)"
+lab = "NVIDIA"
+confidence = "verified"
+source = "manifest model field; OpenRouter slug nvidia/nemotron-3-ultra-550b-a55b:free"
+last_verified = 2026-08-01
+
+[engines.opencode.models."openrouter/qwen/qwen3-coder"]
+display = "Qwen3 Coder 480B A35B"
+lab = "Alibaba (Qwen)"
+confidence = "verified"
+source = "manifest model field; OpenRouter slug qwen/qwen3-coder"
+last_verified = 2026-08-01
+
+[engines.opencode.models."openrouter/thinkingmachines/inkling"]
+display = "Inkling"
+lab = "Thinking Machines Lab"
+confidence = "verified"
+source = "https://openrouter.ai/thinkingmachines/inkling"
+last_verified = 2026-08-01

--- a/registry/model-identity.toml
+++ b/registry/model-identity.toml
@@ -191,3 +191,26 @@ lab = "Thinking Machines Lab"
 confidence = "verified"
 source = "https://openrouter.ai/thinkingmachines/inkling"
 last_verified = 2026-08-01
+
+[engines.opencode.models."openrouter/poolside/laguna-m.1:free"]
+# Not a typo — OpenRouter carried this slug from 2026-07-09 until it was
+# delisted 2026-08-01T23:13:22Z (same day as this entry, hours before this
+# registry check ran). Confirmed via ~/.ringer/openrouter-catalog.changes.jsonl
+# added/removed events, catalog name "Poolside: Laguna M.1 (free)". Historical
+# attempts against this slug should still resolve to Poolside identity even
+# though the model is no longer orderable.
+display = "Laguna M.1 (free)"
+lab = "Poolside"
+confidence = "verified"
+source = "OpenRouter catalog history (~/.ringer/openrouter-catalog.changes.jsonl): added 2026-07-09, delisted 2026-08-01"
+last_verified = 2026-08-01
+
+[engines.opencode.models."openrouter/nousresearch/hermes-3-llama-3.1-405b:free"]
+# Not a typo — OpenRouter carried the free tier of this model from 2026-07-09
+# until it was delisted 2026-07-19; the paid nousresearch/hermes-3-llama-3.1-405b
+# slug remains live. Catalog name "Nous: Hermes 3 405B Instruct (free)".
+display = "Hermes 3 405B Instruct (free)"
+lab = "Nous Research"
+confidence = "verified"
+source = "OpenRouter catalog history (~/.ringer/openrouter-catalog.changes.jsonl): added 2026-07-09, delisted 2026-07-19"
+last_verified = 2026-08-01


### PR DESCRIPTION
Registers 15 OpenCode/OpenRouter model slugs that ringer observes in task
manifests but that `registry/model-identity.toml` has no entry for, so the
scoreboard reports them as unregistered. Follows the identity procedure in
`docs/TAXONOMY.md`.

Labs covered: Anthropic, Cohere, DeepSeek, InclusionAI/Ant Group, Moonshot AI,
NVIDIA, Alibaba/Qwen, Thinking Machines Lab, Poolside, Nous Research. Each slug
matched against `./ringer.py catalog`, and cross-checked against the lab's own
release page where the org segment wasn't self-evident (`kimi-k2.6`,
`ling-3.0-flash`, `inkling`).

### The two delisted slugs

`openrouter/poolside/laguna-m.1:free` and
`openrouter/nousresearch/hermes-3-llama-3.1-405b:free` are absent from the
*current* catalog, so the first commit deliberately left them out rather than
fabricate identity. The second commit traces both through
`~/.ringer/openrouter-catalog.changes.jsonl` added/removed events — neither was
a manifest typo, both were delistings:

- `laguna-m.1:free` — live 2026-07-09 → delisted `2026-08-01T23:13:22Z`, hours
  before the first commit's catalog check ran.
- `hermes-3-llama-3.1-405b:free` — live 2026-07-09 → free tier delisted
  2026-07-19 (the paid variant is still live).

Both are registered so historical attempts resolve to the right lab even though
the models are no longer orderable.

### Deliberately not included: `grok-4.5`

The scoreboard flags the grok engine's `grok-4.5` slug as unregistered too, and
an earlier revision of this PR registered it as a second key alongside
`grok-build`. That has been dropped.

**#106 already covers it, and covers it better** — by renaming the existing
`grok-build` entry to `grok-4.5` with `report_aliases`, rather than adding a
parallel entry for the same artifact. A duplicate entry is close to what the
`grok-build` comment explicitly warns against. This PR now touches no `grok`
entry at all, so the two can merge in either order.

### Scope

Additive only: `registry/model-identity.toml`, **+116 / −0**, no existing entry
modified or removed. Every entry carries `display` / `lab` / `confidence` /
`source` / `last_verified`. `tests/test_taxonomy.py` and
`tests/test_identity_evidence.py` pass.

No key overlap with any other open PR touching this file — #94 adds `ollama*`
slugs, #72 and #71 add `claude`/`cursor` slugs, #106 owns the `grok` and
`claude` entries. This one is `opencode/openrouter` only. Rebased on current
`main`, zero commits behind.
