### PR TITLE
registry: add claude + gemini engines to the model-identity taxonomy

### DIFF
--- a/docs/MODEL-NOTES.md
+++ b/docs/MODEL-NOTES.md
@@ -14,6 +14,14 @@ checks and raw logs support — no vibes, no worker self-reports.
 
 ## codex (GPT-5-class, own harness)
 
+- 2026-09-02 — gpt-5.6-sol, code-feature/code-fix (hermes-control-plane build, 7 parallel
+  worktree tasks, bash scripts + bash tests with fakes, reasoning medium/high): 5/7 PASS
+  first or second try (deploy-lane needed the retry). The two FAILs (backup-crypto 549k tok /
+  25 min, update-lane 418k tok / 24 min) had ALL their lane tests green in the exported
+  patch — they failed only because the ChatGPT plan's usage limit hit before fix-summary.md
+  was written. Lesson: on the flat plan, keep a Codex task under ~15 min / ~250k tokens or
+  split it; 7 concurrent high-effort lanes drain the plan window in one run. Never retry
+  into the limit — verify the exported patch by running the lane tests yourself instead.
 - Strongest general worker; the default engine. Spend reasoning effort per
   task via `engine_args` (`["-c", "model_reasoning_effort=low|medium|high"]`)
   — high on gnarly tasks, low on boilerplate.
@@ -83,8 +91,23 @@ checks and raw logs support — no vibes, no worker self-reports.
   half-written trailing line). Codex is the proven lane for both sides of
   the review->fix loop on this codebase.
 
+- 2026-09-03 (GPT-5.6 Sol / Codex, code-feature ×2, code-review ×1, family-scheduling MVP): brief-renderer
+  task (stdlib Python + 21 tests, 6 files) PASSED first try in 11 min / 85k tokens. dave-brain intake task
+  (541-line Deno module + 47 tests + deploy doc) produced correct code on attempt 1 but the run recorded
+  FAIL twice — my check grepped for a plain `ok |` line while deno emitted ANSI colour; fix was
+  `NO_COLOR=1` in the gate, not the worker. Adversarial review task returned 8 findings with real
+  file:line citations; 2 were actionable, 3 argued against ruled scope — treat its verdicts as input, not
+  gates. Lesson: run `--baseline` AND a dry pass of the verify script on colourised tool output.
+
 ## glm-5.2 via opencode (`openrouter/z-ai/glm-5.2`)
 
+- 2026-09-02 — glm-5.2, code-fix + code-review (hermes-control-plane, bash scripts/tests):
+  fix lanes 4/5 PASS (3 first-try, 1 on retry); the one FAIL was MY check's quoting (nested
+  single quotes in --verify-command) not the model — its edits were correct and exported by
+  hand. Review scouts: 3/6 met the report contract; the two that failed were given too wide a
+  surface (whole restore+mirror lane) or wrote the report last and timed out — narrow surfaces
+  and 'write the skeleton first' fixed it. ~$0.02-0.05/task. Good enough for well-specified
+  bash fixes with executed tests; keep reviews to <= 8 entry-point files per scout.
 - The cheap-intelligence default (~$0.74/M in, $2.33/M out, 2026-07 —
   20-30x cheaper output than frontier coding models). Reliable on
   mechanical, tightly-specced work: file edits, format conversions,
@@ -147,6 +170,11 @@ checks and raw logs support — no vibes, no worker self-reports.
   contention findings (full catalog re-ingest per sync; schema writes on
   read paths) plus an empirical XSS all-clear on the new DOM surfaces.
   Third proven-tier structured review today.
+
+- 2026-09-03 — `openrouter/z-ai/glm-5.2:free` audition (docs, hermes-meal runbook): both attempts
+  died on OpenRouter upstream 429 ("temporarily rate-limited upstream", shared free pool) before
+  any output; 0 deliverable. Not a model failure — the free pool was saturated at 12:05 PT. Don't
+  put the free slug on anything with a deadline; the paid `z-ai/glm-5.2` slug is the real lane.
 
 ## kimi-k2.7 via opencode (`openrouter/moonshotai/kimi-k2.7-code`)
 
@@ -217,6 +245,29 @@ checks and raw logs support — no vibes, no worker self-reports.
   ladder now says: audition free models on SHORT mechanical tasks first;
   long-diff review is a proven-tier lane.
 
+## gemini-3.5-flash (Gemini CLI engine, free tier)
+
+- 2026-09-03 — gemini-3.5-flash (free lane) rescued hermes-meal round 5 when Codex hit its plan
+  limit and OpenRouter was out of credit: code-fix (Playwright capture retry, ~100 lines + 2 tests)
+  PASS on attempt 2 at 1.23M tokens; docs (contracts.md signatures + a one-line logging change)
+  PASS on attempt 2 at 86k tokens — attempt 1 ran the suite but staged NOTHING (empty_patch), i.e.
+  it read and reasoned without writing. Usable as a third lane for small, well-specified tasks;
+  expect a wasted first attempt and a token bill 10x Codex's.
+
+## claude (Claude Code CLI engine — Anthropic models: sonnet/haiku/opus/fable)
+
+- 2026-09-03 — claude-lane bring-up, probe (write answer.md, model haiku): PASS attempt 1, 81 tok,
+  ~15s, ~$0.05. But it took a long auth fight to get there — the engine is fine, the AUTH is the
+  footgun. The headless worker uses `$CLAUDE_CODE_OAUTH_TOKEN` (a `claude setup-token` value in the
+  vault as `claude-code/oauth_token`, exported by ~/.zshenv). Two traps: (1) that token has NO
+  refresh token, so it silently expires — symptom is `session expired, could not be refreshed`
+  (instant, no API call); re-mint with `claude setup-token` then `~/.claude/scripts/set-claude-token.sh`.
+  (2) A terminal paste truncates long tokens — a 79-of-108-char token stored fine but returned
+  `401 OAuth access token is invalid` (real API call, ~1.2s). The set-claude-token.sh helper reads
+  the clipboard whole, strips newlines, and rejects <80 chars — always vault through it, never a
+  manual `creds set`. Interactive `/login` and the Desktop app's host-auth do NOT provision this
+  lane; only the setup-token path does.
+
 ## Small / flash-class models
 
 - First to choke on long conversational or multi-turn harness tasks —
@@ -280,6 +331,12 @@ checks and raw logs support — no vibes, no worker self-reports.
   before blaming the model.
 - 2026-07-06 — opencode sqlite "database is locked" again with just 2
   simultaneous opencode spawns (page-news + page-about-faq); retry absorbed it.
+
+- 2026-09-03 (hermes-meal round 1): the fix-swarm check requires fix-summary.md to START with
+  the line `# Fix Summary`; my spec listed only the four headings, so all four lanes (Codex x3,
+  GLM x1) lost attempt 1 to `missing_title` and passed on retry with identical substance — a
+  spec bug that read as a 0% first-try rate on the scoreboard. Put the exact first line in every
+  spec's output contract (build_r1.py COMMON now does).
 
 ## codex (2026-07-06, bench-operator-proofing)
 - 8/8 code-feature tasks passed attempt 1 across 3 rounds (worktrees mode, Python harness refactor; 108k-406k tokens/task). Specs embedded the approved architecture doc + exact file ownership; checks built fresh uv venvs and ran the full pytest suite.

--- a/docs/MODEL-NOTES.md
+++ b/docs/MODEL-NOTES.md
@@ -268,6 +268,14 @@ checks and raw logs support — no vibes, no worker self-reports.
   manual `creds set`. Interactive `/login` and the Desktop app's host-auth do NOT provision this
   lane; only the setup-token path does.
 
+- 2026-09-03 — sonnet vs opus bakeoff (code-feature, `roman_to_int` + subtractive notation, check
+  runs the code on 10 cases): BOTH PASS attempt 1. sonnet 17 tok / 11s, opus 89 tok / 16s — opus
+  ~5x the output tokens and 40% slower for an identical correct result on a small mechanical task,
+  so sonnet is the default lane here; reserve opus for genuinely hard reasoning. IDENTITY GOTCHA:
+  the CLI aliases self-report concrete slugs — `--model opus` -> claude-opus-5 (NOT 4.8), sonnet ->
+  claude-sonnet-5, haiku -> claude-haiku-4-5-20251001. Register the reported slug, not the alias
+  (docs/TAXONOMY.md); an alias-keyed entry shows every model as [unregistered] on the scoreboard.
+
 ## Small / flash-class models
 
 - First to choke on long conversational or multi-turn harness tasks —

--- a/docs/MODEL-NOTES.md
+++ b/docs/MODEL-NOTES.md
@@ -276,6 +276,12 @@ checks and raw logs support — no vibes, no worker self-reports.
   claude-sonnet-5, haiku -> claude-haiku-4-5-20251001. Register the reported slug, not the alias
   (docs/TAXONOMY.md); an alias-keyed entry shows every model as [unregistered] on the scoreboard.
 
+- 2026-09-03 — fable identity probe (write answer.md, model fable): PASS attempt 1, 52 tok, 17s,
+  self-reports claude-fable-5-1 (1M context, provider firstParty). COST WARNING: ~$0.67 for a
+  trivial probe — fable's list price plus large cache-creation on the 1M window makes it 10x+ the
+  cost of any other lane here. It's an orchestrator-class model; do NOT put it on worker tasks a
+  cheaper lane can pass. Registered for identity/completeness, not as a routing recommendation.
+
 ## Small / flash-class models
 
 - First to choke on long conversational or multi-turn harness tasks —

--- a/registry/model-identity.toml
+++ b/registry/model-identity.toml
@@ -147,7 +147,9 @@ confidence = "verified"     # harness self-report (modelUsage canonicalModel cla
 source = "Claude Code headless modelUsage self-report; --model haiku, run 2026-09-03"
 last_verified = 2026-09-03
 
-# fable (--model fable, expected slug claude-fable-5-1) is served but not yet
-# run through Ringer, so it stays unregistered until a run self-reports its slug
-# — do not add it from the alias alone (TAXONOMY: aliases only when lineage is
-# unestablished, and this one is establishable by simply running it).
+[engines.claude.models."claude-fable-5-1"]
+display = "Claude Fable 5.1"
+lab = "Anthropic"
+confidence = "verified"     # harness self-report (modelUsage canonicalModel, provider firstParty, 1M ctx)
+source = "Claude Code headless modelUsage self-report; --model fable, run 2026-09-03"
+last_verified = 2026-09-03

--- a/registry/model-identity.toml
+++ b/registry/model-identity.toml
@@ -98,3 +98,54 @@ lab = "Meta"
 confidence = "verified"
 source = "manifest model field; OpenRouter slug meta-llama/llama-3.3-70b-instruct:free"
 last_verified = 2026-07-10
+
+[engines.gemini]
+harness = "Gemini CLI"
+access = "Gemini API"
+default_model_key = "gemini-3.5-flash"
+
+[engines.gemini.models."gemini-3.5-flash"]
+display = "Gemini 3.5 Flash"
+lab = "Google"
+confidence = "verified"
+source = "https://ai.google.dev/gemini-api/docs/models"
+last_verified = 2026-09-02
+
+[engines.claude]
+# Claude Code CLI run headless (`-p --model {model} --output-format json`).
+# The {model} slug is the per-task manifest "model" field — the CLI's short
+# aliases below, or a full ID (claude-opus-4-8, claude-sonnet-5, …). Serves
+# Anthropic models only. model_default = "sonnet" (see [engines.claude] in
+# ~/.config/ringer/config.toml). Auth is the Claude subscription/OAuth token;
+# a headless worker needs a long-lived token from `claude setup-token`.
+harness = "Claude Code CLI"
+access = "Claude subscription (OAuth)"
+default_model_key = "sonnet"
+
+[engines.claude.models."sonnet"]
+display = "Claude Sonnet 5"
+lab = "Anthropic"
+confidence = "verified"     # Claude Code --model alias; engine model_default
+source = "Claude Code --model aliases; config.toml [engines.claude] model_default"
+last_verified = 2026-09-03
+
+[engines.claude.models."haiku"]
+display = "Claude Haiku 4.5"
+lab = "Anthropic"
+confidence = "verified"     # Claude Code --model alias
+source = "Claude Code --model aliases (claude-haiku-4-5)"
+last_verified = 2026-09-03
+
+[engines.claude.models."opus"]
+display = "Claude Opus 4.8"
+lab = "Anthropic"
+confidence = "verified"     # Claude Code --model alias
+source = "Claude Code --model aliases (claude-opus-4-8)"
+last_verified = 2026-09-03
+
+[engines.claude.models."fable"]
+display = "Claude Fable 5.1"
+lab = "Anthropic"
+confidence = "verified"     # Claude Code --model alias
+source = "Claude Code --model aliases (claude-fable-5-1)"
+last_verified = 2026-09-03

--- a/registry/model-identity.toml
+++ b/registry/model-identity.toml
@@ -113,39 +113,41 @@ last_verified = 2026-09-02
 
 [engines.claude]
 # Claude Code CLI run headless (`-p --model {model} --output-format json`).
-# The {model} slug is the per-task manifest "model" field — the CLI's short
-# aliases below, or a full ID (claude-opus-4-8, claude-sonnet-5, …). Serves
-# Anthropic models only. model_default = "sonnet" (see [engines.claude] in
-# ~/.config/ringer/config.toml). Auth is the Claude subscription/OAuth token;
-# a headless worker needs a long-lived token from `claude setup-token`.
+# The per-task manifest "model" field is the CLI's short alias — sonnet, haiku,
+# opus, fable — which resolves to the concrete slug the harness self-reports in
+# `modelUsage` (the keys below). Aliases float across releases: as of
+# 2026-09-03 `--model opus` self-reports claude-opus-5 (NOT 4.8), sonnet ->
+# claude-sonnet-5, haiku -> claude-haiku-4-5-20251001. Serves Anthropic models
+# only. Engine model_default = "sonnet" (see [engines.claude] in
+# ~/.config/ringer/config.toml). Auth is the Claude subscription/OAuth token; a
+# headless worker needs a long-lived token from `claude setup-token`. Keys are
+# the harness-reported slugs per docs/TAXONOMY.md, not the aliases.
 harness = "Claude Code CLI"
 access = "Claude subscription (OAuth)"
-default_model_key = "sonnet"
+default_model_key = "claude-sonnet-5"
 
-[engines.claude.models."sonnet"]
+[engines.claude.models."claude-sonnet-5"]
 display = "Claude Sonnet 5"
 lab = "Anthropic"
-confidence = "verified"     # Claude Code --model alias; engine model_default
-source = "Claude Code --model aliases; config.toml [engines.claude] model_default"
+confidence = "verified"     # harness self-report (modelUsage canonicalModel, provider firstParty)
+source = "Claude Code headless modelUsage self-report; --model sonnet, run 2026-09-03"
 last_verified = 2026-09-03
 
-[engines.claude.models."haiku"]
+[engines.claude.models."claude-opus-5"]
+display = "Claude Opus 5"
+lab = "Anthropic"
+confidence = "verified"     # harness self-report (modelUsage canonicalModel, provider firstParty)
+source = "Claude Code headless modelUsage self-report; --model opus, run 2026-09-03"
+last_verified = 2026-09-03
+
+[engines.claude.models."claude-haiku-4-5-20251001"]
 display = "Claude Haiku 4.5"
 lab = "Anthropic"
-confidence = "verified"     # Claude Code --model alias
-source = "Claude Code --model aliases (claude-haiku-4-5)"
+confidence = "verified"     # harness self-report (modelUsage canonicalModel claude-haiku-4-5, provider firstParty)
+source = "Claude Code headless modelUsage self-report; --model haiku, run 2026-09-03"
 last_verified = 2026-09-03
 
-[engines.claude.models."opus"]
-display = "Claude Opus 4.8"
-lab = "Anthropic"
-confidence = "verified"     # Claude Code --model alias
-source = "Claude Code --model aliases (claude-opus-4-8)"
-last_verified = 2026-09-03
-
-[engines.claude.models."fable"]
-display = "Claude Fable 5.1"
-lab = "Anthropic"
-confidence = "verified"     # Claude Code --model alias
-source = "Claude Code --model aliases (claude-fable-5-1)"
-last_verified = 2026-09-03
+# fable (--model fable, expected slug claude-fable-5-1) is served but not yet
+# run through Ringer, so it stays unregistered until a run self-reports its slug
+# — do not add it from the alias alone (TAXONOMY: aliases only when lineage is
+# unestablished, and this one is establishable by simply running it).


### PR DESCRIPTION
Registers two worker engines in `registry/model-identity.toml` so they display by name on the scoreboard and Ringside instead of masquerading as engine names, plus `docs/MODEL-NOTES.md` audition entries from 2026-09-02/03 runs.

## claude (Claude Code CLI engine)
- Runs Anthropic models as workers via `--model {model}`: `sonnet` (default), `haiku`, `opus`, `fable`. Matches the local `[engines.claude]` block (`bin=claude`, `model_default=sonnet`).
- Verified working 2026-09-03: haiku probe PASS on attempt 1 (wrote + validated `answer.md`).
- MODEL-NOTES documents the headless auth path (`$CLAUDE_CODE_OAUTH_TOKEN` from `claude setup-token`) and its two footguns: silent expiry (no refresh token) and paste-truncation → `401 OAuth access token is invalid`.

## gemini (Gemini CLI engine)
- `gemini-3.5-flash`, verified 2026-09-02. Note from a 2026-09-03 hermes-meal rescue run: usable as a third small-task lane, expect a wasted first attempt and ~10x Codex's token bill.

## MODEL-NOTES
- Dated audition entries for codex (gpt-5.6-sol), glm-5.2, and gemini-3.5-flash.

No code changes — registry/taxonomy + notes only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)