### PR TITLE
Refuse a task whose engine_args the resolved args_template would drop

### DIFF
--- a/ringer.py
+++ b/ringer.py
@@ -1821,6 +1821,15 @@ def lint_manifest(
             findings.append(
                 f"{task.key}: check may fail without printing why; retry prompt and eval log depend on failure output."
             )
+        if config is not None and task.engine in config.engines:
+            dropped = dropped_engine_args(config.engines[task.engine], task.engine_args)
+            if dropped:
+                findings.append(
+                    f"ERROR: {task.key}: \"engine_args\" {list(dropped)} would be dropped — "
+                    f"engine {task.engine} has no {{engine_args}} placeholder in its "
+                    f"args_template. Add {{engine_args}} to engines.{task.engine}.args_template "
+                    "in config.toml, or remove the field."
+                )
         if manifest.worktrees and any(is_relative_expect_file(path) for path in task.expect_files):
             findings.append(
                 f"{task.key}: deliverable would be deleted with the worktree; write it outside the worktree or export it in the check."
@@ -9498,6 +9507,21 @@ def resolved_task_model(
     )
 
 
+def dropped_engine_args(engine: EngineConfig, engine_args: tuple[str, ...]) -> tuple[str, ...]:
+    """Per-task engine_args that the resolved args_template would discard.
+
+    build_worker_command expands engine_args only where the template holds the
+    literal {engine_args} token. Without it the arguments are dropped in
+    silence: the field validates as a list of strings, lint passes, the worker
+    spawns, and the flag never reaches the process.
+    """
+    if not engine_args:
+        return ()
+    if "{engine_args}" in engine.args_template:
+        return ()
+    return tuple(engine_args)
+
+
 def build_worker_command(
     engine: EngineConfig,
     *,
@@ -9628,6 +9652,14 @@ def validate_manifest_engines(manifest: Manifest, config: AppConfig) -> None:
             raise ValueError(
                 f"task {task.key}: \"model\" is set but engine {engine.name} has no "
                 "{model} placeholder in its args_template, so it would be silently ignored"
+            )
+        dropped = dropped_engine_args(engine, task.engine_args)
+        if dropped:
+            raise ValueError(
+                f"task {task.key}: \"engine_args\" {list(dropped)} would be dropped — engine "
+                f"{engine.name} has no {{engine_args}} placeholder in its args_template. "
+                f"Add {{engine_args}} to engines.{engine.name}.args_template in config.toml, "
+                "or remove the field."
             )
 
 

--- a/tests/test_engine_args_placeholder.py
+++ b/tests/test_engine_args_placeholder.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""Per-task engine_args must reach the process, or the run must refuse (BLP-201).
+
+build_worker_command substitutes engine_args only where the resolved
+args_template carries the literal {engine_args} token. When it does not, the
+arguments are dropped with no error anywhere: manifest lint passes and the flag
+simply never reaches the process. Observed on the BLP-189 arc, where the gemini
+block had no placeholder and --include-directories vanished silently.
+
+Chris's gemini template now carries the placeholder, so this is regression
+protection rather than a live fix.
+"""
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from ringer import (  # noqa: E402
+    AppConfig,
+    ArtifactConfig,
+    EngineConfig,
+    EvalConfig,
+    Manifest,
+    build_worker_command,
+    lint_manifest,
+    validate_manifest_engines,
+)
+
+LONG_SPEC = (
+    "Create the requested artifact in the current working directory, keep the change scoped, "
+    "and make the check command able to explain any failure clearly."
+)
+GOOD_CHECK = (
+    "test -s output.txt && grep -q 'ready' output.txt || "
+    "{ echo 'FAIL: output.txt missing or does not contain ready'; exit 1; }"
+)
+DROPPED_ARGS = ("--include-directories", "/srv/repo")
+
+
+def engine_without_placeholder() -> EngineConfig:
+    return EngineConfig(
+        name="gemini",
+        bin="/usr/local/bin/gemini",
+        args_template=("--yolo", "-m", "{model}", "-p", "{spec}"),
+        full_access_args=(),
+        sandbox_args=(),
+        token_regex=None,
+        model_default="gemini-flash-latest",
+    )
+
+
+def engine_with_placeholder() -> EngineConfig:
+    return EngineConfig(
+        name="gemini",
+        bin="/usr/local/bin/gemini",
+        args_template=("--yolo", "{engine_args}", "-m", "{model}", "-p", "{spec}"),
+        full_access_args=(),
+        sandbox_args=(),
+        token_regex=None,
+        model_default="gemini-flash-latest",
+    )
+
+
+class EngineArgsPlaceholderTests(unittest.TestCase):
+    def config(self, engine: EngineConfig) -> AppConfig:
+        temp = tempfile.TemporaryDirectory()
+        self.addCleanup(temp.cleanup)
+        root = Path(temp.name)
+        return AppConfig(
+            path=None,
+            identity_default=None,
+            state_dir=root,
+            dashboard_port_base=8787,
+            hud_port=8700,
+            hud_app_path=None,
+            allow_full_access=False,
+            eval=EvalConfig(backend="jsonl", jsonl_path=root / "eval.jsonl"),
+            engines={engine.name: engine},
+            artifact=ArtifactConfig(
+                enabled=False,
+                out_template=str(root / "live.html"),
+                report_template=str(root / "report.html"),
+                index_out=root / "index.html",
+            ),
+        )
+
+    def manifest(self) -> Manifest:
+        temp = tempfile.TemporaryDirectory()
+        self.addCleanup(temp.cleanup)
+        return Manifest.from_obj(
+            {
+                "run_name": "engine-args-test",
+                "workdir": str(Path(temp.name) / "work"),
+                "tasks": [
+                    {
+                        "key": "a",
+                        "spec": LONG_SPEC,
+                        "check": GOOD_CHECK,
+                        "engine": "gemini",
+                        "engine_args": list(DROPPED_ARGS),
+                        "expect_files": ["output.txt"],
+                        "verified": "output exists with expected content",
+                    }
+                ],
+            }
+        )
+
+    # --- the drop is real ---------------------------------------------
+    def test_args_vanish_from_the_built_command_without_the_placeholder(self) -> None:
+        command = build_worker_command(
+            engine_without_placeholder(),
+            taskdir=Path("/tmp/taskdir"),
+            spec="do the thing",
+            full_access=False,
+            engine_args=DROPPED_ARGS,
+        )
+        for arg in DROPPED_ARGS:
+            self.assertNotIn(arg, command, "this is the bug being guarded against")
+
+    # --- run refuses ---------------------------------------------------
+    def test_run_refuses_to_spawn_the_task(self) -> None:
+        with self.assertRaises(ValueError) as caught:
+            validate_manifest_engines(self.manifest(), self.config(engine_without_placeholder()))
+        message = str(caught.exception)
+        self.assertIn("a", message, "the finding must name the task")
+        self.assertIn("gemini", message, "the finding must name the engine")
+        for arg in DROPPED_ARGS:
+            self.assertIn(arg, message, "the finding must name the dropped args")
+
+    # --- lint says so, as a failing finding -----------------------------
+    def test_lint_emits_a_failing_finding(self) -> None:
+        findings = lint_manifest(self.manifest(), config=self.config(engine_without_placeholder()))
+        matching = [f for f in findings if "engine_args" in f]
+        self.assertTrue(matching, f"expected an engine_args finding, got: {findings}")
+        finding = matching[0]
+        self.assertTrue(
+            finding.startswith("ERROR:"),
+            f"a dropped argument is a failure, not a nudge: {finding}",
+        )
+        self.assertIn("gemini", finding)
+        for arg in DROPPED_ARGS:
+            self.assertIn(arg, finding)
+
+    # --- the placeholder case stays clean -------------------------------
+    def test_placeholder_present_means_no_finding_and_args_in_the_command(self) -> None:
+        config = self.config(engine_with_placeholder())
+        manifest = self.manifest()
+
+        validate_manifest_engines(manifest, config)  # must not raise
+
+        findings = lint_manifest(manifest, config=config)
+        self.assertEqual(
+            [], [f for f in findings if "engine_args" in f], "no finding when the args reach the process"
+        )
+
+        command = build_worker_command(
+            engine_with_placeholder(),
+            taskdir=Path("/tmp/taskdir"),
+            spec="do the thing",
+            full_access=False,
+            engine_args=DROPPED_ARGS,
+        )
+        for arg in DROPPED_ARGS:
+            self.assertIn(arg, command)
+
+    def test_no_engine_args_means_no_finding(self) -> None:
+        temp = tempfile.TemporaryDirectory()
+        self.addCleanup(temp.cleanup)
+        manifest = Manifest.from_obj(
+            {
+                "run_name": "engine-args-test",
+                "workdir": str(Path(temp.name) / "work"),
+                "tasks": [
+                    {
+                        "key": "a",
+                        "spec": LONG_SPEC,
+                        "check": GOOD_CHECK,
+                        "engine": "gemini",
+                        "expect_files": ["output.txt"],
+                        "verified": "output exists with expected content",
+                    }
+                ],
+            }
+        )
+        config = self.config(engine_without_placeholder())
+        validate_manifest_engines(manifest, config)  # must not raise
+        self.assertEqual([], [f for f in lint_manifest(manifest, config=config) if "engine_args" in f])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Per-task `engine_args` are dropped in silence when the resolved `args_template` has no `{engine_args}` placeholder.

`build_worker_command` expands `engine_args` only where the template holds that literal token. Without it the arguments vanish with no error on any surface: the field validates as a list of strings at parse time, manifest lint passes, the worker spawns, and the flag never reaches the process. Observed on an earlier run where a gemini block had no placeholder and `--include-directories` disappeared — which then produced a worker that could not read the repo it was told to edit.

**This is regression protection, not a live fix.** The gemini block in my `config.toml` already carries the placeholder:

```toml
  "-m",
  "{model}",
  "{engine_args}",
  "-p",
```

The point is that a future template edit can silently remove it again, and nothing would say so.

## What changed

`dropped_engine_args` sits next to `build_worker_command`, the function whose substitution rule it describes, and is used on both surfaces:

- **`validate_manifest_engines` raises**, so the run refuses to spawn the task. It sits directly beside the existing `{model}` refusal, which already declines a task `model` against an engine that would silently ignore it — this extends the same rule to `engine_args`.
- **`lint_manifest` emits an `ERROR:`-prefixed finding**, which the run path already treats as fatal (`if any(finding.startswith("ERROR:")): return 1`) before `validate_manifest_engines` is reached.

Refuse rather than warn: silently dropping caller arguments is the bug; refusing loudly is fine. The finding names the task, the engine, the exact dropped arguments, and the config edit that fixes it:

```
ERROR: a: "engine_args" ['--include-directories', '/srv/repo'] would be dropped — engine gemini
has no {engine_args} placeholder in its args_template. Add {engine_args} to
engines.gemini.args_template in config.toml, or remove the field.
```

`lint_manifest` already accepted a `config` argument but never read it; this is its first use. The finding is skipped when no config is supplied, so `ringer lint` (which passes none) keeps working unchanged.

## Tests

`tests/test_engine_args_placeholder.py`, 5 tests:

- the args really do vanish from the built command without the placeholder (characterization — this is the bug)
- the run refuses, and the message names task, engine, and the dropped args
- lint emits an `ERROR:`-prefixed finding naming the same three
- with the placeholder: no finding, no raise, and the args are present in the built command
- a task with no `engine_args` is never flagged

```
Ran 5 tests in 0.004s
OK
```

Full suite: **254 before, 259 after.**

## Not addressed here

`tests/test_contributors.py` fails on this branch and is unrelated — it keys on commit author, not content. On an identical tree the suite is `Ran 254 tests ... OK` before a commit and 1 failure after. Per CONTRIBUTING, credit is added by the maintainer on merge.

## Scope

Only the second half of the originating issue. The first half is a prose convention for worker specs (workers quoting a line from each file before editing it) and belongs in playbook text, not here.

## Related

- #95, #105 — same lint surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AVTYzUcjMokzMsyjABjUBF
