### PR TITLE
Nudge hook: re-arm per run instead of once per session, and see CLI-agent spawns

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,6 +397,7 @@ Every community PR that lands in main is credited here — that's a project rule
 - [@davekopecek](https://github.com/davekopecek) (Dave Kopecek) — committed the design-reference fixture so the design-token guard runs on every machine (#30)
 - [@snapsynapse](https://github.com/snapsynapse) (Sam Rogers) — graceful shutdown on SIGINT/SIGTERM with worker-tree cleanup and finished state, plus the 14-test end-to-end CLI regression suite (#4)
 - [@mlava](https://github.com/mlava) (Mark Lavercombe) — named setup failures across every diagnostic surface (#37), `run --baseline`, the no-workers check preflight (#38), and guidance on check-writing failure modes (#57)
+- [@bluemihai](https://github.com/bluemihai) (Mihai Banulescu) — the nudge hook re-arms per run instead of firing once per session, and sees CLI-agent spawns
 
 Contributions are welcome — see [CONTRIBUTING.md](CONTRIBUTING.md) for the philosophy and what gets a PR merged fast. The short version: small and scoped, rebased on current main, every claim backed by an executed test. Authorship is always preserved — where a maintainer pushes a mechanical fix to your branch, you remain the commit author.
 

--- a/hooks/ringer_nudge.py
+++ b/hooks/ringer_nudge.py
@@ -29,6 +29,23 @@ HARNESS_RE = re.compile(
     r"\.(?:mjs|js|ts|py)\b",
     re.IGNORECASE,
 )
+CLI_AGENT_RE = re.compile(
+    r"(?:^|[;&|(]\s*|\s)"
+    r"(?:claude\s+(?:-p|--print)\b|codex\s+exec\b|opencode\s+run\b|aider\b)",
+    re.IGNORECASE,
+)
+
+PRE_BASH_COOLDOWN_SECONDS = 900
+
+
+def pre_bash_cooldown_seconds() -> float:
+    value = os.environ.get("RINGER_NUDGE_COOLDOWN_SECONDS")
+    if value:
+        try:
+            return float(value)
+        except ValueError:
+            pass
+    return float(PRE_BASH_COOLDOWN_SECONDS)
 
 
 def ringer_home() -> Path:
@@ -104,16 +121,24 @@ def marker_path(home: Path, session_id: Any, event: str) -> Path:
     return state_dir(home) / f"{digest}.{event}.nudged"
 
 
-def claim_dedupe_marker(home: Path, session_id: Any, event: str) -> bool:
+def claim_nudge_slot(home: Path, session_id: Any, event: str, cooldown_seconds: float) -> bool:
+    """True when no nudge fired for (session, event) within the cooldown window.
+
+    Claims the slot by (re)stamping the marker with the current time, so the
+    nudge re-arms after the cooldown instead of staying silent all session.
+    """
     directory = state_dir(home)
     directory.mkdir(parents=True, exist_ok=True)
     marker = marker_path(home, session_id, event)
-    try:
-        with marker.open("x", encoding="utf-8") as fh:
-            fh.write(datetime.now(timezone.utc).isoformat())
-            fh.write("\n")
-    except FileExistsError:
-        return False
+    now = datetime.now(timezone.utc)
+    if marker.exists():
+        try:
+            stamped = datetime.fromisoformat(marker.read_text(encoding="utf-8").strip())
+        except ValueError:
+            stamped = None
+        if stamped is not None and (now - stamped).total_seconds() < cooldown_seconds:
+            return False
+    marker.write_text(now.isoformat() + "\n", encoding="utf-8")
     return True
 
 
@@ -147,7 +172,7 @@ def should_nudge_pre_bash(payload: dict[str, Any], home: Path) -> bool:
         return False
     if "ringer.py" in command:
         return False
-    if not (PROVIDER_RE.search(command) or HARNESS_RE.search(command)):
+    if not (PROVIDER_RE.search(command) or HARNESS_RE.search(command) or CLI_AGENT_RE.search(command)):
         return False
 
     active_runs = read_live_active_runs(home)
@@ -164,24 +189,37 @@ def post_edit_state_path(home: Path, session_id: Any) -> Path:
 
 def load_post_edit_state(path: Path) -> dict[str, Any]:
     if not path.exists():
-        return {"count": 0, "file_paths": []}
+        return {"count": 0, "file_paths": [], "last_nudged_count": 0}
     with path.open("r", encoding="utf-8") as fh:
         raw = json.load(fh)
     if not isinstance(raw, dict):
-        return {"count": 0, "file_paths": []}
+        return {"count": 0, "file_paths": [], "last_nudged_count": 0}
     count = raw.get("count")
     file_paths = raw.get("file_paths")
+    last_nudged_count = raw.get("last_nudged_count")
     if not isinstance(count, int):
         count = 0
     if not isinstance(file_paths, list):
         file_paths = []
-    return {"count": count, "file_paths": [str(path) for path in file_paths]}
+    if not isinstance(last_nudged_count, int):
+        last_nudged_count = 0
+    return {
+        "count": count,
+        "file_paths": [str(path) for path in file_paths],
+        "last_nudged_count": last_nudged_count,
+    }
 
 
-def record_post_edit(payload: dict[str, Any], home: Path) -> tuple[int, int]:
+POST_EDIT_NUDGE_EVERY = 8
+POST_EDIT_MIN_FILES = 3
+
+
+def should_nudge_post_edit(payload: dict[str, Any], home: Path) -> bool:
+    """Record the edit; nudge at 8 edits / 3 files, then again every 8 edits."""
     path = post_edit_state_path(home, payload.get("session_id"))
     state = load_post_edit_state(path)
     count = int(state["count"]) + 1
+    last_nudged = int(state["last_nudged_count"])
     files = set(str(item) for item in state["file_paths"])
 
     tool_input = payload.get("tool_input")
@@ -190,16 +228,18 @@ def record_post_edit(payload: dict[str, Any], home: Path) -> tuple[int, int]:
         if isinstance(file_path, str) and file_path.strip():
             files.add(file_path)
 
-    next_state = {"count": count, "file_paths": sorted(files)}
+    nudge = (
+        count >= POST_EDIT_NUDGE_EVERY
+        and len(files) >= POST_EDIT_MIN_FILES
+        and count - last_nudged >= POST_EDIT_NUDGE_EVERY
+        and not read_live_active_runs(home)
+    )
+    if nudge:
+        last_nudged = count
+
+    next_state = {"count": count, "file_paths": sorted(files), "last_nudged_count": last_nudged}
     write_json_atomic(path, next_state)
-    return count, len(files)
-
-
-def should_nudge_post_edit(payload: dict[str, Any], home: Path) -> bool:
-    count, distinct_files = record_post_edit(payload, home)
-    if count < 8 or distinct_files < 3:
-        return False
-    return not read_live_active_runs(home)
+    return nudge
 
 
 def load_stdin_payload() -> dict[str, Any] | None:
@@ -223,11 +263,13 @@ def run(argv: list[str]) -> int:
     session_id = payload.get("session_id")
 
     if mode == "pre-bash":
-        if should_nudge_pre_bash(payload, home) and claim_dedupe_marker(home, session_id, mode):
+        if should_nudge_pre_bash(payload, home) and claim_nudge_slot(
+            home, session_id, mode, pre_bash_cooldown_seconds()
+        ):
             output_nudge("PreToolUse")
         return 0
 
-    if should_nudge_post_edit(payload, home) and claim_dedupe_marker(home, session_id, mode):
+    if should_nudge_post_edit(payload, home):
         output_nudge("PostToolUse")
     return 0
 

--- a/tests/test_nudge_hook.py
+++ b/tests/test_nudge_hook.py
@@ -123,6 +123,27 @@ class NudgeHookTests(unittest.TestCase):
         self.assertNudged(first, "PreToolUse")
         self.assertSilent(second)
 
+    def test_pre_bash_rearms_after_cooldown(self) -> None:
+        os.environ["RINGER_NUDGE_COOLDOWN_SECONDS"] = "0"
+        self.addCleanup(os.environ.pop, "RINGER_NUDGE_COOLDOWN_SECONDS", None)
+        first = self.run_hook("pre-bash", self.pre_bash_payload("node probe-simulate.mjs"))
+        second = self.run_hook("pre-bash", self.pre_bash_payload("node probe-simulate.mjs"))
+        self.assertNudged(first, "PreToolUse")
+        self.assertNudged(second, "PreToolUse")
+
+    def test_pre_bash_nudges_on_cli_agent_spawn(self) -> None:
+        for command in (
+            'claude -p "summarize this repo"',
+            "codex exec --json task.md",
+            "cd /tmp && opencode run fix.md",
+        ):
+            proc = self.run_hook("pre-bash", self.pre_bash_payload(command, f"session-{command[:5]}"))
+            self.assertNudged(proc, "PreToolUse")
+
+    def test_pre_bash_stays_silent_on_plain_claude_invocation(self) -> None:
+        proc = self.run_hook("pre-bash", self.pre_bash_payload("claude --version"))
+        self.assertSilent(proc)
+
     def test_post_edit_nudges_at_eight_edits_and_three_files_once(self) -> None:
         files = [
             "/tmp/a.py",
@@ -141,6 +162,16 @@ class NudgeHookTests(unittest.TestCase):
 
         again = self.run_hook("post-edit", self.post_edit_payload("/tmp/d.py"))
         self.assertSilent(again)
+
+    def test_post_edit_renudges_every_eight_edits(self) -> None:
+        for index in range(8):
+            self.run_hook("post-edit", self.post_edit_payload(f"/tmp/file{index % 4}.py"))
+        for index in range(7):
+            self.assertSilent(
+                self.run_hook("post-edit", self.post_edit_payload(f"/tmp/file{index % 4}.py"))
+            )
+        sixteenth = self.run_hook("post-edit", self.post_edit_payload("/tmp/file0.py"))
+        self.assertNudged(sixteenth, "PostToolUse")
 
     def test_post_edit_stays_silent_for_seven_edits_and_two_files(self) -> None:
         files = ["/tmp/a.py", "/tmp/b.py", "/tmp/a.py", "/tmp/b.py", "/tmp/a.py", "/tmp/b.py", "/tmp/a.py"]


### PR DESCRIPTION
## Why

Two gaps in the nudge hook, both found by it failing to fire when it mattered.

**It fired once per session.** The marker file is keyed on `(session_id, event)`, so the first nudge in a long session was also the last. But a long session is exactly where routing drift happens: the tenth time you catch yourself about to do delegable work by hand is at least as worth catching as the first, and by then the hook has been silent for hours. A guard whose whole job is to interrupt a habit cannot retire after one interruption.

**It didn't see CLI-agent spawns.** The pre-bash matcher missed the shapes that most reliably indicate work routing around Ringer — invoking another coding agent directly from a shell. That is the single clearest tell that a task is about to be done unverified and invisibly, and it was the one case going unremarked.

## What this changes

- The marker re-arms rather than latching for the session, so the nudge is available again on a later occurrence instead of being spent on the first.
- The pre-bash matcher widens to catch CLI-agent spawn shapes.

## Tests

`tests/test_nudge_hook.py` gains coverage for both: that a second occurrence in the same session still nudges (the behaviour that was silently absent), and that the widened matcher fires on agent-spawn command shapes.

13 nudge-hook tests pass; full suite green on this branch: 259 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)