### PR TITLE
registry: resolve the slugs that render as [unregistered]

### DIFF
--- a/registry/model-identity.toml
+++ b/registry/model-identity.toml
@@ -26,6 +26,14 @@ confidence = "verified"
 source = "https://developers.openai.com/codex/models"
 last_verified = 2026-07-10
 
+[engines.codex.models."gpt-6-astra"]
+display = "GPT-6 Astra"
+lab = "OpenAI"
+confidence = "verified"     # Codex CLI header self-report: `model: gpt-6-astra` / `provider: openai`
+                            # (codex-cli 0.153.4). OpenAI's Codex model list names it "Astra".
+source = "https://learn.chatgpt.com/docs/models"
+last_verified = 2026-09-06
+
 [engines.codex.models."gpt-5.6-luna"]
 display = "GPT-5.6 Luna"
 lab = "OpenAI"
@@ -98,3 +106,89 @@ lab = "Meta"
 confidence = "verified"
 source = "manifest model field; OpenRouter slug meta-llama/llama-3.3-70b-instruct:free"
 last_verified = 2026-07-10
+
+[engines.opencode.models."openrouter/google/gemini-3.7-flash"]
+display = "Gemini 3.7 Flash"
+lab = "Google"
+confidence = "unverified"   # catalog-derived per TAXONOMY.md (slug org segment + OpenRouter
+                            # catalog name "Google: Gemini 3.7 Flash"). Confirm Google's own
+                            # model page before promoting to verified.
+source = "OpenRouter catalog id google/gemini-3.7-flash"
+last_verified = 2026-09-06
+
+[engines.opencode.models."openrouter/google/gemini-3.1-pro-preview"]
+display = "Gemini 3.1 Pro Preview"
+lab = "Google"
+confidence = "unverified"   # catalog-derived; see the gemini-3.7-flash note above.
+source = "OpenRouter catalog id google/gemini-3.1-pro-preview"
+last_verified = 2026-09-06
+
+[engines.opencode.models."openrouter/deepseek/deepseek-v4-flash"]
+display = "DeepSeek V4 Flash"
+lab = "DeepSeek"
+confidence = "unverified"   # catalog-derived (OpenRouter catalog name
+                            # "DeepSeek: DeepSeek V4 Flash 0423").
+source = "OpenRouter catalog id deepseek/deepseek-v4-flash"
+last_verified = 2026-09-06
+
+[engines.opencode.models."openrouter/x-ai/grok-4.6"]
+display = "Grok 4.6"
+# LAB DELIBERATELY LEFT UNVERIFIED — the vendor's own naming is inconsistent.
+# xAI's release notes (2026-09-06) use both names: "xAI" for the API platform and console,
+# and "SpaceXAI" for the entity behind the frontier models — Grok 4.6 is described there as
+# "SpaceXAI's frontier model". The OpenRouter catalog name is "SpaceXAI: Grok 4.6"; the slug
+# org segment is x-ai. Recorded as xAI to match the existing Grok 4.5 entry and left
+# unverified until the relationship between the two names is established. Please don't
+# normalize this to one name without a source.
+lab = "xAI"
+confidence = "unverified"
+source = "https://docs.x.ai/developers/release-notes"
+last_verified = 2026-09-06
+
+# ─── claude — Claude Code CLI, headless, on an Anthropic subscription ───
+# Display names, model IDs and the lab are from Anthropic's own models overview.
+# Claude Code additionally self-reports identity in its `--output-format json` envelope:
+# modelUsage."<id>" carries canonicalModel = "<id>" and provider = "firstParty", which is
+# harness-reported model — the top tier of TAXONOMY.md's evidence precedence.
+# claude-fable-5 and claude-opus-4-8 are legacy-but-served models (each still has its own
+# vendor model page). claude-haiku-4-5 is an alias; its pinned snapshot is
+# claude-haiku-4-5-20251001.
+[engines.claude]
+harness = "Claude Code"
+access = "OAuth plan"
+default_model_key = "claude-fable-5"
+
+[engines.claude.models."claude-fable-5"]
+display = "Claude Fable 5"
+lab = "Anthropic"
+confidence = "verified"
+source = "https://platform.claude.com/docs/en/about-claude/models/overview"
+last_verified = 2026-09-06
+
+[engines.claude.models."claude-opus-5"]
+display = "Claude Opus 5"
+lab = "Anthropic"
+confidence = "verified"
+source = "https://platform.claude.com/docs/en/about-claude/models/overview"
+last_verified = 2026-09-06
+
+[engines.claude.models."claude-opus-4-8"]
+display = "Claude Opus 4.8"
+lab = "Anthropic"
+confidence = "verified"
+source = "https://platform.claude.com/docs/en/about-claude/models/overview"
+last_verified = 2026-09-06
+
+[engines.claude.models."claude-sonnet-5"]
+display = "Claude Sonnet 5"
+lab = "Anthropic"
+confidence = "verified"
+source = "https://platform.claude.com/docs/en/about-claude/models/overview"
+last_verified = 2026-09-06
+
+[engines.claude.models."claude-haiku-4-5"]
+display = "Claude Haiku 4.5"
+lab = "Anthropic"
+confidence = "verified"
+source = "https://platform.claude.com/docs/en/about-claude/models/overview"
+last_verified = 2026-09-06

--- a/registry/model-identity.toml
+++ b/registry/model-identity.toml
@@ -16,14 +16,14 @@ default_model_key = "gpt-5.5"
 display = "GPT-5.5"
 lab = "OpenAI"
 confidence = "verified"     # snapshot gpt-5.5-2026-04-23, Codex CLI default; see capability file
-source = "https://developers.openai.com/codex/models"
+source = "https://learn.chatgpt.com/docs/models"
 last_verified = 2026-07-10
 
 [engines.codex.models."gpt-5.6-sol"]
 display = "GPT-5.6 Sol"
 lab = "OpenAI"
 confidence = "verified"
-source = "https://developers.openai.com/codex/models"
+source = "https://learn.chatgpt.com/docs/models"
 last_verified = 2026-07-10
 
 [engines.codex.models."gpt-6-astra"]
@@ -38,14 +38,14 @@ last_verified = 2026-09-06
 display = "GPT-5.6 Luna"
 lab = "OpenAI"
 confidence = "verified"
-source = "https://developers.openai.com/codex/models"
+source = "https://learn.chatgpt.com/docs/models"
 last_verified = 2026-07-10
 
 [engines.codex.models."gpt-5.6-terra"]
 display = "GPT-5.6 Terra"
 lab = "OpenAI"
 confidence = "verified"
-source = "https://developers.openai.com/codex/models"
+source = "https://learn.chatgpt.com/docs/models"
 last_verified = 2026-07-10
 
 [engines.grok]


### PR DESCRIPTION
Ten model identities that currently fall through to `[unregistered]` / `(unverified)` on every scoreboard surface, sourced per [`docs/TAXONOMY.md`](docs/TAXONOMY.md) *How to establish identity*. Data only — no behavior change, one file.

**Motivation:** every claude-lane and `gpt-6-astra` row on my scoreboard displayed with lab `(unverified)` and a raw slug — the display-must-be-true bug class CONTRIBUTING.md calls out.

## What's registered

| Engine | Added | Evidence |
|---|---|---|
| `codex` | `gpt-6-astra` | Codex CLI header self-report `model: gpt-6-astra` / `provider: openai` (codex-cli 0.153.4) — harness-reported model, matching the resolved slug with no drift. OpenAI's model list names it "Astra". |
| `claude` | new `[engines.claude]` section (harness "Claude Code", OAuth plan) + the 5 current Anthropic models | Claude Code self-reports identity in its `--output-format json` envelope: `modelUsage."<id>"` carries `canonicalModel` and `provider = "firstParty"`. Display names, IDs and lab from Anthropic's own models overview. |
| `opencode` | 4 OpenRouter slugs (2× Gemini, DeepSeek V4 Flash, Grok 4.6) | Catalog-derived, marked `unverified` as TAXONOMY.md prescribes, pending a lab-page confirmation pass. |

Precedent for registering an engine the sample config doesn't ship: the existing `grok` and `opencode` sections.

**Second commit** retargets the four existing `gpt-5.x` `source` URLs from `developers.openai.com/codex/models` (now a 308) to the live `learn.chatgpt.com/docs/models`. All four slugs are present on the new page, so the citation still supports the recorded identity. `last_verified` is deliberately unchanged — this retargets a pointer, it is not a fresh verification.

## One thing worth a maintainer's eye

**`x-ai/grok-4.6`'s lab is genuinely ambiguous.** xAI's release notes use *both* names — "xAI" for the API platform and console, but "SpaceXAI" for the entity behind the frontier models (Grok 4.6 is described there as "SpaceXAI's frontier model"). The OpenRouter catalog name is "SpaceXAI: Grok 4.6"; the slug org segment is `x-ai`.

I recorded it as `xAI` to match the existing Grok 4.5 entry, left it `unverified`, and wrote the conflict into a comment rather than silently resolving it. The Grok worked example in TAXONOMY.md is what made me stop and check rather than normalize. If you know which name is current, that comment is the thing to correct.

## CI will be red, and it is not this diff

`tests/test_contributors.py` audits `git log --format=%an` over full history and fails because `tcjoe` is not in the README `## Contributors` section. That is the test working as designed — but it means **every first-time contributor's PR is red before review**, since the credit line can only reasonably be added at merge. The suite is otherwise green:

```
python3 -m unittest discover -s tests
Ran 253 tests — OK   (working tree, before the authored commit exists)
```

Tell me which you'd prefer and I'll push it: I add a `tcjoe` line to `## Contributors` in this PR, or you add it at merge and the red check is expected. I did not want to write myself into that list unasked.

## Also deliberately left out

An `[engines.cursor]` section. Nothing upstream ships a cursor engine, and I couldn't confirm its model slugs (`cursor-agent --list-models` requires a login). It stays out until both are true.