### PR TITLE
Lint: warn when a repo task's check greps before any typecheck

### DIFF
--- a/ringer.py
+++ b/ringer.py
@@ -1821,6 +1821,11 @@ def lint_manifest(
             findings.append(
                 f"{task.key}: check may fail without printing why; retry prompt and eval log depend on failure output."
             )
+        if manifest.repo is not None and check_greps_before_typecheck(task.check):
+            findings.append(
+                f"{task.key}: check greps before any typecheck; a corrupted file can pass "
+                "its greps (text pin — weak, review the check)."
+            )
         if manifest.worktrees and any(is_relative_expect_file(path) for path in task.expect_files):
             findings.append(
                 f"{task.key}: deliverable would be deleted with the worktree; write it outside the worktree or export it in the check."
@@ -1969,6 +1974,37 @@ def consists_only_of_echo_commands(command: str) -> bool:
         if not tokens or tokens[0] != "echo":
             return False
     return True
+
+
+GREP_ARM_RE = re.compile(r"\b(?:grep|rg)\b")
+# Tokens that mean "something structural ran". Deliberately generous: the point
+# is to stay quiet whenever the author plausibly parsed the file, and to speak
+# only when nothing structural precedes the first text match.
+TYPECHECK_ARM_RE = re.compile(
+    r"\b(?:tsc|typecheck|py_compile|mypy|build)\b"
+    r"|\bpnpm\s+check\b"
+    r"|\bnpm\s+run\s+check\b"
+    r"|\bcargo\s+check\b"
+    r"|\bgo\s+vet\b"
+)
+
+
+def check_greps_before_typecheck(check: str) -> bool:
+    """True when the first grep-shaped arm runs with nothing structural ahead of it.
+
+    A text match asserts nothing about a file that does not parse: a corrupted
+    component can carry every string a grep looks for. Comments are stripped
+    first, so naming a typecheck in prose does not satisfy this.
+
+    A text pin on a shell script is weak by construction — hence a warning that
+    says so, never a refusal.
+    """
+    stripped = strip_shell_comments(check)
+    grep_match = GREP_ARM_RE.search(stripped)
+    if grep_match is None:
+        return False
+    typecheck_match = TYPECHECK_ARM_RE.search(stripped)
+    return typecheck_match is None or typecheck_match.start() > grep_match.start()
 
 
 def check_may_fail_silently(check: str) -> bool:

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -32,6 +32,7 @@ class LintManifestTests(unittest.TestCase):
         *,
         worktrees: bool = False,
         max_parallel: int = 1,
+        repo: bool = False,
     ) -> Manifest:
         temp_dir = tempfile.TemporaryDirectory()
         self.addCleanup(temp_dir.cleanup)
@@ -42,7 +43,7 @@ class LintManifestTests(unittest.TestCase):
             "worktrees": worktrees,
             "tasks": tasks,
         }
-        if worktrees:
+        if worktrees or repo:
             obj["repo"] = temp_dir.name
         return Manifest.from_obj(obj)
 
@@ -310,6 +311,56 @@ class LintManifestTests(unittest.TestCase):
                 findings = lint_manifest(manifest)
                 self.assertEqual([], findings, f"{path} should lint clean, got: {findings}")
 
+
+
+    # --- BLP-294(b): grep arms that run before any typecheck ----------------
+    # Condensed from /srv/swarm/blp-252/check.sh: three comment-stripped greps
+    # on the component, then vitest, then `pnpm check`. The real file mentions
+    # "typecheck" in a header COMMENT, which is why comments are stripped
+    # before the scan — reproduced here so a regression would be caught.
+    BLP252_CHECK = (
+        "#!/usr/bin/env bash\n"
+        "# Runs as the orchestrator, which is what makes the typecheck possible at all.\n"
+        "set -uo pipefail\n"
+        'fail() { echo "CHECK FAIL: $*" >&2; exit 1; }\n'
+        "grep -q 'from \"@shared/appointmentSort\"' \"$LIST\" || fail 'no shared import'\n"
+        "sed 's://.*::' \"$LIST\" | grep -q 'sortIndicator' || fail 'no sortIndicator'\n"
+        "sed 's://.*::' \"$LIST\" | grep -q 'aria-sort' || fail 'no aria-sort'\n"
+        "pnpm vitest run shared/appointmentSort.test.ts || fail 'vitest FAILED'\n"
+        "pnpm check || fail 'typecheck FAILED'\n"
+    )
+    GREP_BEFORE_TYPECHECK = (
+        "one: check greps before any typecheck; a corrupted file can pass its greps "
+        "(text pin — weak, review the check)."
+    )
+
+    def test_grep_before_typecheck_fires_on_a_repo_task(self) -> None:
+        findings = lint_manifest(
+            self.manifest([self.task(check=self.BLP252_CHECK)], repo=True)
+        )
+        self.assertHasFinding(findings, self.GREP_BEFORE_TYPECHECK)
+
+    def test_grep_before_typecheck_silent_when_typecheck_runs_first(self) -> None:
+        check = (
+            "set -uo pipefail\n"
+            'fail() { echo "CHECK FAIL: $*" >&2; exit 1; }\n'
+            "pnpm check || fail 'typecheck FAILED'\n"
+            "sed 's://.*::' \"$LIST\" | grep -q 'sortIndicator' || fail 'no sortIndicator'\n"
+        )
+        findings = lint_manifest(self.manifest([self.task(check=check)], repo=True))
+        self.assertNotIn(self.GREP_BEFORE_TYPECHECK, findings)
+
+    def test_grep_before_typecheck_silent_without_a_repo(self) -> None:
+        findings = lint_manifest(self.manifest([self.task(check=self.BLP252_CHECK)]))
+        self.assertNotIn(self.GREP_BEFORE_TYPECHECK, findings)
+
+    def test_grep_before_typecheck_is_a_warning_not_a_refusal(self) -> None:
+        """lint_manifest returns findings; it must not raise on this shape."""
+        findings = lint_manifest(
+            self.manifest([self.task(check=self.BLP252_CHECK)], repo=True)
+        )
+        self.assertIsInstance(findings, list)
+        self.assertHasFinding(findings, self.GREP_BEFORE_TYPECHECK)
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Motivation

A check whose text-matching arms run before anything structural will pass a file that does not parse.

On a repo-feature run, a worker left `AppointmentsList.tsx` structurally broken: `useState` spliced into a props type literal, a duplicated declaration, the `isError` JSX destroyed, the `<tr>` open tag deleted. **Every grep arm in the check was satisfied by that file** — the shared import, `sortIndicator`, `aria-sort`, and both `nextSort(…,'date')` / `nextSort(…,'status')` calls were all present in the corrupted text.

The check's typecheck arm was ordered last, behind a fail-fast `exit 1`, and never ran in either attempt: the evidence directory holds no `typecheck.log`, only a `baseline-typecheck.log` written before the swarm started. The only failure line either attempt produced was `CHECK FAIL: vitest FAILED (rc=1)`.

## What changed

One finding in `lint_manifest`, next to the existing "check may fail without printing why":

```
<key>: check greps before any typecheck; a corrupted file can pass its greps (text pin — weak, review the check).
```

It fires only when the manifest has a `repo` and the first grep-shaped arm (`grep`/`rg`) has no structural token ahead of it. The structural list is deliberately generous — `tsc`, `typecheck`, `py_compile`, `mypy`, `build`, `pnpm check`, `npm run check`, `cargo check`, `go vet` — because the finding should stay quiet whenever the author plausibly parsed the file first, and speak only when nothing structural runs before the first text match.

**A warning, never a refusal**, and the text says why it is weak: it is a text pin on a shell script, the same status as any other prose-level tripwire. Ringer does not confine workers; this only tells the operator their gate may be softer than it looks.

Comments are stripped before the scan. That is load-bearing — the real check script that motivated this opens with a comment reading "which is what makes the typecheck possible at all", and prose naming a typecheck must not satisfy the check for one.

## Executed proof

Against the real check script, not only the condensed fixture:

```
>>> check_greps_before_typecheck(Path("/srv/swarm/blp-252/check.sh").read_text())
True
```

## Tests

Four in `tests/test_lint.py`. The check text is condensed from the real script: three comment-stripped greps on the component, then vitest, then `pnpm check`.

- fires on that shape when a repo is set
- silent when a typecheck runs before the grep
- silent when there is no repo
- returns findings rather than raising — a warning, not a refusal

```
Ran 18 tests in 0.046s
OK
```

Full suite: **254 before, 258 after.**

## Re-derivation note

The issue describes this as firing on "task.repo (or the manifest-level repo)". There is no per-task repo — `TaskSpec` has no `repo` field, only `Manifest` does — so the condition is `manifest.repo is not None`.

## Not addressed here

`tests/test_contributors.py` fails on this branch and is unrelated: it requires every commit author to appear in README `## Contributors`, and keys on author rather than content. On an identical tree the suite is `Ran 254 tests ... OK` before a commit and 1 failure after. Per CONTRIBUTING, credit is added by the maintainer on merge, so no contributor line is added here.

## Related

- #95, #105 — same lint surface.
- #57 — prior guidance on check-writing failure modes; this is the executable version of one of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AVTYzUcjMokzMsyjABjUBF
